### PR TITLE
UF-10943 Bug with status filter and label after reload

### DIFF
--- a/frontend/src/casedata/components/casedata-filtering/casedata-filtering.component.tsx
+++ b/frontend/src/casedata/components/casedata-filtering/casedata-filtering.component.tsx
@@ -38,6 +38,7 @@ import {
 } from './components/casedata-filter-status.component';
 import { CasedataFilterTags } from './components/casedata-filter-tags.component';
 import { useAppContext } from '@contexts/app.context';
+import { ErrandStatus } from '@casedata/interfaces/errand-status';
 
 export type CaseDataFilter = CaseTypeFilter &
   CaseStatusFilter &
@@ -93,11 +94,11 @@ const CaseDataFiltering: React.FC<{
               <div className="relative max-md:w-full">
                 <CasedataFilterPropertyDesignation />
               </div>
-            ) : (
+            ) : ['ArendeAvslutat', 'ArendeInkommit', 'Tilldelat'].every((s) => !selectedErrandStatuses.includes(s)) ? (
               <div className="relative max-md:w-full">
                 <CasedataFilterStatus />
               </div>
-            )}
+            ) : null}
             <div className="relative max-md:w-full">
               <CasedataFilterCaseType />
             </div>
@@ -110,7 +111,8 @@ const CaseDataFiltering: React.FC<{
             <div className="relative max-md:w-full">
               <CasedataFilterAdmins administrators={administrators} />
             </div>
-            {!isPT() ? (
+            {!isPT() &&
+            ['ArendeAvslutat', 'ArendeInkommit', 'Tilldelat'].every((s) => !selectedErrandStatuses.includes(s)) ? (
               <div className="relative max-md:w-full">
                 <CasedataFilterStatus />
               </div>

--- a/frontend/src/casedata/components/casedata-filtering/components/casedata-filter-sidebarstatus-selector.component.tsx
+++ b/frontend/src/casedata/components/casedata-filtering/components/casedata-filter-sidebarstatus-selector.component.tsx
@@ -1,5 +1,11 @@
 import { ErrandStatus } from '@casedata/interfaces/errand-status';
-import { closedStatuses, newStatuses, ongoingStatuses } from '@casedata/services/casedata-errand-service';
+import {
+  assignedStatuses,
+  closedStatuses,
+  getStatusLabel,
+  newStatuses,
+  ongoingStatuses,
+} from '@casedata/services/casedata-errand-service';
 import { SidebarButton } from '@common/interfaces/sidebar-button';
 import { isSuspendEnabled } from '@common/services/feature-flag-service';
 import { AppContextInterface, useAppContext } from '@contexts/app.context';
@@ -46,15 +52,15 @@ export const CasedataFilterSidebarStatusSelector: React.FC = () => {
   const casedataSidebarButtons: SidebarButton[] = useMemo(
     () => [
       {
-        label: 'Nya ärenden',
+        label: getStatusLabel(newStatuses),
         key: newStatuses[0],
         statuses: newStatuses,
         icon: 'inbox',
         totalStatusErrands: newErrands.totalElements,
       },
       {
-        label: 'Öppnade ärenden',
-        key: ErrandStatus.UnderGranskning,
+        label: getStatusLabel(ongoingStatuses),
+        key: ongoingStatuses[0],
         statuses: ongoingStatuses,
         icon: 'clipboard-pen',
         totalStatusErrands: ongoingErrands.totalElements,
@@ -72,14 +78,14 @@ export const CasedataFilterSidebarStatusSelector: React.FC = () => {
         : []),
 
       {
-        label: 'Tilldelade ärenden',
-        key: ErrandStatus.Tilldelat,
-        statuses: [ErrandStatus.Tilldelat],
+        label: getStatusLabel(assignedStatuses),
+        key: assignedStatuses[0],
+        statuses: assignedStatuses,
         icon: 'file-plus',
         totalStatusErrands: assignedErrands.totalElements,
       },
       {
-        label: 'Avslutade ärenden',
+        label: getStatusLabel(closedStatuses),
         key: closedStatuses[0],
         statuses: closedStatuses,
         icon: 'circle-check-big',

--- a/frontend/src/casedata/components/casedata-filtering/components/casedata-filter-sidebarstatus-selector.component.tsx
+++ b/frontend/src/casedata/components/casedata-filtering/components/casedata-filter-sidebarstatus-selector.component.tsx
@@ -10,7 +10,7 @@ import { SidebarButton } from '@common/interfaces/sidebar-button';
 import { isSuspendEnabled } from '@common/services/feature-flag-service';
 import { AppContextInterface, useAppContext } from '@contexts/app.context';
 import LucideIcon from '@sk-web-gui/lucide-icon';
-import { Badge, Button } from '@sk-web-gui/react';
+import { Badge, Button, Spinner } from '@sk-web-gui/react';
 import store from '@supportmanagement/services/storage-service';
 import { useMemo, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
@@ -21,6 +21,7 @@ export const CasedataFilterSidebarStatusSelector: React.FC = () => {
   const [query, setQuery] = useState<string>('');
 
   const {
+    isLoading,
     setSelectedErrandStatuses,
     selectedErrandStatuses,
     setSidebarLabel,
@@ -98,6 +99,9 @@ export const CasedataFilterSidebarStatusSelector: React.FC = () => {
   return (
     <>
       {casedataSidebarButtons?.map((button) => {
+        const buttonIsactive = button.statuses.some((s) => {
+          return selectedErrandStatuses.map((s) => ErrandStatus[s]).includes(s);
+        });
         return (
           <Button
             onClick={() => {
@@ -105,10 +109,8 @@ export const CasedataFilterSidebarStatusSelector: React.FC = () => {
               setSidebarLabel(button.label);
             }}
             aria-label={`status-button-${button.key}`}
-            variant={selectedErrandStatuses.map((s) => ErrandStatus[s]).includes(button.key) ? 'primary' : 'ghost'}
-            className={`justify-start ${
-              !selectedErrandStatuses.includes(button.key as ErrandStatus) && 'hover:bg-dark-ghost'
-            }`}
+            variant={buttonIsactive ? 'primary' : 'ghost'}
+            className={`justify-start ${!buttonIsactive && 'hover:bg-dark-ghost'}`}
             leftIcon={<LucideIcon name={button.icon as any} />}
             key={button.key}
           >
@@ -118,7 +120,7 @@ export const CasedataFilterSidebarStatusSelector: React.FC = () => {
                 className="min-w-fit px-4"
                 inverted={!selectedErrandStatuses.includes(button.key as ErrandStatus)}
                 color={selectedErrandStatuses.includes(button.key as ErrandStatus) ? 'tertiary' : 'vattjom'}
-                counter={button.totalStatusErrands || '0'}
+                counter={isLoading ? '-' : button.totalStatusErrands || '0'}
               />
             </span>
           </Button>

--- a/frontend/src/casedata/components/casedata-filtering/components/casedata-filter-status.component.tsx
+++ b/frontend/src/casedata/components/casedata-filtering/components/casedata-filter-status.component.tsx
@@ -39,6 +39,13 @@ export const CasedataFilterStatus: React.FC = () => {
         />
         <PopupMenu.Items autoFocus={false}>
           {Object.entries(ErrandStatus)
+            .filter((s) => {
+              return (
+                s[1] !== ErrandStatus.ArendeAvslutat &&
+                s[1] !== ErrandStatus.ArendeInkommit &&
+                s[1] !== ErrandStatus.Tilldelat
+              );
+            })
             .filter(
               (s: [string, string]) =>
                 s[0].toLowerCase().includes(query.toLowerCase()) || s[1].toLowerCase().includes(query.toLowerCase())

--- a/frontend/src/casedata/components/casedata-filtering/components/casedata-filter-tags.component.tsx
+++ b/frontend/src/casedata/components/casedata-filtering/components/casedata-filter-tags.component.tsx
@@ -1,7 +1,7 @@
 import { useFormContext } from 'react-hook-form';
 import { CaseDataFilter, CaseDataValues } from '../casedata-filtering.component';
 import { Chip } from '@sk-web-gui/react';
-import { findCaseLabelForCaseType } from '@casedata/services/casedata-errand-service';
+import { findCaseLabelForCaseType, findStatusKeyForStatusLabel } from '@casedata/services/casedata-errand-service';
 import { ErrandStatus } from '@casedata/interfaces/errand-status';
 import { Priority } from '@casedata/interfaces/priority';
 import dayjs from 'dayjs';
@@ -87,6 +87,22 @@ export const CasedataFilterTags: React.FC<CasedataFilterTagsProps> = ({ administ
           {findCaseLabelForCaseType(type)}
         </Chip>
       ))}
+      {statuses
+        .filter(
+          (status) =>
+            ![ErrandStatus.ArendeInkommit, ErrandStatus.ArendeAvslutat, ErrandStatus.Tilldelat]
+              .map(findStatusKeyForStatusLabel)
+              .includes(status)
+        )
+        .map((status, statusIndex) => (
+          <Chip
+            data-cy={`tag-status-${status}`}
+            key={`caseStatus-${statusIndex}`}
+            onClick={() => handleRemoveStatus(status)}
+          >
+            {ErrandStatus[status]}
+          </Chip>
+        ))}
       {priorities.map((priority, prioIndex) => (
         <Chip data-cy="tag-prio" key={`casePrio-${prioIndex}`} onClick={() => handleRemovePriority(priority)}>
           {Priority[priority]} prioritet

--- a/frontend/src/casedata/components/ongoing-casedata-errands/components/casedata-status-label.component.tsx
+++ b/frontend/src/casedata/components/ongoing-casedata-errands/components/casedata-status-label.component.tsx
@@ -3,7 +3,6 @@ import LucideIcon from '@sk-web-gui/lucide-icon';
 import { Label } from '@sk-web-gui/react';
 
 export const CasedataStatusLabelComponent: React.FC<{ status: string }> = ({ status }) => {
-  console.log('status:', status);
   let color,
     inverted = false,
     icon = null;

--- a/frontend/src/casedata/components/ongoing-casedata-errands/ongoing-casedata-errands.component.tsx
+++ b/frontend/src/casedata/components/ongoing-casedata-errands/ongoing-casedata-errands.component.tsx
@@ -1,4 +1,4 @@
-import { useErrands } from '@casedata/services/casedata-errand-service';
+import { getStatusLabel, useErrands } from '@casedata/services/casedata-errand-service';
 import { AppContextInterface, useAppContext } from '@common/contexts/app.context';
 import { getAdminUsers, getMe } from '@common/services/user-service';
 import { useDebounceEffect } from '@common/utils/useDebounceEffect';
@@ -11,6 +11,7 @@ import CaseDataFiltering, { CaseDataFilter, CaseDataValues } from '../casedata-f
 import { ErrandsTable } from './components/errands-table.component';
 import { Button, Link } from '@sk-web-gui/react';
 import { CasedataFilterQuery } from '../casedata-filtering/components/casedata-filter-query.component';
+import { ErrandStatus } from '@casedata/interfaces/errand-status';
 
 export interface TableForm {
   sortOrder: 'asc' | 'desc';
@@ -36,6 +37,7 @@ export const OngoingCaseDataErrands: React.FC = () => {
     administrators,
     selectedErrandStatuses,
     setSelectedErrandStatuses,
+    setSidebarLabel,
   }: AppContextInterface = useAppContext();
   const startdate = watchFilter('startdate');
   const enddate = watchFilter('enddate');
@@ -85,6 +87,10 @@ export const OngoingCaseDataErrands: React.FC = () => {
             filter?.stakeholders !== user.username ? filter?.stakeholders?.split(',') || CaseDataValues.admins : [],
           phase: filter?.phase !== '' ? filter?.phase?.split(',') || CaseDataValues.phase : CaseDataValues.phase,
         };
+        const filterStatuses = filter?.status?.split(',') || CaseDataValues.status;
+        setSelectedErrandStatuses(filterStatuses);
+        const selectedStatusLabel = getStatusLabel(filterStatuses.map((s) => ErrandStatus[s]));
+        setSidebarLabel(selectedStatusLabel);
       } catch (error) {
         store.set('filter', JSON.stringify({}));
         storedFilters = {

--- a/frontend/src/casedata/services/casedata-errand-service.ts
+++ b/frontend/src/casedata/services/casedata-errand-service.ts
@@ -89,7 +89,25 @@ export const ongoingStatuses = [
   ErrandStatus.BeslutOverklagat,
 ];
 
+export const assignedStatuses = [ErrandStatus.Tilldelat];
+
 export const closedStatuses = [ErrandStatus.ArendeAvslutat];
+
+export const getStatusLabel = (statuses: ErrandStatus[]) => {
+  if (statuses.length > 0) {
+    if (statuses.some((s) => newStatuses.includes(s))) {
+      return 'Nya ärenden';
+    } else if (statuses.some((s) => ongoingStatuses.includes(s))) {
+      return 'Öppnade ärenden';
+    } else if (statuses.some((s) => assignedStatuses.includes(s))) {
+      return 'Tilldelade ärenden';
+    } else if (statuses.some((s) => closedStatuses.includes(s))) {
+      return 'Avslutade ärenden';
+    } else {
+      return 'Ärenden';
+    }
+  }
+};
 
 export const findPriorityKeyForPriorityLabel = (key: string) =>
   Object.entries(Priority).find((e: [string, string]) => e[1] === key)?.[0];
@@ -320,6 +338,9 @@ export const useErrands = (
 
   const fetchErrands = useCallback(
     async (page: number = 0) => {
+      if (!filter) {
+        return;
+      }
       await getErrands(municipalityId, page, size, filter, sort, extraParameters)
         .then((res) => {
           setErrands({ ...res, isLoading: false });
@@ -407,7 +428,7 @@ export const useErrands = (
       getErrands(
         municipalityId,
         page,
-        size,
+        1,
         {
           ...filter,
           status: closedStatuses.map(findStatusKeyForStatusLabel).join(','),

--- a/frontend/src/common/components/main-errands-sidebar/main-errands-sidebar.component.tsx
+++ b/frontend/src/common/components/main-errands-sidebar/main-errands-sidebar.component.tsx
@@ -8,7 +8,7 @@ import {
   isPT,
 } from '@common/services/application-service';
 import { FormProvider, useForm } from 'react-hook-form';
-import { useAppContext } from '@contexts/app.context';
+import { AppContextInterface, useAppContext } from '@contexts/app.context';
 import LucideIcon from '@sk-web-gui/lucide-icon';
 import { Avatar, Badge, Button, Divider, Logo } from '@sk-web-gui/react';
 import { NotificationsBell } from '@common/components/notifications/notifications-bell';
@@ -29,7 +29,7 @@ export const MainErrandsSidebar: React.FC<{
 }> = ({ showAttestationTable, setShowAttestationTable }) => {
   const suppportManagementFilterForm = useForm<SupportManagementFilter>({ defaultValues: SupportManagementValues });
   const casedataFilterForm = useForm<CaseDataFilter>({ defaultValues: CaseStatusValues });
-  const { user } = useAppContext();
+  const { user }: AppContextInterface = useAppContext();
   const [showNotifications, setShowNotifications] = useState(false);
 
   const applicationName = getApplicationName();

--- a/frontend/src/common/contexts/app.context.tsx
+++ b/frontend/src/common/contexts/app.context.tsx
@@ -20,6 +20,9 @@ import { Notification as CaseDataNotification } from '@common/data-contracts/cas
 import { createContext, useContext, useState } from 'react';
 
 export interface AppContextInterface {
+  isLoading: boolean;
+  setIsLoading: (isLoading: boolean) => void;
+
   subPage: string;
   setSubPage: (subPage: string) => void;
 
@@ -126,6 +129,7 @@ export interface AppContextInterface {
 const AppContext = createContext<AppContextInterface>(null);
 
 export function AppWrapper({ children }) {
+  const [isLoading, setIsLoading] = useState(false);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [subPage, setSubPage] = useState('');
   const [user, setUser] = useState<User>(emptyUser);
@@ -165,6 +169,9 @@ export function AppWrapper({ children }) {
   return (
     <AppContext.Provider
       value={{
+        isLoading,
+        setIsLoading: (isLoading: boolean) => setIsLoading(isLoading),
+
         subPage,
         setSubPage: (subPage: string) => setSubPage(subPage),
 

--- a/frontend/src/supportmanagement/components/supportmanagement-filtering/components/supportmanagement-filter-sidebarstatus-selector.component.tsx
+++ b/frontend/src/supportmanagement/components/supportmanagement-filtering/components/supportmanagement-filter-sidebarstatus-selector.component.tsx
@@ -19,6 +19,7 @@ export const SupportManagementFilterSidebarStatusSelector: React.FC<{
   setShowAttestationTable;
 }> = ({ showAttestationTable, setShowAttestationTable }) => {
   const {
+    isLoading,
     setSidebarLabel,
     setSelectedSupportErrandStatuses,
     selectedSupportErrandStatuses,
@@ -87,6 +88,7 @@ export const SupportManagementFilterSidebarStatusSelector: React.FC<{
   return (
     <>
       {supportSidebarButtons?.map((button) => {
+        const buttonIsActive = selectedSupportErrandStatuses.includes(button.key as Status);
         return (
           <Button
             onClick={() => {
@@ -95,14 +97,8 @@ export const SupportManagementFilterSidebarStatusSelector: React.FC<{
               setShowAttestationTable(false);
             }}
             aria-label={`status-button-${button.key}`}
-            variant={
-              selectedSupportErrandStatuses.includes(button.key as Status) && !showAttestationTable
-                ? 'primary'
-                : 'ghost'
-            }
-            className={`justify-start ${
-              !selectedSupportErrandStatuses.includes(button.key as Status) && 'hover:bg-dark-ghost'
-            }`}
+            variant={buttonIsActive && !showAttestationTable ? 'primary' : 'ghost'}
+            className={`justify-start ${!buttonIsActive && 'hover:bg-dark-ghost'}`}
             leftIcon={<LucideIcon name={button.icon as any} />}
             key={button.key}
           >
@@ -116,7 +112,7 @@ export const SupportManagementFilterSidebarStatusSelector: React.FC<{
                     ? 'tertiary'
                     : 'vattjom'
                 }
-                counter={button.totalStatusErrands || '0'}
+                counter={isLoading ? '-' : button.totalStatusErrands || '0'}
               />
             </span>
           </Button>


### PR DESCRIPTION
En bugg i MEX/PT där etiketten för vald ärendetyp inte sätts korrekt när man laddar om sidan. Exempel: man går in på översiktsvyn och väljer t ex "Tilldelade ärenden" i sidebaren (detta filter sparas då i localstorage). Man laddar sedan om sidan och då står det "Ärenden" ovanför tabellen, inte "Tilldelade ärenden", och fel ärenden laddas även in.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).
