### PR TITLE
Fix organization search from legalentity instead of businessengagements

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ För MEX (Mark och exploatering):
 | BusinessEngagements |     2.0 |
 | Party               |     2.0 |
 | SimulatorServer     |     2.0 |
+| LegalEntity         |     2.0 |
 
 För KS (Kontakt Sundsvall):
 
@@ -32,6 +33,7 @@ För KS (Kontakt Sundsvall):
 | BusinessEngagements |     2.0 |
 | Party               |     2.0 |
 | SimulatorServer     |     2.0 |
+| LegalEntity         |     2.0 |
 
 För PT (Parkeringstillstånd):
 
@@ -46,6 +48,7 @@ För PT (Parkeringstillstånd):
 | Employee            |     1.0 |
 | BusinessEngagements |     2.0 |
 | SimulatorServer     |     2.0 |
+| LegalEntity         |     2.0 |
 
 För LOP (Lön och pension):
 
@@ -56,7 +59,7 @@ För LOP (Lön och pension):
 | ActiveDirectory     |     1.1 |
 | Templating          |     2.0 |
 | BusinessEngagements |     2.0 |
-| LegalEntity         |     1.0 |
+| LegalEntity         |     2.0 |
 | Employee            |     1.0 |
 | BillingPreprocessor |     3.0 |
 | SimulatorServer     |     2.0 |

--- a/backend/src/controllers/address.controller.ts
+++ b/backend/src/controllers/address.controller.ts
@@ -155,6 +155,8 @@ class CLegalEntity2 implements LegalEntity2 {
   @ValidateNested()
   @TypeTransformer(() => CLEAddress)
   address?: LEAddress;
+  @IsString()
+  phoneNumber?: string | null;
 }
 
 interface LegalEntity2WithId {
@@ -241,7 +243,7 @@ export class AddressController {
     const guidUrl = `party/2.0/${MUNICIPALITY_ID}/ENTERPRISE/${formattedOrgNr}/partyId`;
     const guidRes = await this.apiService.get<string>({ url: guidUrl }, req.user);
 
-    const url = `legalentity/1.0/${guidRes.data}`;
+    const url = `legalentity/2.0/${MUNICIPALITY_ID}/${guidRes.data}`;
 
     const res = await this.apiService.get<LegalEntity2>({ url }, req.user);
 

--- a/backend/src/swagger-typescript-api.ts
+++ b/backend/src/swagger-typescript-api.ts
@@ -54,7 +54,7 @@ const APIS = [
   },
   {
     name: 'legalentity',
-    version: '1.0',
+    version: '2.0',
   },
 ];
 

--- a/frontend/src/data-contracts/backend/data-contracts.ts
+++ b/frontend/src/data-contracts/backend/data-contracts.ts
@@ -63,6 +63,7 @@ export interface CLegalEntity2 {
   name: string;
   postAddress: CLEPostAddress;
   address: CLEAddress;
+  phoneNumber: string;
 }
 
 export interface CLegalEntity2WithId {
@@ -72,6 +73,7 @@ export interface CLegalEntity2WithId {
   name: string;
   postAddress: CLEPostAddress;
   address: CLEAddress;
+  phoneNumber: string;
 }
 
 export interface CAccountInformation {
@@ -304,9 +306,9 @@ export interface CreateErrandDto {
   startDate?: string;
   endDate?: string;
   diaryNumber?: string;
-  status?: StatusDTO;
+  status?: object;
   statusDescription?: string;
-  statuses?: StatusDTO[];
+  statuses?: any[];
   municipalityId?: string;
   stakeholders?: CreateStakeholderDto[];
   decisions?: string;
@@ -319,8 +321,8 @@ export interface CreateErrandDto {
 export interface CPatchErrandDto {
   id?: string;
   externalCaseId?: string;
-  status?: StatusDTO;
-  statuses?: StatusDTO[];
+  status?: object;
+  statuses?: any[];
   statusDescription?: string;
   caseType?: string;
   priority?: string;


### PR DESCRIPTION
I och med faktureringsbranchen så görs sök på organisationer emot APIet LegalEntity istället för som tidigare BusinessEngagements. Dock glömde jag bort att bygga stöd för detta i de andra apparna än Lön och Pension. Denna PR korrigerar detta.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [x] Yes (I have stepped the version number accordingly)
- [ ] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).
