### PR TITLE
Delete unused email fields when escalating to MEX

### DIFF
--- a/frontend/src/supportmanagement/components/support-errand/sidebar/forward-errand.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/forward-errand.component.tsx
@@ -62,6 +62,8 @@ export interface ForwardFormProps {
   department: 'MEX';
   message: string;
   messageBodyPlaintext: string;
+  existingEmail?: string;
+  newEmail?: string;
 }
 
 export const ForwardErrandComponent: React.FC<{ disabled: boolean }> = ({ disabled }) => {

--- a/frontend/src/supportmanagement/services/support-errand-service.ts
+++ b/frontend/src/supportmanagement/services/support-errand-service.ts
@@ -1016,6 +1016,8 @@ export const forwardSupportErrand: (
         throw new Error('MISSING_NAME');
       }
     });
+    delete data.existingEmail;
+    delete data.newEmail;
     return apiService
       .post<ApiSupportErrand, Partial<ForwardFormProps>>(`supporterrands/${municipalityId}/${errand.id}/forward`, data)
       .then((res) => {


### PR DESCRIPTION
Oönskade fält från epostvalidering följer med när man eskalerar till Casedata, om man först väljer "E-post" och sedan går tillbaka till "Verksamhet".

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).
