### PR TITLE
Use string for decision id in form, convert to int when calling api.

### DIFF
--- a/frontend/src/casedata/components/errand/sidebar/sidebar-utredning.component.tsx
+++ b/frontend/src/casedata/components/errand/sidebar/sidebar-utredning.component.tsx
@@ -21,7 +21,7 @@ import { UseFormReturn, useForm } from 'react-hook-form';
 import * as yup from 'yup';
 
 export interface UtredningFormModel {
-  id?: number;
+  id?: string;
   errandNumber?: string;
   description: string;
   law: Law;
@@ -142,7 +142,7 @@ export const SidebarUtredning: React.FC = () => {
       if (isSigned) {
         const decision = getProposedOrRecommendedDecision(errand.decisions);
         data = {
-          id: decision.id,
+          id: decision.id.toString(),
           description: decision.description,
           law: decision.law[0],
           outcome: DecisionOutcomeKey.Bifall,
@@ -210,10 +210,9 @@ export const SidebarUtredning: React.FC = () => {
     setValue('errandNumber', errand.errandNumber);
     setValue('outcome', DecisionOutcomeKey.Bifall);
     if (existingUtredning) {
-      setValue('id', existingUtredning.id);
+      setValue('id', existingUtredning.id.toString());
       setValue('description', existingUtredning.description);
       setRichText(existingUtredning.description);
-      // setValue('law', existingUtredning.law[0].)
       setValue('outcome', existingUtredning.decisionOutcome);
     }
   }, [errand]);

--- a/frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx
@@ -62,7 +62,7 @@ import { CasedataMessageTabFormModel } from '../messages/message-composer.compon
 export type ContactMeans = 'webmessage' | 'email' | 'digitalmail' | false;
 
 export interface DecisionFormModel {
-  id?: number;
+  id?: string;
   errandId?: number;
   errandNumber?: string;
   description: string;
@@ -249,7 +249,6 @@ export const CasedataDecisionTab: React.FC<{
 
   const saveAndSend = async (data: DecisionFormModel) => {
     try {
-      data.outcome = DecisionOutcomeKey[data.outcome];
       data.decidedBy = {
         type: 'PERSON',
         roles: [Role.ADMINISTRATOR],
@@ -357,7 +356,7 @@ export const CasedataDecisionTab: React.FC<{
     try {
       setIsPreviewLoading(true);
       const data = getValues();
-      data.outcome = DecisionOutcomeKey[data.outcome];
+      data.outcome = data.outcome;
       let pdfData: {
         pdfBase64: string;
         error?: string;
@@ -401,7 +400,6 @@ export const CasedataDecisionTab: React.FC<{
       .then((confirmed) => {
         if (confirmed) {
           const data = getValues();
-          data.outcome = DecisionOutcomeKey[data.outcome];
           save(data);
           return Promise.resolve(true);
         }
@@ -429,11 +427,11 @@ export const CasedataDecisionTab: React.FC<{
     setValue('errandId', errand.id);
 
     if (existingDecision && existingDecision.decisionType === 'FINAL') {
-      setValue('id', existingDecision.id);
+      setValue('id', existingDecision.id.toString());
       setValue('description', existingDecision.description);
       setRichText(existingDecision.description);
-      setLawHeading(existingDecision.law[0].heading);
-      setValue('outcome', DecisionOutcomeLabel[existingDecision.decisionOutcome]);
+      setLawHeading(existingDecision.law?.[0]?.heading);
+      setValue('outcome', existingDecision.decisionOutcome);
       setValue('validFrom', dayjs(existingDecision.validFrom).format('YYYY-MM-DD'));
       setValue('validTo', dayjs(existingDecision.validTo).format('YYYY-MM-DD'));
     } else {
@@ -498,7 +496,7 @@ export const CasedataDecisionTab: React.FC<{
             <FormLabel>Beslut</FormLabel>
             <Input data-cy="decision-outcome-input" type="hidden" {...register('outcome')} />
             <Select
-              className="w-full"
+              className={cx(`w-full`, errors.outcome ? 'border-error' : '')}
               data-cy="decision-outcome-select"
               size="sm"
               onChange={(e) => {
@@ -507,18 +505,18 @@ export const CasedataDecisionTab: React.FC<{
               }}
               placeholder="Välj beslut"
               disabled={isErrandLocked(errand) || isSent()}
-              value={getValues('outcome')}
+              value={getValues('outcome') ? getValues('outcome') : ''}
             >
-              <Select.Option data-cy="outcome-input-item" value={'Välj beslut'}>
-                Välj beslut
+              <Select.Option data-cy="outcome-input-item" value={''}>
+                Välj utfall
               </Select.Option>
-              <Select.Option data-cy="outcome-input-item" value={'Bifall'}>
+              <Select.Option data-cy="outcome-input-item" value={'APPROVAL'}>
                 Bifall
               </Select.Option>
-              <Select.Option data-cy="outcome-input-item" value={'Avslag'}>
+              <Select.Option data-cy="outcome-input-item" value={'REJECTION'}>
                 Avslag
               </Select.Option>
-              <Select.Option data-cy="outcome-input-item" value={'Ärendet avskrivs'}>
+              <Select.Option data-cy="outcome-input-item" value={'CANCELLATION'}>
                 Ärendet avskrivs
               </Select.Option>
             </Select>

--- a/frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx
@@ -659,8 +659,8 @@ export const CasedataDecisionTab: React.FC<{
             disabled={
               isLoading ||
               !formState.isValid ||
-              !getValues('validFrom') ||
-              !getValues('validTo') ||
+              (isPT() && !getValues('validFrom')) ||
+              (isPT() && !getValues('validTo')) ||
               isErrandLocked(errand) ||
               !allowed ||
               isSent()

--- a/frontend/src/casedata/components/errand/tabs/investigation/casedata-investigation-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/investigation/casedata-investigation-tab.tsx
@@ -35,7 +35,7 @@ import { useForm, useFormContext, UseFormReturn } from 'react-hook-form';
 import * as yup from 'yup';
 
 export interface UtredningFormModel {
-  id?: number;
+  id?: string;
   errandNumber?: string;
   description: string;
   descriptionPlaintext: string;
@@ -212,7 +212,7 @@ export const CasedataInvestigationTab: React.FC<{
     if (decision) {
       setValue('law', decision.law);
       if (decision?.decisionType === 'PROPOSED') {
-        setValue('id', decision?.id);
+        setValue('id', decision?.id.toString());
       }
       if (decision.decisionType === 'PROPOSED' || decision?.decisionOutcome === 'APPROVAL') {
         setValue('description', decision.description);

--- a/frontend/src/casedata/hooks/displayPhasePoller.ts
+++ b/frontend/src/casedata/hooks/displayPhasePoller.ts
@@ -14,7 +14,7 @@ function useDisplayPhasePoller() {
       } else {
         getErrand(municipalityId, errand.id.toString()).then((res) => {
           setErrand(res.errand);
-          displayPhase = res.errand.extraParameters.find((p) => p.key === 'process.displayPhase')
+          displayPhase = res.errand?.extraParameters.find((p) => p.key === 'process.displayPhase')
             ?.values?.[0] as UiPhase;
         });
       }

--- a/frontend/src/casedata/services/casedata-decision-service.ts
+++ b/frontend/src/casedata/services/casedata-decision-service.ts
@@ -72,7 +72,7 @@ export const saveDecision: (
   };
 
   const obj: Decision = {
-    ...(formData.id && { id: formData.id }),
+    ...(formData.id && { id: parseInt(formData.id, 10) }),
     decisionType,
     decisionOutcome: formData.outcome as DecisionOutcome,
     description: formData.description,


### PR DESCRIPTION
Use string for decision id in form, convert to int when calling api. 

Also use better values for outcome Select.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).
