### PR TITLE
fe: added subtype to notifications for support and casedata

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ För LOP (Lön och pension):
 
 | API                 | Version |
 | ------------------- | ------: |
-| SupportManagement   |    10.2 |
+| SupportManagement   |    10.3 |
 | Citizen             |     3.0 |
 | ActiveDirectory     |     2.0 |
 | Templating          |     2.0 |

--- a/backend/src/controllers/supportmanagement/support-attachment.controller.ts
+++ b/backend/src/controllers/supportmanagement/support-attachment.controller.ts
@@ -35,7 +35,7 @@ class SupportAttachmentDto {
 export class SupportAttachmentController {
   private apiService = new ApiService();
   private namespace = SUPPORTMANAGEMENT_NAMESPACE;
-  private SERVICE = `supportmanagement/10.2`;
+  private SERVICE = `supportmanagement/10.3`;
 
   @Get('/supportattachments/:municipalityId/errands/:id/attachments/:attachmentId')
   @OpenAPI({ summary: 'Get an attachment' })

--- a/backend/src/controllers/supportmanagement/support-errand.controller.ts
+++ b/backend/src/controllers/supportmanagement/support-errand.controller.ts
@@ -332,7 +332,7 @@ export enum SupportStakeholderRole {
 export class SupportErrandController {
   private apiService = new ApiService();
   private namespace = SUPPORTMANAGEMENT_NAMESPACE;
-  SERVICE = `supportmanagement/10.2`;
+  SERVICE = `supportmanagement/10.3`;
 
   preparedErrandResponse = async (errandData: SupportErrand, req: any) => {
     const customer: SupportStakeholder & { personNumber?: string } = errandData.stakeholders.find(s => s.role === SupportStakeholderRole.PRIMARY);

--- a/backend/src/controllers/supportmanagement/support-facilities.controller.ts
+++ b/backend/src/controllers/supportmanagement/support-facilities.controller.ts
@@ -19,7 +19,7 @@ type Parameters = {
 export class SupportFacilitiesController {
   private apiService = new ApiService();
   private namespace = SUPPORTMANAGEMENT_NAMESPACE;
-  SERVICE = `supportmanagement/10.2`;
+  SERVICE = `supportmanagement/10.3`;
 
   @Patch('/supporterrands/saveFacilities/:municipalityId/:id')
   @OpenAPI({ summary: 'Save facilities by errand' })

--- a/backend/src/controllers/supportmanagement/support-history.controller.ts
+++ b/backend/src/controllers/supportmanagement/support-history.controller.ts
@@ -11,7 +11,7 @@ import { OpenAPI } from 'routing-controllers-openapi';
 export class SupportHistoryController {
   private apiService = new ApiService();
   private namespace = SUPPORTMANAGEMENT_NAMESPACE;
-  private SERVICE = `supportmanagement/10.2`;
+  private SERVICE = `supportmanagement/10.3`;
 
   @Get('/supporthistory/:municipalityId/:id')
   @OpenAPI({ summary: 'Get events for errand' })

--- a/backend/src/controllers/supportmanagement/support-message.controller.ts
+++ b/backend/src/controllers/supportmanagement/support-message.controller.ts
@@ -133,7 +133,7 @@ export const generateMessageId = () => `<${uuidv4()}@CONTACTCENTER>`;
 export class SupportMessageController {
   private apiService = new ApiService();
   private namespace = SUPPORTMANAGEMENT_NAMESPACE;
-  private SERVICE = `supportmanagement/10.2`;
+  private SERVICE = `supportmanagement/10.3`;
 
   @Post('/supportmessage/:municipalityId/:id')
   @HttpCode(201)

--- a/backend/src/controllers/supportmanagement/support-metadata.controller.ts
+++ b/backend/src/controllers/supportmanagement/support-metadata.controller.ts
@@ -55,7 +55,7 @@ interface SupportRoles {
 export class SupportMetadataController {
   private apiService = new ApiService();
   private namespace = SUPPORTMANAGEMENT_NAMESPACE;
-  private SERVICE = `supportmanagement/10.2`;
+  private SERVICE = `supportmanagement/10.3`;
 
   @Get('/supportmetadata/:municipalityId')
   @OpenAPI({ summary: 'Get support metadata' })

--- a/backend/src/controllers/supportmanagement/support-note.controller.ts
+++ b/backend/src/controllers/supportmanagement/support-note.controller.ts
@@ -75,7 +75,7 @@ export interface SupportNoteData {
 export class SupportNoteController {
   private apiService = new ApiService();
   private namespace = SUPPORTMANAGEMENT_NAMESPACE;
-  private SERVICE = `supportmanagement/10.2`;
+  private SERVICE = `supportmanagement/10.3`;
 
   @Get('/supportnotes/:municipalityId/:id')
   @OpenAPI({ summary: 'Get notes for errand' })

--- a/backend/src/controllers/supportmanagement/support-notification-controller.ts
+++ b/backend/src/controllers/supportmanagement/support-notification-controller.ts
@@ -50,13 +50,15 @@ export class SupportNotificationDto {
   errandId?: string;
   @IsString()
   errandNumber?: string;
+  @IsString()
+  subtype?: string;
 }
 
 @Controller()
 export class SupportNotificationController {
   private apiService = new ApiService();
   private namespace = SUPPORTMANAGEMENT_NAMESPACE;
-  SERVICE = `supportmanagement/10.2`;
+  SERVICE = `supportmanagement/10.3`;
 
   @Get('/supportnotifications/:municipalityId')
   @OpenAPI({ summary: 'Get support notifications' })

--- a/backend/src/data-contracts/supportmanagement/data-contracts.ts
+++ b/backend/src/data-contracts/supportmanagement/data-contracts.ts
@@ -637,6 +637,11 @@ export interface Notification {
    * @example "PRH-2022-000001"
    */
   errandNumber?: string;
+    /**
+   * Sub type of the notification
+   * @example "PHASE_CHANGE"
+   */
+  subtype?: string;
 }
 
 /** Parameter model */

--- a/backend/src/services/support-errand.service.ts
+++ b/backend/src/services/support-errand.service.ts
@@ -5,7 +5,7 @@ import { apiURL } from '@/utils/util';
 import ApiService from './api.service';
 import { Errand } from '@/data-contracts/supportmanagement/data-contracts';
 
-const SERVICE = `supportmanagement/10.2`;
+const SERVICE = `supportmanagement/10.3`;
 const namespace = SUPPORTMANAGEMENT_NAMESPACE;
 
 export const validateSupportAction: (municipalityId: string, errandId: string, user: User) => Promise<boolean> = async (

--- a/frontend/src/common/components/notifications/notification-item.tsx
+++ b/frontend/src/common/components/notifications/notification-item.tsx
@@ -7,28 +7,19 @@ import { Notification as SupportNotification } from '@common/data-contracts/supp
 import { prettyTime } from '@common/services/helper-service';
 import { appConfig } from '@config/appconfig';
 import { AppContextInterface, useAppContext } from '@contexts/app.context';
-import LucideIcon from '@sk-web-gui/lucide-icon';
 import { Avatar, cx, useSnackbar } from '@sk-web-gui/react';
 import {
   acknowledgeSupportNotification,
   getSupportNotifications,
 } from '@supportmanagement/services/support-notification-service';
 import NextLink from 'next/link';
+import { NotificationRenderIcon } from './notification-render-icon';
 
 type Notification = SupportNotification | CaseDataNotification;
 
 //Help function to get the notification key subtype? in supportmanagement and subType? in casedata
 const getNotificationKey = (notification: Notification): string | undefined => {
   return (notification as any).subType?.toUpperCase() ?? (notification as any).subtype?.toUpperCase();
-};
-
-const iconConfig = {
-  'Meddelande mottaget': { icon: 'message-circle', defaultColor: 'gronsta' },
-  'Parkering av ärendet har upphört': { icon: 'bell-ring', defaultColor: 'juniskar' },
-  'Ärende uppdaterat': { icon: 'bell-ring', defaultColor: 'juniskar' },
-  'En bilaga har lagts till i ärendet.': { icon: 'file', defaultColor: 'vattjom' },
-  'Notering skapad': { avatar: true, defaultColor: 'juniskar' },
-  default: { icon: 'bell', defaultColor: 'vattjom' },
 };
 
 const labelBySubType: Record<string, string> = {
@@ -44,58 +35,6 @@ const labelBySubType: Record<string, string> = {
 const senderFallback = (name?: string): string => {
   if (!name || name.toUpperCase() === 'UNKNOWN') return 'Okänd';
   return name;
-};
-
-const renderIcon = (notification: Notification) => {
-  const config = iconConfig[notification.description as keyof typeof iconConfig] ?? iconConfig.default;
-  const color = notification.acknowledged ? 'primary' : config.defaultColor;
-
-  if ('avatar' in config && config.avatar) {
-    return (
-      <div className={cx(`w-[4rem] h-[4rem] rounded-12 flex items-center justify-center bg-${color}-surface-accent`)}>
-        <Avatar
-          data-cy="avatar-aside"
-          className="flex-none"
-          size="md"
-          initials={`${notification.createdByFullName
-            ?.split(' ')[1]
-            ?.charAt(0)
-            .toUpperCase()}${notification.createdByFullName?.split(' ')[0]?.charAt(0).toUpperCase()}`}
-          color={color}
-        />
-      </div>
-    );
-  }
-
-  return (
-    <div
-      className={cx(
-        `w-[4rem] h-[4rem] rounded-12 flex items-center justify-center ${
-          notification.acknowledged ? 'bg-tertiary-surface' : `bg-${color}-surface-accent`
-        }`
-      )}
-    >
-      {'icon' in config && (
-        <LucideIcon
-          name={config.icon as 'message-circle' | 'bell-ring' | 'file' | 'bell'}
-          color={
-            color as
-              | 'gronsta'
-              | 'juniskar'
-              | 'vattjom'
-              | 'primary'
-              | 'error'
-              | 'info'
-              | 'success'
-              | 'warning'
-              | 'bjornstigen'
-              | 'tertiary'
-          }
-          size="2.4rem"
-        />
-      )}
-    </div>
-  );
 };
 
 export const NotificationItem: React.FC<{ notification: Notification }> = ({ notification }) => {
@@ -128,7 +67,9 @@ export const NotificationItem: React.FC<{ notification: Notification }> = ({ not
 
   return (
     <div className="p-16 flex gap-12 items-start justify-between text-small">
-      <div className="flex items-center my-xs">{renderIcon(notification)}</div>
+      <div className="flex items-center my-xs">
+        <NotificationRenderIcon notification={notification} />
+      </div>
       <div className="flex-grow">
         <div>
           <strong>{notification.description + ' › '}</strong>

--- a/frontend/src/common/components/notifications/notification-item.tsx
+++ b/frontend/src/common/components/notifications/notification-item.tsx
@@ -8,28 +8,117 @@ import { prettyTime } from '@common/services/helper-service';
 import { appConfig } from '@config/appconfig';
 import { AppContextInterface, useAppContext } from '@contexts/app.context';
 import LucideIcon from '@sk-web-gui/lucide-icon';
-import { cx, useSnackbar } from '@sk-web-gui/react';
+import { Avatar, cx, useSnackbar } from '@sk-web-gui/react';
 import {
   acknowledgeSupportNotification,
   getSupportNotifications,
 } from '@supportmanagement/services/support-notification-service';
 import NextLink from 'next/link';
 
-export const NotificationItem: React.FC<{ notification: SupportNotification | CaseDataNotification }> = ({
-  notification,
-}) => {
+type Notification = SupportNotification | CaseDataNotification;
+
+//Help function to get the notification key subtype? in supportmanagement and subType? in casedata
+const getNotificationKey = (notification: Notification): string | undefined => {
+  return (notification as any).subType?.toUpperCase() ?? (notification as any).subtype?.toUpperCase();
+};
+
+const iconConfig: Record<string, { icon?: string; avatar?: boolean; defaultColor: string; label?: string }> = {
+  ATTACHMENT: { icon: 'file', defaultColor: 'vattjom', label: 'Ny bilaga' },
+  DECISION: { icon: 'bell-ring', defaultColor: 'juniskar', label: 'Nytt beslut' },
+  ERRAND: { icon: 'bell-ring', defaultColor: 'juniskar', label: 'Ärende uppdaterat' },
+  MESSAGE: { icon: 'message-circle', defaultColor: 'gronsta', label: 'Nytt meddelande' },
+  NOTE: { avatar: true, defaultColor: 'juniskar', label: 'Ny kommentar/anteckning' },
+  SYSTEM: { icon: 'bell', defaultColor: 'vattjom', label: 'Fasbyte' },
+  SUSPENSION: { icon: 'bell-ring', defaultColor: 'juniskar', label: 'Parkering upphört' },
+
+  default: { icon: 'bell', defaultColor: 'vattjom', label: 'Notis' },
+};
+
+const senderFallback = (name?: string): string => {
+  if (!name || name.toUpperCase() === 'UNKNOWN') return 'Okänd';
+  return name;
+};
+
+const renderIcon = (notification: Notification) => {
+  const key = getNotificationKey(notification) ?? notification.description?.toUpperCase();
+  const config = iconConfig[key as keyof typeof iconConfig] ?? iconConfig.default;
+  const color = notification.acknowledged ? 'tertiary' : config.defaultColor;
+
+  if (config.avatar) {
+    const initials = `${notification.createdByFullName?.split(' ')[1]?.charAt(0)?.toUpperCase() ?? ''}${
+      notification.createdByFullName?.split(' ')[0]?.charAt(0)?.toUpperCase() ?? ''
+    }`;
+
+    return (
+      <div className={cx(`w-[4rem] h-[4rem] rounded-12 flex items-center justify-center bg-${color}-surface-accent`)}>
+        <Avatar size="md" initials={initials} color={color} />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cx(
+        `w-[4rem] h-[4rem] rounded-12 flex items-center justify-center ${
+          notification.acknowledged ? 'bg-tertiary-surface' : `bg-${color}-surface-accent`
+        }`
+      )}
+    >
+      {config.icon && (
+        <LucideIcon
+          name={config.icon as 'message-circle' | 'bell-ring' | 'file' | 'bell'}
+          color={
+            color as
+              | 'gronsta'
+              | 'juniskar'
+              | 'vattjom'
+              | 'primary'
+              | 'error'
+              | 'info'
+              | 'success'
+              | 'warning'
+              | 'bjornstigen'
+              | 'tertiary'
+          }
+          size="2.4rem"
+        />
+      )}
+    </div>
+  );
+};
+
+export const NotificationItem: React.FC<{ notification: Notification }> = ({ notification }) => {
   const { municipalityId, setNotifications }: AppContextInterface = useAppContext();
   const toastMessage = useSnackbar();
 
-  const color = notification.acknowledged ? 'tertiary' : 'info';
+  const handleAcknowledge = async () => {
+    try {
+      if (appConfig.isCaseData) {
+        await acknowledgeCasedataNotification(municipalityId, notification as CaseDataNotification);
+      } else {
+        await acknowledgeSupportNotification(municipalityId, notification as SupportNotification);
+      }
+
+      const getNotifications = appConfig.isCaseData ? getCasedataNotifications : getSupportNotifications;
+
+      const notifications = await getNotifications(municipalityId);
+      setNotifications(notifications);
+    } catch (error) {
+      toastMessage({
+        position: 'bottom',
+        closeable: false,
+        message: 'Något gick fel när notifieringen skulle kvitteras',
+        status: 'error',
+      });
+    }
+  };
+
   return (
     <div className="p-16 flex gap-12 items-start justify-between text-small">
-      <div className="flex items-center my-xs">
-        <LucideIcon.Padded name="message-circle" color={color} inverted size="4rem" />
-      </div>
+      <div className="flex items-center my-xs">{renderIcon(notification)}</div>
       <div className="flex-grow">
         <div>
-          {notification.description}{' '}
+          <strong>{notification.description + ' › '}</strong>
           <NextLink
             href={
               appConfig.isCaseData
@@ -37,57 +126,30 @@ export const NotificationItem: React.FC<{ notification: SupportNotification | Ca
                 : `/arende/${municipalityId}/${notification.errandId}`
             }
             target="_blank"
-            onClick={async (e) => {
-              try {
-                if (appConfig.isCaseData) {
-                  await acknowledgeCasedataNotification(municipalityId, notification as CaseDataNotification).catch(
-                    () => {
-                      throw new Error('Failed to acknowledge notification');
-                    }
-                  );
-                } else {
-                  await acknowledgeSupportNotification(municipalityId, notification as SupportNotification).catch(
-                    () => {
-                      throw new Error('Failed to acknowledge notification');
-                    }
-                  );
-                }
-                // const acknowledgeNotification =
-                //   isPT() || isMEX() ? acknowledgeCasedataNotification : acknowledgeSupportNotification;
-                //   const patchedNotification = isPT() || isMEX() ? notification as CaseDataNotification : notification as SupportNotification;
-                // await acknowledgeNotification(municipalityId, notification).catch(() => {
-                //   throw new Error('Failed to acknowledge notification');
-                // });
-                const getNotifications = appConfig.isCaseData ? getCasedataNotifications : getSupportNotifications;
-                const notifications = await getNotifications(municipalityId);
-                setNotifications(notifications);
-              } catch (error) {
-                toastMessage({
-                  position: 'bottom',
-                  closeable: false,
-                  message: 'Något gick fel när notifieringen skulle kvitteras',
-                  status: 'error',
-                });
-              }
-            }}
+            onClick={handleAcknowledge}
             className="underline whitespace-nowrap"
           >
             {notification.errandNumber || 'Till ärendet'}
           </NextLink>
         </div>
-        <div>Från {notification.createdByFullName || notification.createdBy || '(okänt)'}</div>
+        <div>Från: {senderFallback(notification.createdByFullName || notification.createdBy)}</div>
+        {(() => {
+          const key = getNotificationKey(notification);
+          const config = iconConfig[key as keyof typeof iconConfig];
+          return config?.label ? <div>Händelse: {config.label}</div> : null;
+        })()}
       </div>
       <span className="whitespace-nowrap">{prettyTime(notification.created)}</span>
-      {!notification.acknowledged ? (
+      {!notification.acknowledged && (
         <div>
           <span
             className={cx(
-              notification.acknowledged ? 'bg-gray-200' : `bg-vattjom-surface-primary`,
-              `w-12 h-12 my-xs rounded-full flex items-center justify-center text-lg`
+              `w-12 h-12 my-xs rounded-full flex items-center justify-center text-lg`,
+              `bg-vattjom-surface-primary`
             )}
-          ></span>
+          />
         </div>
-      ) : null}
+      )}
     </div>
   );
 };

--- a/frontend/src/common/components/notifications/notification-render-icon.tsx
+++ b/frontend/src/common/components/notifications/notification-render-icon.tsx
@@ -1,0 +1,68 @@
+import { Notification as CaseDataNotification } from '@common/data-contracts/case-data/data-contracts';
+import { Notification as SupportNotification } from '@common/data-contracts/supportmanagement/data-contracts';
+import { Avatar, cx } from '@sk-web-gui/react';
+import LucideIcon from '@sk-web-gui/lucide-icon';
+
+type Notification = SupportNotification | CaseDataNotification;
+
+interface NotificationRenderIconProps {
+  notification: Notification;
+}
+
+const iconConfig = {
+  'Meddelande mottaget': { icon: 'message-circle', defaultColor: 'gronsta' },
+  'Parkering av ärendet har upphört': { icon: 'bell-ring', defaultColor: 'juniskar' },
+  'Ärende uppdaterat': { icon: 'bell-ring', defaultColor: 'juniskar' },
+  'En bilaga har lagts till i ärendet.': { icon: 'file', defaultColor: 'vattjom' },
+  'Notering skapad': { avatar: true, defaultColor: 'juniskar' },
+  default: { icon: 'bell', defaultColor: 'vattjom' },
+};
+
+const surfaceColor: Record<string, string> = {
+  juniskar: 'bg-juniskar-surface-accent',
+  gronsta: 'bg-gronsta-surface-accent',
+  vattjom: 'bg-vattjom-surface-accent',
+  bjornstigen: 'bg-bjornstigen-surface-accent',
+};
+
+export const NotificationRenderIcon: React.FC<NotificationRenderIconProps> = ({ notification }) => {
+  const config = iconConfig[notification.description as keyof typeof iconConfig] ?? iconConfig.default;
+  const color = notification.acknowledged ? 'primary' : config.defaultColor;
+  const bgColor = surfaceColor[color] ?? 'bg-tertiary-surface';
+
+  if ('avatar' in config && config.avatar) {
+    const initials =
+      `${notification.createdByFullName?.split(' ')[1]?.charAt(0).toUpperCase() ?? ''}` +
+      `${notification.createdByFullName?.split(' ')[0]?.charAt(0).toUpperCase() ?? ''}`;
+
+    return (
+      <div className={cx(`w-[4rem] h-[4rem] rounded-12 flex items-center justify-center bg-${color}-surface-accent`)}>
+        <Avatar data-cy="avatar-aside" className="flex-none" size="md" initials={initials} color={color} />
+      </div>
+    );
+  }
+
+  return (
+    <div className={cx(`w-[4rem] h-[4rem] rounded-12 flex items-center justify-center`, bgColor)}>
+      {'icon' in config && (
+        <LucideIcon
+          name={config.icon as 'message-circle' | 'bell-ring' | 'file' | 'bell'}
+          color={
+            color as
+              | 'gronsta'
+              | 'juniskar'
+              | 'vattjom'
+              | 'primary'
+              | 'error'
+              | 'info'
+              | 'success'
+              | 'warning'
+              | 'bjornstigen'
+              | 'tertiary'
+          }
+          size="2.4rem"
+        />
+      )}
+    </div>
+  );
+};

--- a/frontend/src/common/components/notifications/notifications-bell.tsx
+++ b/frontend/src/common/components/notifications/notifications-bell.tsx
@@ -27,7 +27,11 @@ export const NotificationsBell = (props: { toggleShow: () => void }) => {
           className="absolute -top-10 -right-10 text-white"
           rounded
           color="vattjom"
-          counter={notifications.filter((n) => !n.acknowledged).length}
+          counter={
+            notifications.filter((n) => !n.acknowledged).length > 99
+              ? '99+'
+              : notifications.filter((n) => !n.acknowledged).length
+          }
         />
       ) : null}
     </Button>

--- a/frontend/src/common/data-contracts/case-data/data-contracts.ts
+++ b/frontend/src/common/data-contracts/case-data/data-contracts.ts
@@ -776,6 +776,11 @@ export interface Notification {
    * @example "PRH-2022-000001"
    */
   errandNumber?: string;
+  /**
+   * Sub type of the notification
+   * @example "PHASE_CHANGE"
+   */
+  subtype?: string;
 }
 
 export interface Errand {

--- a/frontend/src/common/data-contracts/supportmanagement/data-contracts.ts
+++ b/frontend/src/common/data-contracts/supportmanagement/data-contracts.ts
@@ -729,6 +729,11 @@ export interface Notification {
    * @example "PRH-2022-000001"
    */
   errandNumber?: string;
+  /**
+   * Subtype of the notification
+   * @example "ATTACHMENT"
+   */
+  subType?: string;
 }
 
 /** CreateErrandNoteRequest model */


### PR DESCRIPTION
- Added new subtype for notifications for both supportmanagement and casedata applications.
- Uppdated design for notification items
- Included translation mappings
- Upgraded supportmanagement version 10.1 to 10.3
- Updated documentation

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [x] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).

JIRA: https://jira.sundsvall.se/browse/UF-16030?workflowName=Software+Simplified+Workflow+for+Project+UF&stepId=33
