### PR TITLE
fe: new label in table header for responsible person

### DIFF
--- a/frontend/public/locales/sv/common.json
+++ b/frontend/public/locales/sv/common.json
@@ -32,6 +32,7 @@
     },
     "incomingVia": "Inkom via",
     "registered": "Registrerades",
+    "registeredBy": "Registrerad av",
     "priority": "Prioritet",
     "reminder": "Påminnelse",
     "responsible": "Ansvarig"

--- a/frontend/src/supportmanagement/components/ongoing-support-errands/components/supporterrands-table.component.tsx
+++ b/frontend/src/supportmanagement/components/ongoing-support-errands/components/supporterrands-table.component.tsx
@@ -123,25 +123,29 @@ export const SupportErrandsTable: React.FC = () => {
     window.open(`${process.env.NEXT_PUBLIC_BASEPATH}/arende/${municipalityId}/${errand.id}`, '_blank');
   };
 
-  const headers = useOngoingSupportErrandLabels(selectedSupportErrandStatuses).map((header, index) => (
-    <Table.HeaderColumn key={`header-${index}`} sticky={true}>
-      {header.screenReaderOnly ? (
-        <span className="sr-only">{header.label}</span>
-      ) : header.sortable ? (
-        <Table.SortButton
-          isActive={
-            isKC() ? sortColumn === serverSideSortableColsKC[index] : sortColumn === serverSideSortableColsLOP[index]
-          }
-          sortOrder={sortOrders[sortOrder] as SortMode}
-          onClick={() => handleSort(index)}
-        >
-          {header.label}
-        </Table.SortButton>
-      ) : (
-        header.label
-      )}
-    </Table.HeaderColumn>
-  ));
+  const overrideResponsibleLabel =
+    selectedSupportErrandStatuses.length === 1 && selectedSupportErrandStatuses[0] === Status.NEW;
+  const headers = useOngoingSupportErrandLabels(selectedSupportErrandStatuses, overrideResponsibleLabel).map(
+    (header, index) => (
+      <Table.HeaderColumn key={`header-${index}`} sticky={true}>
+        {header.screenReaderOnly ? (
+          <span className="sr-only">{header.label}</span>
+        ) : header.sortable ? (
+          <Table.SortButton
+            isActive={
+              isKC() ? sortColumn === serverSideSortableColsKC[index] : sortColumn === serverSideSortableColsLOP[index]
+            }
+            sortOrder={sortOrders[sortOrder] as SortMode}
+            onClick={() => handleSort(index)}
+          >
+            {header.label}
+          </Table.SortButton>
+        ) : (
+          header.label
+        )}
+      </Table.HeaderColumn>
+    )
+  );
 
   const StatusLabelComponent = (status: string, resolution: string) => {
     const solvedErrandIcon = () => {

--- a/frontend/src/supportmanagement/components/ongoing-support-errands/components/supporterrands-table.component.tsx
+++ b/frontend/src/supportmanagement/components/ongoing-support-errands/components/supporterrands-table.component.tsx
@@ -123,29 +123,25 @@ export const SupportErrandsTable: React.FC = () => {
     window.open(`${process.env.NEXT_PUBLIC_BASEPATH}/arende/${municipalityId}/${errand.id}`, '_blank');
   };
 
-  const overrideResponsibleLabel =
-    selectedSupportErrandStatuses.length === 1 && selectedSupportErrandStatuses[0] === Status.NEW;
-  const headers = useOngoingSupportErrandLabels(selectedSupportErrandStatuses, overrideResponsibleLabel).map(
-    (header, index) => (
-      <Table.HeaderColumn key={`header-${index}`} sticky={true}>
-        {header.screenReaderOnly ? (
-          <span className="sr-only">{header.label}</span>
-        ) : header.sortable ? (
-          <Table.SortButton
-            isActive={
-              isKC() ? sortColumn === serverSideSortableColsKC[index] : sortColumn === serverSideSortableColsLOP[index]
-            }
-            sortOrder={sortOrders[sortOrder] as SortMode}
-            onClick={() => handleSort(index)}
-          >
-            {header.label}
-          </Table.SortButton>
-        ) : (
-          header.label
-        )}
-      </Table.HeaderColumn>
-    )
-  );
+  const headers = useOngoingSupportErrandLabels(selectedSupportErrandStatuses).map((header, index) => (
+    <Table.HeaderColumn key={`header-${index}`} sticky={true}>
+      {header.screenReaderOnly ? (
+        <span className="sr-only">{header.label}</span>
+      ) : header.sortable ? (
+        <Table.SortButton
+          isActive={
+            isKC() ? sortColumn === serverSideSortableColsKC[index] : sortColumn === serverSideSortableColsLOP[index]
+          }
+          sortOrder={sortOrders[sortOrder] as SortMode}
+          onClick={() => handleSort(index)}
+        >
+          {header.label}
+        </Table.SortButton>
+      ) : (
+        header.label
+      )}
+    </Table.HeaderColumn>
+  ));
 
   const StatusLabelComponent = (status: string, resolution: string) => {
     const solvedErrandIcon = () => {

--- a/frontend/src/supportmanagement/components/support-errand/support-labels.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/support-labels.component.tsx
@@ -2,9 +2,8 @@ import { All } from '@supportmanagement/interfaces/priority';
 import { Status } from '@supportmanagement/services/support-errand-service';
 import { useTranslation } from 'react-i18next';
 
-export const useOngoingSupportErrandLabels = (statuses: Status[]) => {
+export const useOngoingSupportErrandLabels = (statuses: Status[], overrideResponsibleLabel: boolean = false) => {
   const { t } = useTranslation();
-
   const labels = [
     { label: t('common:overview.status'), screenReaderOnly: false, sortable: true, shownForStatus: All.ALL },
     { label: t('common:overview.lastActivity'), screenReaderOnly: false, sortable: true, shownForStatus: All.ALL },
@@ -40,7 +39,12 @@ export const useOngoingSupportErrandLabels = (statuses: Status[]) => {
       sortable: true,
       shownForStatus: [Status.SUSPENDED],
     },
-    { label: t('common:overview.responsible'), screenReaderOnly: false, sortable: true, shownForStatus: All.ALL },
+    {
+      label: overrideResponsibleLabel ? t('common:overview.registeredBy') : t('common:overview.responsible'),
+      screenReaderOnly: false,
+      sortable: true,
+      shownForStatus: All.ALL,
+    },
   ];
 
   return labels.filter(

--- a/frontend/src/supportmanagement/components/support-errand/support-labels.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/support-labels.component.tsx
@@ -2,7 +2,7 @@ import { All } from '@supportmanagement/interfaces/priority';
 import { Status } from '@supportmanagement/services/support-errand-service';
 import { useTranslation } from 'react-i18next';
 
-export const useOngoingSupportErrandLabels = (statuses: Status[], overrideResponsibleLabel: boolean = false) => {
+export const useOngoingSupportErrandLabels = (statuses: Status[]) => {
   const { t } = useTranslation();
   const labels = [
     { label: t('common:overview.status'), screenReaderOnly: false, sortable: true, shownForStatus: All.ALL },
@@ -40,10 +40,16 @@ export const useOngoingSupportErrandLabels = (statuses: Status[], overrideRespon
       shownForStatus: [Status.SUSPENDED],
     },
     {
-      label: overrideResponsibleLabel ? t('common:overview.registeredBy') : t('common:overview.responsible'),
+      label: t('common:overview.responsible'),
       screenReaderOnly: false,
       sortable: true,
-      shownForStatus: All.ALL,
+      shownForStatus: Object.values(Status).filter((status) => status !== Status.NEW),
+    },
+    {
+      label: t('common:overview.registeredBy'),
+      screenReaderOnly: false,
+      sortable: true,
+      shownForStatus: [Status.NEW],
     },
   ];
 


### PR DESCRIPTION
- Changed name of table header label from responsible to registred by in supportmanagement applications. This change only applies to the selected new errands.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).

JIRA: https://jira.sundsvall.se/browse/DRAKEN-1523
