### PR TITLE
Feature/draken 1762 toastmessage changes

### DIFF
--- a/frontend/src/casedata/components/errand/appeal-button.component.tsx
+++ b/frontend/src/casedata/components/errand/appeal-button.component.tsx
@@ -2,6 +2,7 @@ import { IErrand } from '@casedata/interfaces/errand';
 import { UiPhase } from '@casedata/interfaces/errand-phase';
 import { appealErrand, getErrand } from '@casedata/services/casedata-errand-service';
 import { Admin } from '@common/services/user-service';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 import { useAppContext } from '@contexts/app.context';
 import { Button, useConfirm, useSnackbar } from '@sk-web-gui/react';
 import { useRouter } from 'next/navigation';
@@ -38,12 +39,12 @@ export const AppealButtonComponent: React.FC<{ disabled: boolean }> = (props) =>
           throw new Error('Failed to fetch the appealed errand');
         }
         setErrand(appealedErrand.errand, () => {
-          toastMessage({
-            position: 'bottom',
-            closeable: false,
-            message: 'Överklagan registrerad',
-            status: 'success',
-          });
+          toastMessage(
+            getToastOptions({
+              message: 'Överklagan registrerad',
+              status: 'success',
+            })
+          );
         });
         router.replace(`/arende/${municipalityId}/${appealedErrand.errand.errandNumber}`);
         setIsLoading(false);

--- a/frontend/src/casedata/components/errand/casedata-errand.component.tsx
+++ b/frontend/src/casedata/components/errand/casedata-errand.component.tsx
@@ -112,12 +112,14 @@ export const CasedataErrandComponent: React.FC<{ id?: string }> = (props) => {
       // Registering new errand, show default values
       setErrand(emptyErrand);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router]);
 
   useEffect(() => {
     if (errand) {
       setUiPhase(getUiPhase(errand));
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [errand]);
 
   function estateToText(propertyDesignation: string) {

--- a/frontend/src/casedata/components/errand/forms/simplified-contact-form.component.tsx
+++ b/frontend/src/casedata/components/errand/forms/simplified-contact-form.component.tsx
@@ -25,6 +25,7 @@ import * as yup from 'yup';
 import { ContactSearchField } from './contact-search-field.component';
 import { SearchModeSelector } from './search-mode-selector.component';
 import { SearchResult } from './search-result.component';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 
 export const emptyContact: CasedataOwnerOrContact = {
   id: undefined,
@@ -272,12 +273,12 @@ export const SimplifiedContactForm: React.FC<{
       .then((res) => {
         getErrand(municipalityId, errand.id.toString()).then((res) => {
           setErrand(res.errand);
-          toastMessage({
-            position: 'bottom',
-            closeable: false,
-            message: 'Ärendepersonen sparades',
-            status: 'success',
-          });
+          toastMessage(
+            getToastOptions({
+              message: 'Ärendepersonen sparades',
+              status: 'success',
+            })
+          );
           onClose();
           setModalOpen(false);
           setManual(false);

--- a/frontend/src/casedata/components/errand/phasechanger/phasechanger.component.tsx
+++ b/frontend/src/casedata/components/errand/phasechanger/phasechanger.component.tsx
@@ -16,6 +16,7 @@ import {
 import { setAdministrator } from '@casedata/services/casedata-stakeholder-service';
 import { useAppContext } from '@common/contexts/app.context';
 import { Admin } from '@common/services/user-service';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 import LucideIcon from '@sk-web-gui/lucide-icon';
 import {
   Button,
@@ -132,12 +133,12 @@ export const PhaseChanger = () => {
     setError(false);
     return setAdministrator(municipalityId, errand, admin)
       .then(() => {
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: 'Handläggaren sparades, går vidare till granskning',
-          status: 'success',
-        });
+        toastMessage(
+          getToastOptions({
+            message: 'Handläggaren sparades, går vidare till granskning',
+            status: 'success',
+          })
+        );
         setIsLoading(false);
         getErrand(municipalityId, errand.id.toString()).then((res) => setErrand(res.errand));
         reset();
@@ -171,12 +172,12 @@ export const PhaseChanger = () => {
             .then((res) => setErrand(res.errand))
             .then(() => {
               setIsLoading(false);
-              toastMessage({
-                position: 'bottom',
-                closeable: false,
-                message: 'Fasbytet inleddes',
-                status: 'success',
-              });
+              toastMessage(
+                getToastOptions({
+                  message: 'Fasbytet inleddes',
+                  status: 'success',
+                })
+              );
               setError(true);
               setIsLoading(false);
             })

--- a/frontend/src/casedata/components/errand/sidebar/resume-errand-button.component.tsx
+++ b/frontend/src/casedata/components/errand/sidebar/resume-errand-button.component.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { sortBy } from '@common/services/helper-service';
 import { getErrand, setErrandStatus } from '@casedata/services/casedata-errand-service';
 import { ErrandStatus } from '@casedata/interfaces/errand-status';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 
 export const ResumeErrandButton: React.FC<{ disabled: boolean }> = ({ disabled }) => {
   const { municipalityId, errand, setErrand } = useAppContext();
@@ -23,12 +24,12 @@ export const ResumeErrandButton: React.FC<{ disabled: boolean }> = ({ disabled }
       null
     )
       .then((res) => {
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: 'Ärendet återupptogs',
-          status: 'success',
-        });
+        toastMessage(
+          getToastOptions({
+            message: 'Ärendet återupptogs',
+            status: 'success',
+          })
+        );
         setIsLoading(false);
         getErrand(municipalityId, errand.id.toString()).then((res) => setErrand(res.errand));
       })

--- a/frontend/src/casedata/components/errand/sidebar/sidebar-generic-notes.component.tsx
+++ b/frontend/src/casedata/components/errand/sidebar/sidebar-generic-notes.component.tsx
@@ -10,6 +10,7 @@ import { getErrand, isErrandAdmin } from '@casedata/services/casedata-errand-ser
 import { useAppContext } from '@common/contexts/app.context';
 import { sanitizedInline } from '@common/services/sanitizer-service';
 import { getInitialsFromADUsername } from '@common/services/user-service';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 import LucideIcon from '@sk-web-gui/lucide-icon';
 import { Avatar, Button, Divider, FormControl, Modal, PopupMenu, Textarea, cx, useSnackbar } from '@sk-web-gui/react';
 import dayjs from 'dayjs';
@@ -71,12 +72,12 @@ export const SidebarGenericNotes: React.FC<{
     if (createNote) {
       return saveErrandNote(municipalityId, errand.id?.toString(), newNote)
         .then(() => {
-          toastMessage({
-            position: 'bottom',
-            closeable: false,
-            message: `${label_singular}en sparades`,
-            status: 'success',
-          });
+          toastMessage(
+            getToastOptions({
+              message: `${label_singular}en sparades`,
+              status: 'success',
+            })
+          );
           setIsLoading(false);
           getErrand(municipalityId, errand.id.toString()).then((res) => setErrand(res.errand));
           setValue('text', '');
@@ -131,12 +132,12 @@ export const SidebarGenericNotes: React.FC<{
 
     return saveErrandNote(municipalityId, errand.id?.toString(), editNote)
       .then(() => {
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: `${label_singular}en sparades`,
-          status: 'success',
-        });
+        toastMessage(
+          getToastOptions({
+            message: `${label_singular}en sparades`,
+            status: 'success',
+          })
+        );
         getErrand(municipalityId, errand.id.toString()).then((res) => setErrand(res.errand));
         setValue('text', '');
         setEditNote(false);
@@ -157,12 +158,12 @@ export const SidebarGenericNotes: React.FC<{
   const removeNote = (inNote) => {
     return deleteErrandNote(municipalityId, errand.id?.toString(), inNote.id?.toString())
       .then(() => {
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: `${label_singular}en togs bort`,
-          status: 'success',
-        });
+        toastMessage(
+          getToastOptions({
+            message: `${label_singular}en togs bort`,
+            status: 'success',
+          })
+        );
         getErrand(municipalityId, errand.id.toString()).then((res) => setErrand(res.errand));
         setValue('text', '');
       })

--- a/frontend/src/casedata/components/errand/sidebar/sidebar-info.component.tsx
+++ b/frontend/src/casedata/components/errand/sidebar/sidebar-info.component.tsx
@@ -39,6 +39,7 @@ import { AppealButtonComponent } from '../appeal-button.component';
 import { PhaseChanger } from '../phasechanger/phasechanger.component';
 import { ResumeErrandButton } from './resume-errand-button.component';
 import { MessageComposer } from '../tabs/messages/message-composer.component';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 
 export const SidebarInfo: React.FC<{}> = () => {
   const {
@@ -122,12 +123,12 @@ export const SidebarInfo: React.FC<{}> = () => {
     setError(false);
     return setAdministrator(municipalityId, errand, admin)
       .then(() => {
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: 'Handläggare sparades',
-          status: 'success',
-        });
+        toastMessage(
+          getToastOptions({
+            message: 'Handläggare sparades',
+            status: 'success',
+          })
+        );
 
         const status = Object.entries(ErrandStatus).find(([key, label]) => label === 'Tilldelat')[1];
         updateErrandStatus(municipalityId, errand.id.toString(), status).then(() => {
@@ -156,12 +157,12 @@ export const SidebarInfo: React.FC<{}> = () => {
     setError(false);
     return setAdministrator(municipalityId, errand, admin)
       .then(() => {
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: 'Handläggare sparades',
-          status: 'success',
-        });
+        toastMessage(
+          getToastOptions({
+            message: 'Handläggare sparades',
+            status: 'success',
+          })
+        );
         setIsLoading(false);
         getErrand(municipalityId, errand.id.toString()).then((res) => setErrand(res.errand));
         reset();
@@ -186,12 +187,12 @@ export const SidebarInfo: React.FC<{}> = () => {
     setError(false);
     return updateErrandStatus(municipalityId, errand.id.toString(), status)
       .then(() => {
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: 'Status ändrades',
-          status: 'success',
-        });
+        toastMessage(
+          getToastOptions({
+            message: 'Status ändrades',
+            status: 'success',
+          })
+        );
         setIsLoading(false);
         getErrand(municipalityId, errand.id.toString()).then((res) => setErrand(res.errand));
         reset();
@@ -256,21 +257,21 @@ export const SidebarInfo: React.FC<{}> = () => {
       };
       return saveErrandNote(municipalityId, errand.id?.toString(), newNote)
         .then(() => {
-          toastMessage({
-            position: 'bottom',
-            closeable: false,
-            message: `Tjänsteanteckningen sparades`,
-            status: 'success',
-          });
+          toastMessage(
+            getToastOptions({
+              message: `Tjänsteanteckningen sparades`,
+              status: 'success',
+            })
+          );
 
           cancelErrandPhaseChange(municipalityId, errand)
             .then(() => {
-              toastMessage({
-                position: 'bottom',
-                closeable: false,
-                message: 'Ärendet avslutades',
-                status: 'success',
-              });
+              toastMessage(
+                getToastOptions({
+                  message: 'Ärendet avslutades',
+                  status: 'success',
+                })
+              );
               setModalIsOpen(false);
 
               //TODO add polling.

--- a/frontend/src/casedata/components/errand/sidebar/sidebar-utredning.component.tsx
+++ b/frontend/src/casedata/components/errand/sidebar/sidebar-utredning.component.tsx
@@ -21,6 +21,7 @@ import { useEffect, useRef, useState } from 'react';
 import { UseFormReturn, useForm } from 'react-hook-form';
 import * as yup from 'yup';
 import dynamic from 'next/dynamic';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 const TextEditor = dynamic(() => import('@sk-web-gui/text-editor'), { ssr: false });
 
 export interface UtredningFormModel {
@@ -99,12 +100,12 @@ export const SidebarUtredning: React.FC = () => {
       const refresh = await getErrand(municipalityId, errand.id.toString()).then((res) => setErrand(res.errand));
       setIsLoading(false);
       setError(undefined);
-      toastMessage({
-        position: 'bottom',
-        closeable: false,
-        message: 'Utredningen sparades',
-        status: 'success',
-      });
+      toastMessage(
+        getToastOptions({
+          message: 'Utredningen sparades',
+          status: 'success',
+        })
+      );
     } catch (error) {
       toastMessage({
         position: 'bottom',

--- a/frontend/src/casedata/components/errand/tabs/attachments/casedata-attachments.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/attachments/casedata-attachments.component.tsx
@@ -40,6 +40,7 @@ import { Fragment, useEffect, useRef, useState } from 'react';
 import { Resolver, useFieldArray, useForm } from 'react-hook-form';
 import * as yup from 'yup';
 import { FileUploadWrapper } from '../../../../../common/components/file-upload/file-upload-dragdrop-context';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 
 export interface SingleAttachment {
   file: File | undefined;
@@ -388,12 +389,12 @@ export const CasedataAttachments: React.FC = () => {
                           getErrand(municipalityId, errand.id.toString())
                             .then((res) => setErrand(res.errand))
                             .then(() => {
-                              toastMessage({
-                                position: 'bottom',
-                                closeable: false,
-                                message: attachments.length > 1 ? 'Bilagorna sparades' : 'Bilagan sparades',
-                                status: 'success',
-                              });
+                              toastMessage(
+                                getToastOptions({
+                                  message: attachments.length > 1 ? 'Bilagorna sparades' : 'Bilagan sparades',
+                                  status: 'success',
+                                })
+                              );
                               setSelectedAttachment(null);
                               setValue('id', undefined);
                               reset(defaultAttachmentInformation);
@@ -571,10 +572,12 @@ export const CasedataAttachments: React.FC = () => {
                                               });
                                             })
                                             .then(() => {
-                                              toastMessage({
-                                                message: 'Bilagan togs bort',
-                                                status: 'success',
-                                              });
+                                              toastMessage(
+                                                getToastOptions({
+                                                  message: 'Bilagan togs bort',
+                                                  status: 'success',
+                                                })
+                                              );
                                             })
                                             .catch((e) => {
                                               toastMessage({

--- a/frontend/src/casedata/components/errand/tabs/contract/casedata-contract-attachment-upload.tsx
+++ b/frontend/src/casedata/components/errand/tabs/contract/casedata-contract-attachment-upload.tsx
@@ -1,6 +1,7 @@
 import { getErrand, isErrandLocked, validateAction } from '@casedata/services/casedata-errand-service';
 import { saveSignedContractAttachment } from '@casedata/services/contract-service';
 import FileUpload from '@common/components/file-upload/file-upload.component';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 import { useAppContext } from '@contexts/app.context';
 import { yupResolver } from '@hookform/resolvers/yup';
 import LucideIcon from '@sk-web-gui/lucide-icon';
@@ -131,12 +132,12 @@ export const CasedataContractAttachmentUpload: React.FC<{ contractId: string }> 
                     getErrand(municipalityId, errand.id.toString())
                       .then((res) => setErrand(res.errand))
                       .then(() => {
-                        toastMessage({
-                          position: 'bottom',
-                          closeable: false,
-                          message: 'Bilagan sparades',
-                          status: 'success',
-                        });
+                        toastMessage(
+                          getToastOptions({
+                            message: 'Bilagan sparades',
+                            status: 'success',
+                          })
+                        );
                       })
                   )
                   .catch(() => {

--- a/frontend/src/casedata/components/errand/tabs/contract/casedata-contract-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/contract/casedata-contract-tab.tsx
@@ -46,6 +46,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { ContractNavigation } from './contract-navigation';
 import { KopeAvtal } from './kopeavtal';
 import { Lagenhetsarrende } from './lagenhetsarrende';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 
 interface CasedataContractProps {
   update: () => void;
@@ -168,12 +169,12 @@ export const CasedataContractTab: React.FC<CasedataContractProps> = (props) => {
         getErrand(municipalityId, errand.id.toString())
           .then((res) => {
             setErrand(res.errand);
-            toastMessage({
-              position: 'bottom',
-              closeable: false,
-              message: 'Avtalet sparades',
-              status: 'success',
-            });
+            toastMessage(
+              getToastOptions({
+                message: 'Avtalet sparades',
+                status: 'success',
+              })
+            );
             setIsLoading(undefined);
           })
           .catch((e) => {
@@ -364,12 +365,12 @@ export const CasedataContractTab: React.FC<CasedataContractProps> = (props) => {
                                   });
                                 })
                                 .then(() => {
-                                  toastMessage({
-                                    position: 'bottom',
-                                    closeable: false,
-                                    message: 'Bilagan togs bort',
-                                    status: 'success',
-                                  });
+                                  toastMessage(
+                                    getToastOptions({
+                                      message: 'Bilagan togs bort',
+                                      status: 'success',
+                                    })
+                                  );
                                 })
                                 .catch(() => {
                                   toastMessage({

--- a/frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx
@@ -59,6 +59,7 @@ import {
 } from '@sk-web-gui/react';
 import dynamic from 'next/dynamic';
 import { CasedataMessageTabFormModel } from '../messages/message-composer.component';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 const TextEditor = dynamic(() => import('@sk-web-gui/text-editor'), { ssr: false });
 
 export type ContactMeans = 'webmessage' | 'email' | 'digitalmail' | false;
@@ -200,12 +201,12 @@ export const CasedataDecisionTab: React.FC<{
       .then((res) => setErrand(res.errand))
       .then(() => {
         setIsLoading(false);
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: 'Fasbytet inleddes',
-          status: 'success',
-        });
+        toastMessage(
+          getToastOptions({
+            message: 'Fasbytet inleddes',
+            status: 'success',
+          })
+        );
         setIsLoading(false);
       })
       .catch(() => {
@@ -227,12 +228,12 @@ export const CasedataDecisionTab: React.FC<{
       setIsLoading(false);
       setError(undefined);
       props.setUnsaved(false);
-      toastMessage({
-        position: 'bottom',
-        closeable: false,
-        message: 'Beslutet sparades',
-        status: 'success',
-      });
+      toastMessage(
+        getToastOptions({
+          message: 'Beslutet sparades',
+          status: 'success',
+        })
+      );
       await getErrand(municipalityId, errand.id.toString()).then((res) => setErrand(res.errand));
     } catch (error) {
       toastMessage({
@@ -314,12 +315,12 @@ export const CasedataDecisionTab: React.FC<{
           };
       const updatedStatus = await updateErrandStatus(municipalityId, errand.id.toString(), ErrandStatus.Beslutad);
       const phaseChange = await triggerPhaseChange();
-      toastMessage({
-        position: 'bottom',
-        closeable: false,
-        message: 'Beslutet skickades',
-        status: 'success',
-      });
+      toastMessage(
+        getToastOptions({
+          message: 'Beslutet skickades',
+          status: 'success',
+        })
+      );
     } catch (error) {
       toastMessage({
         position: 'bottom',

--- a/frontend/src/casedata/components/errand/tabs/details/casedata-details-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/details/casedata-details-tab.tsx
@@ -17,6 +17,7 @@ import { Button, Divider, FormControl, FormLabel, Input, Textarea, cx, useSnackb
 import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { CasedataFormFieldRenderer } from './casedata-formfield-renderer';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 
 interface CasedataDetailsProps {
   update: () => void;
@@ -103,12 +104,12 @@ export const CasedataDetailsTab: React.FC<CasedataDetailsProps> = (props) => {
       return getErrand(municipalityId, errand.id.toString())
         .then((res) => {
           setErrand(res.errand);
-          toastMessage({
-            position: 'bottom',
-            closeable: false,
-            message: 'Fastighetsinformationen sparades',
-            status: 'success',
-          });
+          toastMessage(
+            getToastOptions({
+              message: 'Fastighetsinformationen sparades',
+              status: 'success',
+            })
+          );
           setIsLoading(undefined);
         })
         .catch(() => {
@@ -142,12 +143,12 @@ export const CasedataDetailsTab: React.FC<CasedataDetailsProps> = (props) => {
         props.setUnsaved(false);
         getErrand(municipalityId, errand.id.toString()).then((res) => {
           setErrand(res.errand);
-          toastMessage({
-            position: 'bottom',
-            closeable: false,
-            message: 'Uppgifterna sparades',
-            status: 'success',
-          });
+          toastMessage(
+            getToastOptions({
+              message: 'Uppgifterna sparades',
+              status: 'success',
+            })
+          );
           setIsLoading(undefined);
         });
       })

--- a/frontend/src/casedata/components/errand/tabs/investigation/casedata-investigation-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/investigation/casedata-investigation-tab.tsx
@@ -13,6 +13,7 @@ import { getErrand, isErrandLocked, isFTErrand, validateAction } from '@casedata
 import { FT_INVESTIGATION_TEXT } from '@casedata/utils/investigation-text';
 import { Law } from '@common/data-contracts/case-data/data-contracts';
 import sanitized from '@common/services/sanitizer-service';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 import { AppContextInterface, useAppContext } from '@contexts/app.context';
 import { yupResolver } from '@hookform/resolvers/yup';
 import LucideIcon from '@sk-web-gui/lucide-icon';
@@ -138,12 +139,12 @@ export const CasedataInvestigationTab: React.FC<{
       setIsLoading(false);
       setError(undefined);
       props.setUnsaved(false);
-      toastMessage({
-        position: 'bottom',
-        closeable: false,
-        message: 'Utredningen sparades',
-        status: 'success',
-      });
+      toastMessage(
+        getToastOptions({
+          message: 'Utredningen sparades',
+          status: 'success',
+        })
+      );
       await getErrand(municipalityId, errand.id.toString()).then((res) => setErrand(res.errand));
     } catch (error) {
       toastMessage({

--- a/frontend/src/casedata/components/errand/tabs/messages/message-composer.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/messages/message-composer.component.tsx
@@ -47,6 +47,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Resolver, useFieldArray, useForm } from 'react-hook-form';
 import * as yup from 'yup';
 import { MessageWrapper } from './message-wrapper.component';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 const TextEditor = dynamic(() => import('@sk-web-gui/text-editor'), { ssr: false });
 
 export interface CasedataMessageTabFormModel {
@@ -253,12 +254,12 @@ export const MessageComposer: React.FC<{
         data.messageAttachments.map((a) => a.file).filter((f): f is FileList => !!f)
       )
         .then(() => {
-          toastMessage({
-            position: 'bottom',
-            closeable: false,
-            message: `Meddelandet skickades`,
-            status: 'success',
-          });
+          toastMessage(
+            getToastOptions({
+              message: `Meddelandet skickades`,
+              status: 'success',
+            })
+          );
           setIsLoading(false);
           props.update();
           clearAndClose();
@@ -278,18 +279,18 @@ export const MessageComposer: React.FC<{
     } else {
       apiCall(municipalityId, errand, data)
         .then(() => {
-          toastMessage({
-            position: 'bottom',
-            closeable: false,
-            message: `${
-              data.contactMeans === 'sms'
-                ? 'SMS:et'
-                : data.contactMeans === 'email'
-                ? 'E-postmeddelandet'
-                : 'Meddelandet'
-            } skickades`,
-            status: 'success',
-          });
+          toastMessage(
+            getToastOptions({
+              message: `${
+                data.contactMeans === 'sms'
+                  ? 'SMS:et'
+                  : data.contactMeans === 'email'
+                  ? 'E-postmeddelandet'
+                  : 'Meddelandet'
+              } skickades`,
+              status: 'success',
+            })
+          );
           setIsLoading(false);
           props.update();
           clearAndClose();

--- a/frontend/src/casedata/components/errand/tabs/overview/casedata-contacts.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/overview/casedata-contacts.component.tsx
@@ -13,6 +13,7 @@ import {
   removeStakeholder,
 } from '@casedata/services/casedata-stakeholder-service';
 import { useAppContext } from '@common/contexts/app.context';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 import { appConfig } from '@config/appconfig';
 import LucideIcon from '@sk-web-gui/lucide-icon';
 import { Avatar, Button, Divider, FormControl, FormLabel, useConfirm, useSnackbar } from '@sk-web-gui/react';
@@ -43,15 +44,8 @@ export const CasedataContactsComponent: React.FC<CasedataContactsProps> = (props
   }, [errand]);
 
   const {
-    register,
     control,
-    handleSubmit,
-    watch,
-    setValue,
-    trigger,
     reset,
-    getValues,
-    formState,
     formState: { errors },
   }: UseFormReturn<IErrand, any, undefined> = useFormContext();
 
@@ -70,6 +64,7 @@ export const CasedataContactsComponent: React.FC<CasedataContactsProps> = (props
 
   useEffect(() => {
     reset(errand);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [errand]);
 
   const onRemoveContact: (stakeholderId: string, index: number) => Promise<boolean> = (stakeholderId, index) => {
@@ -77,12 +72,12 @@ export const CasedataContactsComponent: React.FC<CasedataContactsProps> = (props
       .then((res) => {
         getErrand(municipalityId, errand.id.toString()).then((res) => {
           setErrand(res.errand);
-          toastMessage({
-            position: 'bottom',
-            closeable: false,
-            message: 'Intressenten togs bort',
-            status: 'success',
-          });
+          toastMessage(
+            getToastOptions({
+              message: 'Intressenten togs bort',
+              status: 'success',
+            })
+          );
         });
         return !!res;
       })
@@ -106,12 +101,12 @@ export const CasedataContactsComponent: React.FC<CasedataContactsProps> = (props
       .then((res) => {
         getErrand(municipalityId, errand.id.toString()).then((res) => {
           setErrand(res.errand);
-          toastMessage({
-            position: 'bottom',
-            closeable: false,
-            message: 'Ändringen sparades',
-            status: 'success',
-          });
+          toastMessage(
+            getToastOptions({
+              message: 'Ändringen sparades',
+              status: 'success',
+            })
+          );
         });
         return res ? true : false;
       })

--- a/frontend/src/casedata/components/save-button/save-button.component.tsx
+++ b/frontend/src/casedata/components/save-button/save-button.component.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from 'react';
 import { useFormContext, UseFormReturn } from 'react-hook-form';
 import { stakeholder2Contact } from '@casedata/services/casedata-stakeholder-service';
 import { Role } from '@casedata/interfaces/role';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 
 export const SaveButtonComponent: React.FC<{
   registeringNewErrand?: boolean;
@@ -128,12 +129,12 @@ export const SaveButtonComponent: React.FC<{
           setErrand(saved.errand);
         }
         setIsLoading(false);
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: 'Ärendet sparades',
-          status: 'success',
-        });
+        toastMessage(
+          getToastOptions({
+            message: 'Ärendet sparades',
+            status: 'success',
+          })
+        );
       })
       .catch((e) => {
         console.error('Error when updating errand:', e);

--- a/frontend/src/casedata/components/suspend-errand.tsx
+++ b/frontend/src/casedata/components/suspend-errand.tsx
@@ -1,6 +1,7 @@
 import { IErrand } from '@casedata/interfaces/errand';
 import { ErrandStatus } from '@casedata/interfaces/errand-status';
 import { getErrand, phaseChangeInProgress, setErrandStatus } from '@casedata/services/casedata-errand-service';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 import { useAppContext } from '@contexts/app.context';
 import { yupResolver } from '@hookform/resolvers/yup';
 import LucideIcon from '@sk-web-gui/lucide-icon';
@@ -53,12 +54,12 @@ export const SuspendErrandComponent: React.FC<{ disabled: boolean }> = ({ disabl
     setError(false);
     return setErrandStatus(errand.id, municipalityId, ErrandStatus.Parkerad, data.date, data.comment)
       .then((res) => {
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: 'Ärendet parkerades',
-          status: 'success',
-        });
+        toastMessage(
+          getToastOptions({
+            status: 'success',
+            message: 'Ärendet parkerades',
+          })
+        );
         setIsLoading(false);
         setShowModal(false);
         getErrand(municipalityId, errand.id.toString()).then((res) => setErrand(res.errand));

--- a/frontend/src/common/utils/toast-message-settings.ts
+++ b/frontend/src/common/utils/toast-message-settings.ts
@@ -1,0 +1,30 @@
+export type ToastStatus = 'success' | 'error' | 'info' | 'warning';
+
+export interface ToastOverrides {
+  duration?: number;
+  position?: 'top' | 'bottom';
+  closeable?: boolean;
+}
+
+const statusOverrides: Partial<Record<ToastStatus, ToastOverrides>> = {
+  success: {
+    duration: 2000,
+    closeable: true,
+    position: 'bottom',
+  },
+  // error, info, warning kan läggas till vid behov
+};
+
+interface ToastInput {
+  status: ToastStatus;
+  message: string;
+}
+
+export function getToastOptions({ status, message }: ToastInput) {
+  const overrides = statusOverrides[status] ?? {};
+  return {
+    status,
+    message,
+    ...overrides,
+  };
+}

--- a/frontend/src/common/utils/toast-message-settings.ts
+++ b/frontend/src/common/utils/toast-message-settings.ts
@@ -12,7 +12,7 @@ const statusOverrides: Partial<Record<ToastStatus, ToastOverrides>> = {
     closeable: true,
     position: 'bottom',
   },
-  // error, info, warning kan läggas till vid behov
+  // Options for error, info, warning can be added similarly
 };
 
 interface ToastInput {

--- a/frontend/src/supportmanagement/components/attestation-tab/attestation-invoice-form.component.tsx
+++ b/frontend/src/supportmanagement/components/attestation-tab/attestation-invoice-form.component.tsx
@@ -17,6 +17,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { FormProvider, Resolver, useForm } from 'react-hook-form';
 import { CBillingRecord, CBillingRecordStatusEnum } from 'src/data-contracts/backend/data-contracts';
 import BillingForm from '../billing/billing-form.component';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 
 export const AttestationInvoiceForm: React.FC<{
   setUnsaved?: (boolean) => void;
@@ -98,12 +99,12 @@ export const AttestationInvoiceForm: React.FC<{
   const onSubmit = () => {
     return saveBillingRecord(undefined, municipalityId, getValues())
       .then(() => {
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: 'Fakturan sparades',
-          status: 'success',
-        });
+        toastMessage(
+          getToastOptions({
+            message: 'Fakturan sparades',
+            status: 'success',
+          })
+        );
         props.update(getValues().id);
       })
       .catch(() => {

--- a/frontend/src/supportmanagement/components/support-errand/sidebar/close-errand.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/close-errand.component.tsx
@@ -1,6 +1,7 @@
 import { User } from '@common/interfaces/user';
 import { isIK, isKA, isLOP, isROB } from '@common/services/application-service';
 import { deepFlattenToObject } from '@common/services/helper-service';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 import { useAppContext } from '@contexts/app.context';
 import LucideIcon from '@sk-web-gui/lucide-icon';
 import { Button, Checkbox, FormControl, Modal, RadioButton, useConfirm, useSnackbar } from '@sk-web-gui/react';
@@ -16,7 +17,6 @@ import {
   SupportErrand,
   closeSupportErrand,
   getSupportErrandById,
-  shouldShowResumeErrandButton,
 } from '@supportmanagement/services/support-errand-service';
 import { sendClosingMessage } from '@supportmanagement/services/support-message-service';
 import { applicantHasContactChannel, getAdminName } from '@supportmanagement/services/support-stakeholder-service';
@@ -62,12 +62,12 @@ export const CloseErrandComponent: React.FC<{ disabled: boolean }> = ({ disabled
         }
       })
       .then(() => {
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: 'Ärendet avslutades',
-          status: 'success',
-        });
+        toastMessage(
+          getToastOptions({
+            message: 'Ärendet avslutades',
+            status: 'success',
+          })
+        );
         setTimeout(() => {
           window.close();
         }, 2000);

--- a/frontend/src/supportmanagement/components/support-errand/sidebar/forward-errand.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/forward-errand.component.tsx
@@ -37,6 +37,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useForm, useFormContext, UseFormReturn } from 'react-hook-form';
 import * as yup from 'yup';
 import dynamic from 'next/dynamic';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 const TextEditor = dynamic(() => import('@sk-web-gui/text-editor'), { ssr: false });
 
 const yupForwardForm = yup.object().shape(
@@ -171,12 +172,12 @@ export const ForwardErrandComponent: React.FC<{ disabled: boolean }> = ({ disabl
         }
       })
       .then(() => {
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: 'Ärendet vidarebefordrades',
-          status: 'success',
-        });
+        toastMessage(
+          getToastOptions({
+            message: 'Ärendet vidarebefordrades',
+            status: 'success',
+          })
+        );
         setTimeout(() => {
           window.close();
         }, 2000);

--- a/frontend/src/supportmanagement/components/support-errand/sidebar/request-internal.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/request-internal.component.tsx
@@ -34,6 +34,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useForm, UseFormReturn } from 'react-hook-form';
 import * as yup from 'yup';
 import dynamic from 'next/dynamic';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 const TextEditor = dynamic(() => import('@sk-web-gui/text-editor'), { ssr: false });
 
 const yupRequestFeedbackForm = yup.object().shape(
@@ -128,12 +129,12 @@ export const RequestInternalComponent: React.FC<{ disabled: boolean }> = ({ disa
     setError(false);
     return requestInternal(user, supportErrand, municipalityId, data, addedAttachment, appConfig.applicationName)
       .then(() => {
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: 'Komplettering begärd',
-          status: 'success',
-        });
+        toastMessage(
+          getToastOptions({
+            message: 'Komplettering begärd',
+            status: 'success',
+          })
+        );
         setIsLoading(false);
         setShowModal(false);
         getSupportErrandById(supportErrand.id, municipalityId).then((res) => setSupportErrand(res.errand));

--- a/frontend/src/supportmanagement/components/support-errand/sidebar/sidebar-generic-notes.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/sidebar-generic-notes.component.tsx
@@ -3,6 +3,7 @@ import { noteIsComment, noteIsTjansteanteckning } from '@casedata/services/cased
 import { useAppContext } from '@common/contexts/app.context';
 import { sanitizedInline } from '@common/services/sanitizer-service';
 import { getInitialsFromADUsername } from '@common/services/user-service';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 import { yupResolver } from '@hookform/resolvers/yup';
 import LucideIcon from '@sk-web-gui/lucide-icon';
 import {
@@ -87,12 +88,12 @@ export const SidebarGenericNotes: React.FC<{
 
     return apiCall
       .then(() => {
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: `${label_singular}en sparades`,
-          status: 'success',
-        });
+        toastMessage(
+          getToastOptions({
+            message: `${label_singular}en sparades`,
+            status: 'success',
+          })
+        );
         setIsLoading(false);
         getSupportErrandById(supportErrand.id, municipalityId).then((res) => setSupportErrand(res.errand));
         setValue('text', '');
@@ -133,12 +134,12 @@ export const SidebarGenericNotes: React.FC<{
     const note: ErrandNotesTabFormModel = getValues();
     return updateSupportNote(supportErrand.id, municipalityId, note.id, note.text)
       .then(() => {
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: `${label_singular}en sparades`,
-          status: 'success',
-        });
+        toastMessage(
+          getToastOptions({
+            message: `${label_singular}en sparades`,
+            status: 'success',
+          })
+        );
         getSupportErrandById(supportErrand.id, municipalityId).then((res) => setSupportErrand(res.errand));
         setValue('text', '');
         setValue('id', '');
@@ -159,12 +160,12 @@ export const SidebarGenericNotes: React.FC<{
   const removeNote = (inNote) => {
     return deleteSupportNote(supportErrand.id, municipalityId, inNote.id)
       .then(() => {
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: `${label_singular}en togs bort`,
-          status: 'success',
-        });
+        toastMessage(
+          getToastOptions({
+            message: `${label_singular}en togs bort`,
+            status: 'success',
+          })
+        );
         getSupportErrandById(supportErrand.id, municipalityId).then((res) => setSupportErrand(res.errand));
         setValue('text', '');
       })

--- a/frontend/src/supportmanagement/components/support-errand/sidebar/sidebar-info.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/sidebar-info.component.tsx
@@ -32,6 +32,7 @@ import { ForwardErrandComponent } from './forward-errand.component';
 import { SupportResumeErrandButton } from './support-resume-errand-button.component';
 import { StartProcessComponent } from './start-process.component';
 import { SuspendErrandComponent } from './suspend-errand.component';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 
 export const SidebarInfo: React.FC<{
   unsavedFacility: boolean;
@@ -77,13 +78,23 @@ export const SidebarInfo: React.FC<{
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user, supportErrand]);
 
-  const toast = (kind, label) =>
-    toastMessage({
-      position: 'bottom',
-      closeable: false,
-      message: label,
-      status: kind,
-    });
+  const toast = (kind: 'success' | 'error' | 'warning' | 'info', label) => {
+    if (kind === 'success') {
+      toastMessage(
+        getToastOptions({
+          message: label,
+          status: kind,
+        })
+      );
+    } else {
+      toastMessage({
+        position: 'bottom',
+        closeable: false,
+        message: label,
+        status: kind,
+      });
+    }
+  };
 
   const {
     register,
@@ -145,12 +156,12 @@ export const SidebarInfo: React.FC<{
             });
         }
         update();
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: 'Ärendet uppdaterades',
-          status: 'success',
-        });
+        toastMessage(
+          getToastOptions({
+            message: 'Ärendet uppdaterades',
+            status: 'success',
+          })
+        );
         setTimeout(async () => {
           const e = await getSupportErrandById(getValues().id, municipalityId);
           setSupportErrand(e.errand);

--- a/frontend/src/supportmanagement/components/support-errand/sidebar/support-resume-errand-button.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/support-resume-errand-button.component.tsx
@@ -8,6 +8,7 @@ import {
   Status,
 } from '@supportmanagement/services/support-errand-service';
 import { useState } from 'react';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 
 export const SupportResumeErrandButton: React.FC<{ disabled: boolean }> = ({ disabled }) => {
   const { municipalityId, supportErrand, setSupportErrand } = useAppContext();
@@ -19,12 +20,12 @@ export const SupportResumeErrandButton: React.FC<{ disabled: boolean }> = ({ dis
     setIsLoading(true);
     return setSupportErrandStatus(supportErrand.id, municipalityId, Status.ONGOING)
       .then(() => {
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: 'Ärende återupptogs',
-          status: 'success',
-        });
+        toastMessage(
+          getToastOptions({
+            message: 'Ärende återupptogs',
+            status: 'success',
+          })
+        );
         return getSupportErrandById(supportErrand.id, municipalityId).then((res) => {
           setSupportErrand(res.errand);
           setIsLoading(false);

--- a/frontend/src/supportmanagement/components/support-errand/sidebar/suspend-errand.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/suspend-errand.component.tsx
@@ -1,4 +1,5 @@
 import { User } from '@common/interfaces/user';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 import { useAppContext } from '@contexts/app.context';
 import { yupResolver } from '@hookform/resolvers/yup';
 import LucideIcon from '@sk-web-gui/lucide-icon';
@@ -71,12 +72,12 @@ export const SuspendErrandComponent: React.FC<{ disabled: boolean }> = ({ disabl
     setError(false);
     return setSuspension(supportErrand.id, municipalityId, Status.SUSPENDED, data.date, data.comment)
       .then(() => {
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: 'Ärendet parkerades',
-          status: 'success',
-        });
+        toastMessage(
+          getToastOptions({
+            message: 'Ärendet parkerades',
+            status: 'success',
+          })
+        );
         setIsLoading(false);
         setShowModal(false);
         getSupportErrandById(supportErrand.id, municipalityId).then((res) => setSupportErrand(res.errand));

--- a/frontend/src/supportmanagement/components/support-errand/support-errand.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/support-errand.component.tsx
@@ -131,6 +131,7 @@ export const SupportErrandComponent: React.FC<{ id?: string }> = (props) => {
           });
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router, municipalityId, props.id]);
 
   return (

--- a/frontend/src/supportmanagement/components/support-errand/tabs/support-errand-attachments-tab.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/tabs/support-errand-attachments-tab.tsx
@@ -2,6 +2,7 @@ import { FileUploadWrapper } from '@common/components/file-upload/file-upload-dr
 import FileUpload from '@common/components/file-upload/file-upload.component';
 import { useAppContext } from '@common/contexts/app.context';
 import { isKC } from '@common/services/application-service';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from '@headlessui/react';
 import { yupResolver } from '@hookform/resolvers/yup';
 import LucideIcon from '@sk-web-gui/lucide-icon';
@@ -214,12 +215,12 @@ export const SupportErrandAttachmentsTab: React.FC<{
             setSelectedAttachment(null);
           })
           .then(() => {
-            toastMessage({
-              position: 'bottom',
-              closeable: false,
-              message: 'Bilagan togs bort',
-              status: 'success',
-            });
+            toastMessage(
+              getToastOptions({
+                message: 'Bilagan togs bort',
+                status: 'success',
+              })
+            );
             setIsLoading(false);
           })
           .catch((e) => {
@@ -371,12 +372,12 @@ export const SupportErrandAttachmentsTab: React.FC<{
                           reset();
                           setAddAttachmentWindowIsOpen(false);
                           setDragDrop(false);
-                          toastMessage({
-                            position: 'bottom',
-                            closeable: false,
-                            message: 'Bilagan sparades',
-                            status: 'success',
-                          });
+                          toastMessage(
+                            getToastOptions({
+                              message: 'Bilagan sparades',
+                              status: 'success',
+                            })
+                          );
                         })
                         .catch((e) => {
                           if (e.message === 'MAX_SIZE') {

--- a/frontend/src/supportmanagement/components/support-errand/tabs/support-errand-invoice-tab.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/tabs/support-errand-invoice-tab.tsx
@@ -1,5 +1,6 @@
 import { User } from '@common/interfaces/user';
 import { prettyTime } from '@common/services/helper-service';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 import { useAppContext } from '@contexts/app.context';
 import { yupResolver } from '@hookform/resolvers/yup';
 import LucideIcon from '@sk-web-gui/lucide-icon';
@@ -174,12 +175,12 @@ export const SupportErrandInvoiceTab: React.FC<{
     return saveBillingRecord(supportErrand, municipalityId, getValues())
       .then(() => {
         setIsLoading(false);
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: 'Fakturan sparades',
-          status: 'success',
-        });
+        toastMessage(
+          getToastOptions({
+            message: 'Fakturan sparades',
+            status: 'success',
+          })
+        );
         getSupportErrandById(supportErrand.id, municipalityId).then((res) => setSupportErrand(res.errand));
       })
       .catch(() => {

--- a/frontend/src/supportmanagement/components/support-message-form/support-message-form.component.tsx
+++ b/frontend/src/supportmanagement/components/support-message-form/support-message-form.component.tsx
@@ -52,6 +52,7 @@ import {
   sendSupportInternalMessage,
 } from '@supportmanagement/services/support-conversation-service';
 import dynamic from 'next/dynamic';
+import { getToastOptions } from '@common/utils/toast-message-settings';
 const TextEditor = dynamic(() => import('@sk-web-gui/text-editor'), { ssr: false });
 
 const PREFILL_VALUE = '+46';
@@ -311,12 +312,12 @@ export const SupportMessageForm: React.FC<{
           const updated = await getSupportErrandById(supportErrand.id, municipalityId);
           setSupportErrand(updated.errand);
 
-          toastMessage({
-            position: 'bottom',
-            closeable: false,
-            message: 'Ditt meddelande skickades',
-            status: 'success',
-          });
+          toastMessage(
+            getToastOptions({
+              message: 'Ditt meddelande skickades',
+              status: 'success',
+            })
+          );
         })
         .catch((e) => {
           console.error(e);
@@ -383,15 +384,15 @@ export const SupportMessageForm: React.FC<{
           const updated = await getSupportErrandById(supportErrand.id, municipalityId);
           setSupportErrand(updated.errand);
 
-          toastMessage({
-            position: 'bottom',
-            closeable: false,
-            message:
-              data.emails.length + data.phoneNumbers.length === 1
-                ? 'Ditt meddelande skickades'
-                : 'Dina meddelanden skickades',
-            status: 'success',
-          });
+          toastMessage(
+            getToastOptions({
+              message:
+                data.emails.length + data.phoneNumbers.length === 1
+                  ? 'Ditt meddelande skickades'
+                  : 'Dina meddelanden skickades',
+              status: 'success',
+            })
+          );
         })
         .catch((e) => {
           console.error(e);

--- a/frontend/src/supportmanagement/services/support-billing-service.ts
+++ b/frontend/src/supportmanagement/services/support-billing-service.ts
@@ -501,6 +501,7 @@ export const useBillingRecords = (
           });
         });
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [setBillingRecords, billingRecords, size, filter, sort, toastMessage]
   );
 
@@ -508,6 +509,7 @@ export const useBillingRecords = (
     if (size && size > 0) {
       fetchBillingRecords().then(() => setIsLoading(false));
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filter, size, sort]);
 
   useEffect(() => {


### PR DESCRIPTION
## Types of changes
- Added new option file to sync toastmessage settings so that they appear the same way in both CD and SM.
- Only options for Success is added but can add more for error or warning later on.
- Changed all toastmessage success in the application to use the same settings.
- 2000ms duration and they can now be closed by the user.
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).

Jira: https://jira.sundsvall.se/browse/DRAKEN-1762
