### PR TITLE
Potential fix for code scanning alert no. 25: Log injection

### DIFF
--- a/backend/src/middlewares/error.middleware.ts
+++ b/backend/src/middlewares/error.middleware.ts
@@ -2,6 +2,11 @@ import { NextFunction, Request, Response } from 'express';
 import { HttpException } from '@exceptions/HttpException';
 import { logger } from '@utils/logger';
 
+// Helper function to sanitize log input by removing CR and LF characters
+function sanitizeLogInput(input: string): string {
+  return input.replace(/[\r\n]/g, '');
+}
+
 const errorMiddleware = (error: HttpException, req: Request, res: Response, next: NextFunction) => {
   try {
     const status: number = error.status || 500;
@@ -9,8 +14,14 @@ const errorMiddleware = (error: HttpException, req: Request, res: Response, next
     const errors: string =
       error.errors?.length > 0 ? JSON.stringify(error.errors.map(error => ({ property: error.property, constraints: error.constraints }))) : '';
 
-    console.error(`[${req.method}] ${req.path} >> StatusCode:: ${status}, Message:: ${message}, Errors:: ${errors}`);
-    logger.error(`[${req.method}] ${req.path} >> StatusCode:: ${status}, Message:: ${message}, Errors:: ${errors}`);
+    // Sanitize user-controlled input before logging
+    const safeMethod = sanitizeLogInput(String(req.method));
+    const safePath = sanitizeLogInput(String(req.path));
+    const safeMessage = sanitizeLogInput(String(message));
+    const safeErrors = sanitizeLogInput(String(errors));
+
+    console.error(`[${safeMethod}] ${safePath} >> StatusCode:: ${status}, Message:: ${safeMessage}, Errors:: ${safeErrors}`);
+    logger.error(`[${safeMethod}] ${safePath} >> StatusCode:: ${status}, Message:: ${safeMessage}, Errors:: ${safeErrors}`);
     res.status(status).json({ message });
   } catch (error) {
     next(error);


### PR DESCRIPTION
Potential fix for [https://github.com/Sundsvallskommun/web-app-draken-public/security/code-scanning/25](https://github.com/Sundsvallskommun/web-app-draken-public/security/code-scanning/25)

To fix the problem, we need to sanitize any user-controlled input before logging it. Specifically, we should remove or escape newline (`\n`) and carriage return (`\r`) characters from `req.path` (and, for completeness, from `req.method`, `message`, and `errors` if they can be influenced by user input). The best way to do this is to define a small helper function that strips these characters from strings, and use it to sanitize the relevant variables before including them in the log entry. This change should be made in the `errorMiddleware` function in `backend/src/middlewares/error.middleware.ts`. We can define the helper function within the same file, above the middleware function, and use it to sanitize `req.path`, `req.method`, `message`, and `errors` before logging.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
