### PR TITLE
feat: json based services for paratransit errands

### DIFF
--- a/backend/src/config/api-config.ts
+++ b/backend/src/config/api-config.ts
@@ -58,7 +58,7 @@ export const APIS = [
   },
   {
     name: 'partyassets',
-    version: '3.0',
+    version: '3.1',
   },
 ];
 

--- a/backend/src/controllers/metadata.controller.ts
+++ b/backend/src/controllers/metadata.controller.ts
@@ -1,0 +1,39 @@
+import { apiServiceName } from '@/config/api-config';
+import { RequestWithUser } from '@interfaces/auth.interface';
+import authMiddleware from '@middlewares/auth.middleware';
+import ApiService from '@services/api.service';
+import { Controller, Get, Param, Req, UseBefore } from 'routing-controllers';
+import { OpenAPI } from 'routing-controllers-openapi';
+
+interface ResponseData<T> {
+  data: T;
+  message: string;
+}
+
+@Controller()
+export class MetadataController {
+  private apiService = new ApiService();
+  PARTYASSETS_SERVICE = apiServiceName('partyassets');
+
+  @Get('/:municipalityId/metadata/jsonschemas')
+  @OpenAPI({ summary: 'List JSON schemas' })
+  @UseBefore(authMiddleware)
+  async listJsonSchemas(@Req() req: RequestWithUser, @Param('municipalityId') municipalityId: string): Promise<ResponseData<any>> {
+    const url = `${this.PARTYASSETS_SERVICE}/${municipalityId}/metadata/jsonschemas`;
+    const res = await this.apiService.get<any>({ url }, req.user);
+    return { data: res.data, message: 'success' };
+  }
+
+  @Get('/:municipalityId/metadata/jsonschemas/:id')
+  @OpenAPI({ summary: 'Get JSON schema by id' })
+  @UseBefore(authMiddleware)
+  async getJsonSchema(
+    @Req() req: RequestWithUser,
+    @Param('municipalityId') municipalityId: string,
+    @Param('id') id: string,
+  ): Promise<ResponseData<any>> {
+    const url = `${this.PARTYASSETS_SERVICE}/${municipalityId}/metadata/jsonschemas/${id}`;
+    const res = await this.apiService.get<any>({ url }, req.user);
+    return { data: res.data, message: 'success' };
+  }
+}

--- a/backend/src/dtos/assets-dto.ts
+++ b/backend/src/dtos/assets-dto.ts
@@ -1,0 +1,27 @@
+export type AssetStatusDto = 'ACTIVE' | 'INACTIVE' | 'REVOKED' | 'EXPIRED' | string;
+
+export interface CreateAssetDto {
+  assetId: string;
+  origin: string;
+  partyId: string;
+  caseReferenceIds?: string[];
+  type: string;
+  issued?: string | null;
+  validTo?: string | null;
+  status?: AssetStatusDto;
+  statusReason?: string;
+  description?: string;
+  additionalParameters?: Record<string, unknown>;
+  jsonParameters?: Array<{ key: string; value: string; schemaId?: string }>;
+  created?: string;
+  modified?: string;
+}
+
+export interface PatchAssetDto {
+  caseReferenceIds?: string[];
+  validTo?: string | null;
+  status?: AssetStatusDto;
+  statusReason?: string;
+  additionalParameters?: Record<string, unknown>;
+  jsonParameters?: Array<{ key: string; value: string; schemaId?: string }>;
+}

--- a/frontend/src/casedata/components/errand/casedata-tabs-wrapper.tsx
+++ b/frontend/src/casedata/components/errand/casedata-tabs-wrapper.tsx
@@ -1,8 +1,9 @@
 import { CasedataMessagesTab } from '@casedata/components/errand/tabs/messages/casedata-messages-tab';
 import { IErrand } from '@casedata/interfaces/errand';
 import { ErrandPhase, UiPhase } from '@casedata/interfaces/errand-phase';
-import { Role } from '@casedata/interfaces/role';
 import { getAssets } from '@casedata/services/asset-service';
+
+import { getConversationMessages, getConversations } from '@casedata/services/casedata-conversation-service';
 import {
   getErrand,
   isErrandLocked,
@@ -15,6 +16,7 @@ import {
   fetchMessagesTree,
   groupByConversationIdSortedTree,
 } from '@casedata/services/casedata-message-service';
+import { getOwnerStakeholder } from '@casedata/services/casedata-stakeholder-service';
 import { useAppContext } from '@common/contexts/app.context';
 import { getApplicationEnvironment, isPT } from '@common/services/application-service';
 import WarnIfUnsavedChanges from '@common/utils/warnIfUnsavedChanges';
@@ -26,11 +28,9 @@ import { CasedataContractTab } from './tabs/contract/casedata-contract-tab';
 import { CasedataDecisionTab } from './tabs/decision/casedata-decision-tab';
 import { CasedataDetailsTab } from './tabs/details/casedata-details-tab';
 import { CasedataInvestigationTab } from './tabs/investigation/casedata-investigation-tab';
+import CasedataForm from './tabs/overview/casedata-form.component';
 import { CasedataPermitServicesTab } from './tabs/permits-services/casedata-permits-services-tab';
 import { CasedataServicesTab } from './tabs/services/casedata-service-tab';
-import { getConversationMessages, getConversations } from '@casedata/services/casedata-conversation-service';
-import CasedataForm from './tabs/overview/casedata-form.component';
-import { getOwnerStakeholder } from '@casedata/services/casedata-stakeholder-service';
 
 export const CasedataTabsWrapper: React.FC = () => {
   const {
@@ -107,9 +107,12 @@ export const CasedataTabsWrapper: React.FC = () => {
       handleConversation(municipalityId, errand.id);
       isPT() &&
         owner?.personId &&
-        getAssets(owner.personId, 'PARKINGPERMIT')
+        getAssets({
+          partyId: owner.personId,
+          type: 'PARKINGPERMIT',
+        })
           .then((res) => setAssets(res.data))
-          .catch((e) => {
+          .catch(() => {
             toastMessage({
               position: 'bottom',
               closeable: false,
@@ -352,10 +355,13 @@ export const CasedataTabsWrapper: React.FC = () => {
       disabled: !errand?.id,
       visibleFor: errand?.id
         ? [
+            ErrandPhase.aktualisering,
+            ErrandPhase.utredning,
             ErrandPhase.beslut,
             ErrandPhase.hantera,
             ErrandPhase.verkstalla,
             ErrandPhase.uppfoljning,
+            ErrandPhase.canceled,
             ErrandPhase.overklagad,
           ]
         : [],

--- a/frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx
@@ -62,6 +62,7 @@ import {
 } from '@sk-web-gui/react';
 import dynamic from 'next/dynamic';
 import { CasedataMessageTabFormModel } from '../messages/message-composer.component';
+import { ServiceListComponent } from '../services/casedata-service-list.component';
 import { SendDecisionDialogComponent } from './send-decision-dialog.component';
 const TextEditor = dynamic(() => import('@sk-web-gui/text-editor'), { ssr: false });
 
@@ -660,7 +661,10 @@ export const CasedataDecisionTab: React.FC<{
             <FormErrorMessage>{errors.description?.message}</FormErrorMessage>
           )}
         </div>
-
+        <div className="pb-20">
+          <h4 className="text-h6 mb-sm border-b">Här listas de insatser som bifalls</h4>
+          <ServiceListComponent errand={errand} readOnly />
+        </div>
         <div className="flex justify-start gap-md">
           <Button
             data-cy="save-decision-button"
@@ -723,6 +727,7 @@ export const CasedataDecisionTab: React.FC<{
             Skicka beslut
           </Button>
         </div>
+
         {!validateOwnerForSendingDecision(errand) ? (
           <FormErrorMessage data-cy="attachment-error-message" className="mt-md text-error">
             För att skicka beslut måste ärendeägaren ha en giltig e-postadress eller ha registrerats med sitt

--- a/frontend/src/casedata/components/errand/tabs/overview/casedata-contacts.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/overview/casedata-contacts.component.tsx
@@ -10,7 +10,7 @@ import { getStakeholderRelation } from '@casedata/services/casedata-stakeholder-
 import { useAppContext } from '@common/contexts/app.context';
 import { appConfig } from '@config/appconfig';
 import LucideIcon from '@sk-web-gui/lucide-icon';
-import { Avatar, Button, Disclosure, Divider, FormControl, FormLabel, useConfirm } from '@sk-web-gui/react';
+import { Avatar, Button, Disclosure, FormControl, FormLabel, useConfirm } from '@sk-web-gui/react';
 import { useEffect, useState } from 'react';
 import { useFieldArray, useFormContext, UseFormReturn } from 'react-hook-form';
 import { v4 as uuidv4 } from 'uuid';

--- a/frontend/src/casedata/components/errand/tabs/services/casedata-service-domain.ts
+++ b/frontend/src/casedata/components/errand/tabs/services/casedata-service-domain.ts
@@ -1,0 +1,202 @@
+import { Asset } from '@casedata/interfaces/asset';
+import { IErrand } from '@casedata/interfaces/errand';
+import { Role } from '@casedata/interfaces/role';
+import { createAsset, getAssets, updateAsset } from '@casedata/services/asset-service';
+import { Service } from './casedata-service-item.component';
+import { mapServiceToJsonParameter, SCHEMA_KEY, toDateOnly } from './casedata-service-mapper';
+import { transportValueMap, travelTypeValueMap } from './service';
+
+const findExistingAsset = async (errand: IErrand): Promise<Asset | undefined> => {
+  const partyId = errand.stakeholders?.find((s) => s.roles.includes(Role.APPLICANT))?.personId;
+  if (!partyId) return undefined;
+
+  const res = await getAssets({
+    partyId,
+    type: 'PERMIT',
+  });
+  const assets = res?.data ?? [];
+
+  const byAssetId = assets.find((a) => a.assetId === errand.errandNumber);
+  if (byAssetId) return byAssetId;
+
+  const byCaseRef = assets.find(
+    (a) => Array.isArray(a.caseReferenceIds) && a.caseReferenceIds.includes(String(errand.id))
+  );
+  return byCaseRef;
+};
+
+const touchParamTimestamps = (jp: any, prev?: any) => {
+  const now = new Date().toISOString();
+  return { ...jp, created: prev?.created ?? now, modified: now };
+};
+
+function getIdxFromCompositeId(serviceId: string, assetUuid: string): number | null {
+  const prefix = `${assetUuid}:`;
+  if (!serviceId?.startsWith(prefix)) return null;
+  const num = Number(serviceId.slice(prefix.length));
+  return Number.isInteger(num) ? num : null;
+}
+
+function normalizeForCompare(v: any) {
+  const { created, modified, ...rest } = v ?? {};
+  if (rest.notes == null) rest.notes = [];
+  if (rest.validTo === undefined) rest.validTo = null;
+  return rest;
+}
+
+const isSameSchemaValue = (nextValObj: any, prevValObj: any) =>
+  JSON.stringify(normalizeForCompare(nextValObj)) === JSON.stringify(normalizeForCompare(prevValObj));
+
+const buildCreatePayload = (errand: IErrand, services: Service[]) => {
+  const partyId = errand.stakeholders?.find((s) => s.roles.includes(Role.APPLICANT))?.personId!;
+  const baseJsonParameters = services.map((s) => mapServiceToJsonParameter(s)); // mappern stämplar root.created/modified
+
+  const starts = services.map((s) => toDateOnly(s.startDate)).filter(Boolean) as string[];
+  const ends = services
+    .map((s) => (s.validityType === 'tidsbegransad' ? toDateOnly(s.endDate) : undefined))
+    .filter(Boolean) as string[];
+
+  const issued = starts.length ? starts.sort()[0] : toDateOnly(new Date().toISOString());
+  const validTo = ends.length ? ends.sort()[ends.length - 1] : undefined;
+
+  const now = new Date().toISOString();
+
+  return {
+    assetId: errand.errandNumber,
+    partyId,
+    origin: 'CASEDATA',
+    type: 'PERMIT',
+    status: 'ACTIVE',
+    issued,
+    validTo,
+    description: '',
+    caseReferenceIds: errand?.id ? [String(errand.id)] : undefined,
+    jsonParameters: baseJsonParameters.map((jp) => touchParamTimestamps(jp)),
+    created: now,
+    modified: now,
+  };
+};
+
+const buildPatchPayload = (existing: Asset, errand: IErrand, services: Service[]) => {
+  const prevParams = existing.jsonParameters ?? [];
+  const nextParams = [...prevParams];
+
+  for (const s of services) {
+    let prevParam: any | undefined;
+    let prevValueObj: any | undefined;
+    let targetIndex: number | null = null;
+
+    const idx = getIdxFromCompositeId(s.id, existing.id);
+    if (idx !== null && prevParams[idx]?.key === SCHEMA_KEY && typeof prevParams[idx].value === 'string') {
+      prevParam = prevParams[idx];
+      targetIndex = idx;
+      try {
+        prevValueObj = JSON.parse(prevParam.value);
+      } catch {
+        prevValueObj = undefined;
+      }
+    }
+
+    const candidateParam = mapServiceToJsonParameter(s, { prevValue: prevParam?.value });
+
+    let hasChanged = true;
+    if (prevValueObj) {
+      try {
+        const nextValueObj = JSON.parse(candidateParam.value);
+        hasChanged = !isSameSchemaValue(nextValueObj, prevValueObj);
+      } catch {
+        hasChanged = true;
+      }
+    }
+
+    if (targetIndex !== null && prevParam && !hasChanged) {
+      nextParams[targetIndex] = prevParam;
+    } else if (targetIndex !== null && prevParam && hasChanged) {
+      nextParams[targetIndex] = touchParamTimestamps(candidateParam, prevParam);
+    } else {
+      nextParams.push(touchParamTimestamps(candidateParam));
+    }
+  }
+
+  const ends = services
+    .map((s) => (s.validityType === 'tidsbegransad' ? toDateOnly(s.endDate) : undefined))
+    .filter(Boolean) as string[];
+  const validTo = ends.length ? ends.sort()[ends.length - 1] : null;
+
+  return {
+    caseReferenceIds: Array.from(
+      new Set([...(existing.caseReferenceIds ?? []), ...(errand?.id ? [String(errand.id)] : [])])
+    ),
+    validTo,
+    status: existing.status ?? 'ACTIVE',
+    statusReason: existing.statusReason ?? undefined,
+    additionalParameters: existing.additionalParameters ?? undefined,
+    jsonParameters: nextParams,
+  };
+};
+
+export const saveOrUpdateServicesToBackend = async (errand: IErrand): Promise<Asset | undefined> => {
+  const services: Service[] = errand.services ?? [];
+  if (services.length === 0) return;
+
+  const municipalityId = String(errand.municipalityId ?? 2281);
+  const existing = await findExistingAsset(errand);
+
+  if (!existing) {
+    const payload = buildCreatePayload(errand, services);
+    const createdResp = await createAsset(municipalityId, payload as any);
+    return createdResp?.data;
+  }
+
+  const patchPayload = buildPatchPayload(existing, errand, services);
+  const updatedResp = await updateAsset(municipalityId, existing.id, patchPayload);
+  return updatedResp?.data;
+};
+
+export const getServicesFromBackend = async (errand: IErrand): Promise<Service[]> => {
+  const partyId = errand.stakeholders?.find((s) => s.roles.includes(Role.APPLICANT))?.personId;
+  if (!partyId) return [];
+
+  const res = await getAssets({
+    partyId,
+    type: 'PERMIT',
+    assetId: errand.errandNumber,
+  });
+  const assets = (res?.data ?? []) as any[];
+  const out: Service[] = [];
+
+  for (const asset of assets) {
+    if (asset.origin !== 'CASEDATA') continue;
+
+    if (Array.isArray(asset.jsonParameters)) {
+      for (let idx = 0; idx < asset.jsonParameters.length; idx++) {
+        const jp = asset.jsonParameters[idx];
+        if (jp?.key !== SCHEMA_KEY || typeof jp?.value !== 'string') continue;
+
+        try {
+          const parsed = JSON.parse(jp.value);
+          const typeLabel = travelTypeValueMap[parsed.type] ?? parsed.type ?? asset.type ?? '';
+          const rawTransport = parsed.carTypes?.[0]?.value;
+          const transportLabel = transportValueMap[rawTransport] ?? rawTransport ?? '';
+
+          out.push({
+            id: `${asset.id}:${idx}`,
+            restyp: typeLabel,
+            transport: transportLabel,
+            aids: Array.isArray(parsed.mobilityAids) ? parsed.mobilityAids : [],
+            addon: Array.isArray(parsed.additionalAids) ? parsed.additionalAids : [],
+            winter: parsed.winter ?? false,
+            comment: parsed.notes?.[0]?.value ?? '',
+            startDate: parsed.validFrom ?? '',
+            endDate: parsed.validTo ?? '',
+            validityType: parsed.period === 'Tillsvidare' ? 'tillsvidare' : 'tidsbegransad',
+          });
+        } catch (e) {
+          console.warn('Kunde inte parsa jsonParameters-post:', jp, e);
+        }
+      }
+    }
+  }
+
+  return out;
+};

--- a/frontend/src/casedata/components/errand/tabs/services/casedata-service-item.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/services/casedata-service-item.component.tsx
@@ -3,12 +3,20 @@ import LucideIcon from '@sk-web-gui/lucide-icon';
 import { Button } from '@sk-web-gui/react';
 import React from 'react';
 
+export interface AidOrAddon {
+  key: string;
+  value: string;
+  approved?: boolean;
+  standard?: boolean;
+}
+
 export interface Service {
   id: string;
   restyp: string;
   transport: string;
-  aids: string[];
-  addon: string[];
+  aids: AidOrAddon[];
+  addon: AidOrAddon[];
+  winter: boolean;
   comment: string;
   startDate: string;
   endDate: string;
@@ -17,12 +25,12 @@ export interface Service {
 
 interface Props {
   service: Service;
-  onRemove: (id: string) => void;
-  onOrder: (id: string) => void;
-  onEdit: (service: Service) => void;
+  onRemove?: (id: string) => void;
+  onEdit?: (service: Service) => void;
+  readOnly?: boolean;
 }
 
-export const ServiceListItem: React.FC<Props> = ({ service: service, onRemove, onOrder, onEdit }) => {
+export const ServiceListItem: React.FC<Props> = ({ service, onRemove, onEdit, readOnly }) => {
   return (
     <div className="w-full py-24 border-b border-gray-200">
       <div className="flex items-start gap-18">
@@ -32,8 +40,8 @@ export const ServiceListItem: React.FC<Props> = ({ service: service, onRemove, o
 
         <div className="flex flex-col gap-4 flex-1">
           <div className="flex justify-between items-center">
-            <div className="text-base font-bold text-primary-900">{service.restyp}</div>
-            <div className="text-md font-normal text-primary-700 whitespace-nowrap">
+            <div className="text-base font-bold text-primary-900 dark:text-white">{service.restyp}</div>
+            <div className="text-md font-normal text-primary-700 dark:text-white whitespace-nowrap">
               {service.validityType === 'tillsvidare'
                 ? `Insatsen gäller från och med ${service.startDate}`
                 : `Insatsen gäller ${service.startDate} - ${service.endDate}`}
@@ -41,33 +49,34 @@ export const ServiceListItem: React.FC<Props> = ({ service: service, onRemove, o
           </div>
 
           <div className="flex gap-16 items-center text-md">
-            <div className="flex items-center gap-4 text-primary-900">
+            <div className="flex items-center gap-4 text-primary-900 dark:text-white">
               <LucideIcon name="car" size={16} />
               <span>{service.transport}</span>
             </div>
-            <div className="flex items-center gap-4 text-primary-700">
+            <div className="flex items-center gap-4 text-primary-700 dark:text-white">
               <LucideIcon name="cog" size={16} />
-              <span>{service.aids.length > 0 ? service.aids.join(', ') : 'Inga valda hjälpmedel'}</span>
+              <span>
+                {service.aids.length > 0 ? service.aids.map((a) => a.value).join(', ') : 'Inga valda hjälpmedel'}
+              </span>
             </div>
           </div>
 
           <div
-            className="text-primary-900 text-base break-words whitespace-pre-wrap leading-relaxed overflow-hidden"
+            className="text-primary-900 dark:text-white text-base break-words whitespace-pre-wrap leading-relaxed overflow-hidden"
             style={{ wordBreak: 'break-word' }}
             dangerouslySetInnerHTML={{ __html: sanitized(service.comment) }}
           />
 
-          <div className="pt-16 flex gap-16">
-            <Button size="sm" onClick={() => onOrder(service.id)}>
-              Beställ insats
-            </Button>
-            <Button size="sm" variant="secondary" onClick={() => onEdit(service)}>
-              Redigera
-            </Button>
-            <Button size="sm" variant="secondary" onClick={() => onRemove(service.id)}>
-              Ta bort
-            </Button>
-          </div>
+          {!readOnly && (
+            <div className="pt-16 flex gap-16">
+              <Button size="sm" variant="secondary" onClick={() => onEdit?.(service)}>
+                Redigera
+              </Button>
+              <Button size="sm" variant="secondary" onClick={() => onRemove?.(service.id)}>
+                Ta bort
+              </Button>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/casedata/components/errand/tabs/services/casedata-service-list.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/services/casedata-service-list.component.tsx
@@ -1,20 +1,91 @@
+'use client';
+
+import { IErrand } from '@casedata/interfaces/errand';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { getServicesFromBackend } from './casedata-service-domain';
 import { Service, ServiceListItem } from './casedata-service-item.component';
 
-export const ServiceListComponent = ({
-  services,
-  onRemove,
-  onOrder,
-  onEdit,
-}: {
-  services: Service[];
-  onRemove: (id: string) => void;
-  onOrder: (id: string) => void;
-  onEdit: (service: Service) => void;
-}) => {
+type ServiceWithKey = Service & { fieldId: string };
+type Props = {
+  errand: IErrand;
+  append?: (value: Service | Service[]) => void;
+  services?: ServiceWithKey[];
+  onEdit?: (service: Service) => void;
+  onRemove?: (id: string) => void;
+  readOnly?: boolean;
+};
+
+const EMPTY: ServiceWithKey[] = [];
+
+export const ServiceListComponent: React.FC<Props> = ({ errand, append, services, onEdit, onRemove, readOnly }) => {
+  const isReadOnly = readOnly === true || !append;
+
+  const editableServices = useMemo(() => services ?? EMPTY, [services]);
+
+  const servicesRef = useRef<ServiceWithKey[]>(editableServices);
+  useEffect(() => {
+    servicesRef.current = editableServices;
+  }, [editableServices]);
+
+  const appendRef = useRef<typeof append>(append);
+  useEffect(() => {
+    appendRef.current = append;
+  }, [append]);
+
+  const removedIdsRef = useRef<Set<string>>(new Set());
+  const handleRemove = (id: string) => {
+    removedIdsRef.current.add(id);
+    onRemove?.(id);
+  };
+
+  const [items, setItems] = useState<ServiceWithKey[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      const fromBackend = await getServicesFromBackend(errand);
+      if (cancelled) return;
+
+      if (isReadOnly) {
+        const mapped: ServiceWithKey[] = fromBackend.map((s) => ({
+          ...s,
+          fieldId: s.id ?? `${s.restyp}-${s.startDate}-${s.endDate}`,
+        }));
+        setItems(mapped);
+        return;
+      }
+
+      const existingIds = new Set(servicesRef.current.map((s) => s.id));
+      const toAdd: Service[] = [];
+      for (const svc of fromBackend) {
+        if (!existingIds.has(svc.id) && !removedIdsRef.current.has(svc.id)) {
+          toAdd.push(svc);
+        }
+      }
+      if (toAdd.length > 0) {
+        appendRef.current?.(toAdd);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isReadOnly, errand?.id, errand?.errandNumber]);
+
+  const list = isReadOnly ? items : editableServices;
+
   return (
     <div className="mt-32">
-      {services.map((service) => (
-        <ServiceListItem key={service.id} service={service} onRemove={onRemove} onOrder={onOrder} onEdit={onEdit} />
+      {list.map((service) => (
+        <ServiceListItem
+          key={service.fieldId}
+          service={service}
+          readOnly={isReadOnly}
+          onEdit={isReadOnly ? undefined : onEdit}
+          onRemove={isReadOnly ? undefined : handleRemove}
+        />
       ))}
     </div>
   );

--- a/frontend/src/casedata/components/errand/tabs/services/casedata-service-mapper.ts
+++ b/frontend/src/casedata/components/errand/tabs/services/casedata-service-mapper.ts
@@ -1,0 +1,62 @@
+import { Service } from './casedata-service-item.component';
+import { serviceModeOfTransportation, travelTypeKeyMap } from './service';
+
+export const SCHEMA_KEY = 'FTErrandAssets';
+export const SCHEMA_ID = '2281_fterrandassets_1.0';
+
+const transportKeyMap = Object.fromEntries(serviceModeOfTransportation.map((t) => [t.value, t.key]));
+export const toDateOnly = (d?: string) => (!d ? undefined : d.slice(0, 10));
+
+function stampRoot<T extends { created?: string; modified?: string }>(
+  next: Omit<T, 'created' | 'modified'>,
+  prevJson?: string
+): T {
+  const now = new Date().toISOString();
+  let prev: Partial<T> | undefined;
+  if (prevJson) {
+    try {
+      prev = JSON.parse(prevJson) as Partial<T>;
+    } catch {}
+  }
+  return { ...(next as any), created: prev?.created ?? now, modified: now } as T;
+}
+
+function buildSchemaValue(service: Service) {
+  return {
+    period: service.validityType === 'tillsvidare' ? 'Tillsvidare' : 'Tidsbegränsad',
+    type: travelTypeKeyMap[service.restyp] ?? service.restyp ?? '',
+    validFrom: toDateOnly(service.startDate),
+    validTo: service.validityType === 'tidsbegransad' ? toDateOnly(service.endDate) : null,
+    winter: service.winter ?? false,
+    carTypes: [
+      {
+        key: transportKeyMap[service.transport] ?? 'USER_SELECTED',
+        value: service.transport ?? '',
+        approved: null,
+      },
+    ],
+    mobilityAids: (service.aids ?? []).map((aid) => ({
+      key: aid.key,
+      value: aid.value,
+      approved: aid.approved ?? null,
+      standard: aid.standard ?? false,
+    })),
+    additionalAids: (service.addon ?? []).map((addon) => ({
+      key: addon.key,
+      value: addon.value,
+      approved: addon.approved ?? null,
+      standard: addon.standard ?? false,
+    })),
+    notes: service.comment ? [{ key: 'driverInstructions', value: service.comment }] : null,
+  };
+}
+
+export const mapServiceToJsonParameter = (service: Service, opts?: { prevValue?: string }) => {
+  const base = buildSchemaValue(service);
+  const stamped = stampRoot(base, opts?.prevValue);
+  return {
+    key: SCHEMA_KEY,
+    schemaId: SCHEMA_ID,
+    value: JSON.stringify(stamped),
+  };
+};

--- a/frontend/src/casedata/components/errand/tabs/services/service.ts
+++ b/frontend/src/casedata/components/errand/tabs/services/service.ts
@@ -1,40 +1,53 @@
 export const serviceTravelTypes = [
-  { value: 'privatresor', label: 'Privatresor' },
-  { value: 'arbetsresor', label: 'Arbets-/utbildningsresor' },
-  { value: 'gymnasieresor', label: 'Gymnasieresor' },
+  { key: 'PR', value: 'Privatresor' },
+  { key: 'AR', value: 'Arbets-/utbildningsresor' },
+  { key: 'GY', value: 'Gymnasieresor' },
 ];
 
 export const serviceModeOfTransportation = [
-  { value: 'taxibil', label: 'Taxibil' },
-  { value: 'stor_taxibil', label: 'Stor taxibil' },
-  { value: 'litet_multifordon', label: 'Litet multifordon' },
-  { value: 'stort_multifordon', label: 'Stort multifordon' },
+  { key: 'LTAXI', value: 'Taxibil' },
+  { key: 'STAXI', value: 'Stor taxibil' },
+  { key: 'LMULTI', value: 'Litet multifordon' },
+  { key: 'SMULTI', value: 'Stort multifordon' },
 ];
 
 export const serviceAids = [
-  { value: 'rollator', label: 'Rollator' },
-  { value: 'manuell_rullstol', label: 'Manuell rullstol (hopfällbar)' },
-  { value: 'hd_stol', label: 'HD-stol' },
-  { value: 'elrullstol', label: 'Elrullstol' },
-  { value: 'elmoped', label: 'Elmoped/elscooter' },
-  { value: 'kryckor', label: 'Kryckor/käpp' },
-  { value: 'stavar', label: 'Stavar' },
-  { value: 'vagn', label: 'Vagn' },
-  { value: 'syrgas', label: 'Syrgas' },
-  { value: 'balteskudde', label: 'Bälteskudde' },
-  { value: 'ledarhund', label: 'Ledarhund' },
+  { key: 'O', value: 'Rollator' },
+  { key: 'U', value: 'Manuell rullstol (hopfällbar)' },
+  { key: 'ER', value: 'Elrullstol' },
+  { key: 'REM', value: 'Elmoped/elscooter' },
+  { key: 'KR', value: 'Kryckor/käpp' },
+  { key: 'ST', value: 'Stavar' },
+  { key: 'V', value: 'Vagn' },
+  { key: 'O2', value: 'Syrgas' },
+  { key: 'BBS', value: 'Bälteskudde' },
+  { key: 'LH', value: 'Ledarhund' },
 ];
 
 export const serviceAddons = [
-  { value: 'ledsagare', label: 'Ledsagare' },
-  { value: 'hamta_lamnas', label: 'Hämta/lämnas i bostaden av chauffören' },
-  { value: 'framsate', label: 'Framsätesplacering' },
-  { value: 'baksate', label: 'Baksätesplacering (H/V/Båda)' },
-  { value: 'hela_baksatet', label: 'Tillgång till hela baksätet' },
-  { value: 'begransad_samakning', label: 'Begränsad samåkning' },
-  { value: 'ensamakning', label: 'Ensamåkning' },
-  { value: 'omvagsbegransning', label: 'Begränsning i omväg' },
-  { value: 'egna_barn', label: 'Medföljande egna barn' },
-  { value: 'barhjalp', label: 'Bärhjälp' },
-  { value: 'litet_djur', label: 'Litet djur' },
+  { key: 'LS', value: 'Ledsagare' },
+  { key: 'HLB', value: 'Hämta/lämnas i bostaden av chauffören' },
+  { key: 'F', value: 'Framsätesplacering' },
+  { key: 'BH', value: 'Baksätesplacering (Höger)' },
+  { key: 'BV', value: 'Baksätesplacering (Vänster)' },
+  { key: 'BS', value: 'Tillgång till hela baksätet' },
+  { key: 'SAMG', value: 'Begränsad samåkning' },
+  { key: 'E', value: 'Ensamåkning' },
+  { key: 'MO', value: 'Begränsning i omväg' },
+  { key: 'MB', value: 'Medföljande egna barn' },
+  { key: 'H', value: 'Bärhjälp' },
+  { key: 'D', value: 'Litet djur' },
 ];
+
+export const travelTypeMap = Object.fromEntries(serviceTravelTypes.map((t) => [t.value, t.key]));
+export const transportMap = Object.fromEntries(serviceModeOfTransportation.map((t) => [t.value, t.key]));
+export const aidMap = Object.fromEntries(serviceAids.map((a) => [a.value, a.key]));
+export const addonMap = Object.fromEntries(serviceAddons.map((a) => [a.value, a.key]));
+
+export const aidValueToKeyMap = Object.fromEntries(serviceAids.map((a) => [a.value, a.key]));
+export const addonValueToKeyMap = Object.fromEntries(serviceAddons.map((a) => [a.value, a.key]));
+export const transportKeyMap = Object.fromEntries(serviceModeOfTransportation.map((t) => [t.value, t.key]));
+export const travelTypeKeyMap = Object.fromEntries(serviceTravelTypes.map((t) => [t.value, t.key]));
+
+export const travelTypeValueMap = Object.fromEntries(serviceTravelTypes.map((t) => [t.key, t.value]));
+export const transportValueMap = Object.fromEntries(serviceModeOfTransportation.map((t) => [t.key, t.value]));

--- a/frontend/src/casedata/hooks/useSaveCasedataErrand.ts
+++ b/frontend/src/casedata/hooks/useSaveCasedataErrand.ts
@@ -1,6 +1,8 @@
 import { baseDetails } from '@casedata/components/errand/extraparameter-templates/base-template';
+import { saveOrUpdateServicesToBackend } from '@casedata/components/errand/tabs/services/casedata-service-domain';
 import { IErrand } from '@casedata/interfaces/errand';
 import { ErrandStatus } from '@casedata/interfaces/errand-status';
+import { Role } from '@casedata/interfaces/role';
 import { getErrand, saveErrand, updateErrandStatus } from '@casedata/services/casedata-errand-service';
 import {
   EXTRAPARAMETER_SEPARATOR,
@@ -150,6 +152,26 @@ export function useSaveCasedataErrand(registeringNewErrand: boolean = false) {
         await removeStakeholder(municipalityId, res.errandId.toString(), removed.id);
       }
       const saved2 = await getErrand(municipalityId, res.errandId.toString());
+
+      if (data.services && data.services.length > 0) {
+        const partyId = data.stakeholders?.find((s) => s.roles.includes(Role.APPLICANT))?.personId;
+        if (partyId) {
+          try {
+            await saveOrUpdateServicesToBackend(data);
+          } catch (e) {
+            console.error('Kunde inte spara insatser:', e);
+            toastMessage({
+              position: 'bottom',
+              closeable: false,
+              message: 'Insatser kunde inte sparas',
+              status: 'error',
+            });
+          }
+        } else {
+          console.warn('Ingen partyId för insatser');
+        }
+      }
+
       setErrand(saved2.errand);
 
       if (registeringNewErrand) {

--- a/frontend/src/casedata/interfaces/asset.ts
+++ b/frontend/src/casedata/interfaces/asset.ts
@@ -8,6 +8,13 @@ export enum assetStatusLabels {
 export enum assetTypeLabels {
   PARKINGPERMIT = 'P-tillstånd',
 }
+
+export interface JsonParameter {
+  key: string;
+  value: string;
+  schemaId: string;
+}
+
 export interface Asset {
   id: string;
   assetId: string;
@@ -21,6 +28,7 @@ export interface Asset {
   statusReason: string;
   description: string;
   additionalParameters: { [key: string]: string };
+  jsonParameters: JsonParameter[];
 }
 
 export interface UpdateAsset {

--- a/frontend/src/casedata/interfaces/errand.ts
+++ b/frontend/src/casedata/interfaces/errand.ts
@@ -1,14 +1,15 @@
+import { Service } from '@casedata/components/errand/tabs/services/casedata-service-item.component';
 import { Channels } from '@casedata/interfaces/channels';
 import { Decision } from '@casedata/interfaces/decision';
 import { ErrandPhase } from '@casedata/interfaces/errand-phase';
 import { All, Priority } from '@casedata/interfaces/priority';
+import { ExtraParameter, Notification } from '@common/data-contracts/case-data/data-contracts';
 import { FacilityDTO } from '@common/interfaces/facilities';
 import { Data } from '@common/services/api-service';
 import { Attachment } from './attachment';
 import { ApiErrandStatus } from './errand-status';
 import { ErrandNote } from './errandNote';
 import { CasedataOwnerOrContact, CreateStakeholderDto, Stakeholder } from './stakeholder';
-import { ExtraParameter, Notification } from '@common/data-contracts/case-data/data-contracts';
 
 export interface ApiErrand {
   id: number;
@@ -106,6 +107,7 @@ export interface IErrand {
   notifications?: Notification[];
   relatesTo?: RelatedErrand[];
   publicNote?: string;
+  services?: Service[];
 }
 
 export interface ErrandsData extends Data {

--- a/frontend/src/casedata/services/asset-service.ts
+++ b/frontend/src/casedata/services/asset-service.ts
@@ -1,16 +1,87 @@
 import { Asset } from '@casedata/interfaces/asset';
 import { ApiResponse, apiService } from '@common/services/api-service';
 
-export const getAssets: (partyId: string, type: string) => Promise<ApiResponse<Asset[]>> = (partyId, type) => {
-  if (!partyId) {
-    console.error('No note id found, cannot fetch. Returning.');
+export type GetAssetsParams = {
+  municipalityId?: string;
+  partyId?: string;
+  type?: string;
+  status?: string;
+  origin?: string;
+  assetId?: string;
+  issued?: string;
+  validTo?: string;
+};
+
+const buildQuery = (p: GetAssetsParams) => {
+  const params = new URLSearchParams();
+  (Object.entries(p) as [keyof GetAssetsParams, any][]).forEach(([k, v]) => {
+    if (v !== undefined && v !== null && v !== '') params.set(String(k), String(v));
+  });
+  const qs = params.toString();
+  return qs ? `?${qs}` : '';
+};
+
+export async function getAssets(params: GetAssetsParams): Promise<ApiResponse<Asset[]>> {
+  const url = `assets${buildQuery(params)}`;
+  try {
+    const res = await apiService.get<ApiResponse<Asset[]>>(url);
+    return res.data;
+  } catch (e) {
+    console.error('Something went wrong when fetching assets:', params, e);
+    throw e;
   }
-  const url = `assets?partyId=${partyId}&type=${type}`;
+}
+
+export function getAssetsForErrand(errandNumber: string, opts?: Omit<GetAssetsParams, 'assetId'>) {
+  if (!errandNumber) throw new Error('Missing errandNumber');
+  return getAssets({ assetId: errandNumber, ...opts });
+}
+
+export const getMetadataSchema: (municipalityId?: string, schemaId?: string) => Promise<ApiResponse<any>> = (
+  municipalityId = '2281',
+  schemaId = '2281_fterrandassets_1.0'
+) => {
+  const url = `${municipalityId}/metadata/jsonschemas/${schemaId}`;
   return apiService
-    .get<ApiResponse<Asset[]>>(url)
+    .get<ApiResponse<any>>(url)
     .then((res) => res.data)
     .catch((e) => {
-      console.error('Something went wrong when fetching asset: ', partyId);
+      console.error('Something went wrong when fetching metadata schema for id: ', schemaId);
+      throw e;
+    });
+};
+
+export const createAsset = (
+  municipalityId: string,
+  payload: Partial<Asset> & Record<string, any>
+): Promise<ApiResponse<Asset>> => {
+  if (!municipalityId) {
+    console.error('No municipalityId provided, cannot create asset.');
+  }
+  const url = `assets?municipalityId=${municipalityId}`;
+  return apiService
+    .post<ApiResponse<Asset>, typeof payload>(url, payload)
+    .then((res) => res.data)
+    .catch((e) => {
+      console.error('Something went wrong when creating asset:', e);
+      throw e;
+    });
+};
+
+export const updateAsset = (
+  municipalityId: string,
+  id: string,
+  payload: Partial<Asset> & Record<string, any>
+): Promise<ApiResponse<Asset>> => {
+  if (!municipalityId || !id) {
+    console.error('Missing municipalityId or asset id, cannot update asset.');
+  }
+  const url = `assets/${encodeURIComponent(id)}?municipalityId=${municipalityId}`;
+  return apiService
+    .patch<ApiResponse<Asset>, typeof payload>(url, payload)
+    .then((res) => res.data)
+    .catch((e) => {
+      console.error(`Something went wrong when updating asset ${id}:`, e);
       throw e;
     });
 };


### PR DESCRIPTION
- Services are now supported and will be saved with json format.
- Json content will be validated with json validation schema on backend. (This schema can be updated but then the code needs update).
- Added services will be listed as readonly in decision tab. Todo: Add support to export services to decision templates for paratransit errands.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).

Jira: https://jira.sundsvall.se/browse/DRAKEN-1582
