### PR TITLE
[2/5] feat: add Zustand stores and migrate AppContext consumers

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,9 +73,9 @@
     "@sk-web-gui/core": "4.3.3",
     "@sk-web-gui/react": "3.0.9",
     "@sk-web-gui/text-editor": "2.0.2",
-    "lucide-react": "0.575.0",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/forms": "^0.5.10",
+    "@tanstack/react-query": "^5.91.2",
     "ajv": "^8.17.1",
     "ajv-errors": "^3.0.0",
     "axios": "^1.11.0",
@@ -85,9 +85,9 @@
     "escape-string-regexp": "^5.0.0",
     "i18next": "^24.2.3",
     "i18next-resources-to-backend": "^1.2.1",
+    "lucide-react": "0.575.0",
     "next": "16.1.6",
     "next-i18n-router": "^5.5.6",
-    "next-i18next": "^15.4.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-hook-form": "^7.71.2",
@@ -98,7 +98,8 @@
     "sharp": "^0.34.3",
     "underscore.string": "^3.3.6",
     "uuid": "^9.0.0",
-    "yup": "1.7.0"
+    "yup": "1.7.0",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@cypress/code-coverage": "^4.0.1",

--- a/frontend/src/casedata/components/casedata-filtering/casedata-filtering.component.tsx
+++ b/frontend/src/casedata/components/casedata-filtering/casedata-filtering.component.tsx
@@ -40,7 +40,7 @@ import {
   CasedataFilterStatus,
 } from './components/casedata-filter-status.component';
 import { CasedataFilterTags } from './components/casedata-filter-tags.component';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore } from '@stores/index';
 import { appConfig } from '@config/appconfig';
 import {
   CasedataStakeholderType,
@@ -79,7 +79,7 @@ const CaseDataFiltering: React.FC<{
   numberOfFilters: number;
 }> = ({ numberOfFilters, ownerFilterHandler = () => false, ownerFilter, administrators = [] }) => {
   const [show, setShow] = useState<boolean>(true);
-  const { selectedErrandStatuses } = useAppContext();
+  const selectedErrandStatuses = useCasedataStore((s) => s.selectedErrandStatuses);
 
   return (
     <>

--- a/frontend/src/casedata/components/casedata-filtering/components/casedata-filter-sidebarstatus-selector.component.tsx
+++ b/frontend/src/casedata/components/casedata-filtering/components/casedata-filter-sidebarstatus-selector.component.tsx
@@ -8,7 +8,7 @@ import {
   suspendedStatuses,
 } from '@casedata/services/casedata-errand-service';
 import { SidebarButton } from '@common/interfaces/sidebar-button';
-import { AppContextInterface, useAppContext } from '@contexts/app.context';
+import { useCasedataStore } from '@stores/index';
 import { Badge, Button, Spinner } from '@sk-web-gui/react';
 import store from '@supportmanagement/services/storage-service';
 import { useMemo } from 'react';
@@ -19,16 +19,14 @@ export const CasedataFilterSidebarStatusSelector: React.FC<{
   setShowContractTable: (show: boolean) => void;
   iconButton: boolean;
 }> = ({ showContractTable, setShowContractTable, iconButton }) => {
-  const {
-    setSelectedErrandStatuses,
-    selectedErrandStatuses,
-    setSidebarLabel,
-    newErrands,
-    ongoingErrands,
-    assignedErrands,
-    suspendedErrands,
-    closedErrands,
-  }: AppContextInterface = useAppContext();
+  const setSelectedErrandStatuses = useCasedataStore((s) => s.setSelectedErrandStatuses);
+  const selectedErrandStatuses = useCasedataStore((s) => s.selectedErrandStatuses);
+  const setSidebarLabel = useCasedataStore((s) => s.setSidebarLabel);
+  const newErrands = useCasedataStore((s) => s.newErrands);
+  const ongoingErrands = useCasedataStore((s) => s.ongoingErrands);
+  const assignedErrands = useCasedataStore((s) => s.assignedErrands);
+  const suspendedErrands = useCasedataStore((s) => s.suspendedErrands);
+  const closedErrands = useCasedataStore((s) => s.closedErrands);
 
   const updateStatusFilter = (ss: ErrandStatus[]) => {
     try {

--- a/frontend/src/casedata/components/casedata-filtering/components/casedata-filter-tags.component.tsx
+++ b/frontend/src/casedata/components/casedata-filtering/components/casedata-filter-tags.component.tsx
@@ -10,7 +10,7 @@ import {
   newStatuses,
 } from '@casedata/services/casedata-errand-service';
 import { Admin } from '@common/services/user-service';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore } from '@stores/index';
 import { Chip } from '@sk-web-gui/react';
 import dayjs from 'dayjs';
 import { useFormContext } from 'react-hook-form';
@@ -22,6 +22,7 @@ interface CasedataFilterTagsProps {
 
 export const CasedataFilterTags: React.FC<CasedataFilterTagsProps> = ({ administrators }) => {
   const { watch, setValue, reset } = useFormContext<CaseDataFilter>();
+  const selectedErrandStatuses = useCasedataStore((s) => s.selectedErrandStatuses);
   const types = watch('caseType');
   const statuses = watch('status');
   const priorities = watch('priority');
@@ -32,8 +33,6 @@ export const CasedataFilterTags: React.FC<CasedataFilterTagsProps> = ({ administ
   const phases = watch('phase');
   const channels = watch('channel');
   const stakeholderType = watch('stakeholderType');
-
-  const { selectedErrandStatuses }: { selectedErrandStatuses: string[] } = useAppContext();
 
   const hasTags =
     types.length > 0 ||

--- a/frontend/src/casedata/components/contract-overview/contract-detail-form.component.tsx
+++ b/frontend/src/casedata/components/contract-overview/contract-detail-form.component.tsx
@@ -31,7 +31,7 @@ import { getToastOptions } from '@common/utils/toast-message-settings';
 import { Role } from '@casedata/interfaces/role';
 import { CasedataOwnerOrContact, StakeholderType } from '@casedata/interfaces/stakeholder';
 import { setAdministrator } from '@casedata/services/casedata-stakeholder-service';
-import { useAppContext } from '@contexts/app.context';
+import { useConfigStore, useUserStore } from '@stores/index';
 import { Admin } from '@common/services/user-service';
 import { ExternalLink } from 'lucide-react';
 
@@ -124,8 +124,9 @@ export const ContractDetailForm: React.FC<{
   selectedContract: Contract;
   update?: (contractId: string) => void;
 }> = ({ selectedContract }) => {
-  const { municipalityId, user, administrators }: { municipalityId: string; user: any; administrators: Admin[] } =
-    useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const user = useUserStore((s) => s.user);
+  const administrators: Admin[] = useUserStore((s) => s.administrators);
 
   const contractData = useMemo<ContractData>(() => {
     if (selectedContract.type === ContractType.PURCHASE_AGREEMENT) {

--- a/frontend/src/casedata/components/errand/appeal-button.component.tsx
+++ b/frontend/src/casedata/components/errand/appeal-button.component.tsx
@@ -3,18 +3,16 @@ import { UiPhase } from '@casedata/interfaces/errand-phase';
 import { appealErrand, getErrand } from '@casedata/services/casedata-errand-service';
 import { Admin } from '@common/services/user-service';
 import { getToastOptions } from '@common/utils/toast-message-settings';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore, useConfigStore } from '@stores/index';
 import { Button, useConfirm, useSnackbar } from '@sk-web-gui/react';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { useFormContext, UseFormReturn } from 'react-hook-form';
 
 export const AppealButtonComponent: React.FC<{ disabled: boolean }> = (props) => {
-  const {
-    municipalityId,
-    errand,
-    setErrand,
-  } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const errand = useCasedataStore((s) => s.errand);
+  const setErrand = useCasedataStore((s) => s.setErrand);
 
   const toastMessage = useSnackbar();
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/frontend/src/casedata/components/errand/forms/contact-modal.component.tsx
+++ b/frontend/src/casedata/components/errand/forms/contact-modal.component.tsx
@@ -3,7 +3,7 @@ import { CasedataOwnerOrContact } from '@casedata/interfaces/stakeholder';
 import CommonNestedEmailArrayV2 from '@common/components/commonNestedEmailArrayV2';
 import CommonNestedPhoneArrayV2 from '@common/components/commonNestedPhoneArrayV2';
 import { appConfig } from '@config/appconfig';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore } from '@stores/index';
 import { Button, cx, FormControl, FormErrorMessage, FormLabel, Input, Modal } from '@sk-web-gui/react';
 import { UseFieldArrayReplace, UseFormReturn } from 'react-hook-form';
 import { ContactRelationSelect } from './contact-relation-select.component';
@@ -47,7 +47,7 @@ export const ContactModal: React.FC<ContactModalProps> = ({
 }) => {
   const { control, register, formState, watch, setValue, trigger } = form;
   const errors = formState.errors;
-  const { errand } = useAppContext();
+  const errand = useCasedataStore((s) => s.errand);
 
   return (
     <Modal

--- a/frontend/src/casedata/components/errand/forms/search-result.component.tsx
+++ b/frontend/src/casedata/components/errand/forms/search-result.component.tsx
@@ -1,7 +1,7 @@
 import { CasedataOwnerOrContact } from '@casedata/interfaces/stakeholder';
 import CommonNestedEmailArrayV2 from '@common/components/commonNestedEmailArrayV2';
 import CommonNestedPhoneArrayV2 from '@common/components/commonNestedPhoneArrayV2';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore } from '@stores/index';
 import { Button, FormErrorMessage } from '@sk-web-gui/react';
 import { UseFormReturn } from 'react-hook-form';
 import { ContactRelationSelect } from './contact-relation-select.component';
@@ -25,7 +25,7 @@ export const SearchResult: React.FC<SearchResultProps> = ({
   onSubmit,
   label,
 }) => {
-  const { errand } = useAppContext();
+  const errand = useCasedataStore((s) => s.errand);
   const { control, register, formState, watch, setValue, trigger } = form;
   const errors = formState.errors;
 

--- a/frontend/src/casedata/components/errand/forms/simplified-contact-form.component.tsx
+++ b/frontend/src/casedata/components/errand/forms/simplified-contact-form.component.tsx
@@ -2,7 +2,7 @@ import { ContactModal } from '@casedata/components/errand/forms/contact-modal.co
 import { Channels } from '@casedata/interfaces/channels';
 import { Role } from '@casedata/interfaces/role';
 import { CasedataOwnerOrContact } from '@casedata/interfaces/stakeholder';
-import { useAppContext } from '@common/contexts/app.context';
+import { useCasedataStore } from '@stores/index';
 import { isValidOrgNumber } from '@common/services/adress-service';
 import {
   invalidOrgNumberMessage,
@@ -186,7 +186,7 @@ export const SimplifiedContactForm: React.FC<{
     ]
   );
 
-  const { errand } = useAppContext();
+  const errand = useCasedataStore((s) => s.errand);
   const [searchMode, setSearchMode] = useState('person');
   const [searching, setSearching] = useState(false);
   const [notFound, setNotFound] = useState(false);

--- a/frontend/src/casedata/components/errand/phasechanger/phasechanger.component.tsx
+++ b/frontend/src/casedata/components/errand/phasechanger/phasechanger.component.tsx
@@ -14,27 +14,30 @@ import {
 } from '@casedata/services/casedata-errand-service';
 import { setAdministrator } from '@casedata/services/casedata-stakeholder-service';
 import { phaseChangeInProgress, triggerErrandPhaseChange } from '@casedata/services/process-service';
-import { useAppContext } from '@common/contexts/app.context';
+import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
 import { isPT } from '@common/services/application-service';
 import { getToastOptions } from '@common/utils/toast-message-settings';
 import { Button, FormErrorMessage, Spinner, useSnackbar } from '@sk-web-gui/react';
 import { ArrowRight } from 'lucide-react';
 import { IconName } from 'lucide-react/dynamic';
-import { JSX, useEffect, useState } from 'react';
+import { JSX, useEffect, useMemo, useState } from 'react';
 import { UseFormReturn, useForm } from 'react-hook-form';
 import { PhaseChangerDialogComponent } from './phasechanger-dialog.component';
 
 export const PhaseChanger = () => {
-  const { municipalityId, user, errand, setErrand, administrators, uiPhase } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const user = useUserStore((s) => s.user);
+  const errand = useCasedataStore((s) => s.errand);
+  const setErrand = useCasedataStore((s) => s.setErrand);
+  const administrators = useUserStore((s) => s.administrators);
+  const uiPhase = useCasedataStore((s) => s.uiPhase);
   const [isLoading, setIsLoading] = useState(false);
   const [phaseDialogOpen, setPhaseDialogOpen] = useState(false);
   const toastMessage = useSnackbar();
   const { pollDisplayPhase } = useDisplayPhasePoller();
-  const [allowed, setAllowed] = useState(false);
-  useEffect(() => {
-    if (!errand) return;
-    const _a = validateAction(errand, user);
-    setAllowed(_a);
+  const allowed = useMemo(() => {
+    if (!errand) return false;
+    return validateAction(errand, user);
   }, [user, errand]);
 
   const {

--- a/frontend/src/casedata/components/errand/sidebar/resume-errand-button.component.tsx
+++ b/frontend/src/casedata/components/errand/sidebar/resume-errand-button.component.tsx
@@ -2,13 +2,15 @@ import { ErrandStatus, pausedStatuses } from '@casedata/interfaces/errand-status
 import { getErrand, setErrandStatus } from '@casedata/services/casedata-errand-service';
 import { sortBy } from '@common/services/helper-service';
 import { getToastOptions } from '@common/utils/toast-message-settings';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore, useConfigStore } from '@stores/index';
 import { Button, useConfirm, useSnackbar } from '@sk-web-gui/react';
 import { useState } from 'react';
 import { CirclePlay } from 'lucide-react';
 
 export const ResumeErrandButton: React.FC<{ disabled: boolean }> = ({ disabled }) => {
-  const { municipalityId, errand, setErrand } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const errand = useCasedataStore((s) => s.errand);
+  const setErrand = useCasedataStore((s) => s.setErrand);
   const confirm = useConfirm();
   const toastMessage = useSnackbar();
   const [isLoading, setIsLoading] = useState(false);

--- a/frontend/src/casedata/components/errand/sidebar/sidebar-generic-notes.component.tsx
+++ b/frontend/src/casedata/components/errand/sidebar/sidebar-generic-notes.component.tsx
@@ -7,13 +7,13 @@ import {
   saveErrandNote,
 } from '@casedata/services/casedata-errand-notes-service';
 import { getErrand, isErrandAdmin } from '@casedata/services/casedata-errand-service';
-import { useAppContext } from '@common/contexts/app.context';
+import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
 import { sanitizedInline } from '@common/services/sanitizer-service';
 import { getInitialsFromADUsername } from '@common/services/user-service';
 import { getToastOptions } from '@common/utils/toast-message-settings';
 import { Avatar, Button, Divider, FormControl, Modal, PopupMenu, Textarea, cx, useSnackbar } from '@sk-web-gui/react';
 import dayjs from 'dayjs';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { UseFormReturn, useForm } from 'react-hook-form';
 import { Ellipsis, Pencil, Trash } from 'lucide-react';
 
@@ -22,9 +22,13 @@ export const SidebarGenericNotes: React.FC<{
   label_singular: 'Kommentar' | 'Tjänsteanteckning';
   noteType: NoteType;
 }> = ({ label_plural, label_singular, noteType }) => {
-  const { municipalityId, user, errand, setErrand, administrators, uiPhase } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const user = useUserStore((s) => s.user);
+  const errand = useCasedataStore((s) => s.errand);
+  const setErrand = useCasedataStore((s) => s.setErrand);
+  const administrators = useUserStore((s) => s.administrators);
+  const uiPhase = useCasedataStore((s) => s.uiPhase);
   const [selectedNote, setSelectedNote] = useState<ErrandNote>();
-  const [notes, setNotes] = useState<ErrandNote[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(false);
   const [activePage, setActivePage] = useState(1);
@@ -100,14 +104,17 @@ export const SidebarGenericNotes: React.FC<{
     console.error('Something went wrong when saving note');
   };
 
-  useEffect(() => {
-    setNotes(
+  const notes = useMemo(
+    () =>
       (errand?.notes ?? [])
         .sort((a, b) =>
           dayjs(a.updated).isAfter(dayjs(b.updated)) ? 1 : dayjs(b.updated).isAfter(dayjs(a.updated)) ? -1 : 0
         )
-        .reverse()
-    );
+        .reverse(),
+    [errand?.notes]
+  );
+
+  useEffect(() => {
     if (selectedNote) {
       setSelectedNote(errand?.notes?.find((n) => n.id === selectedNote.id));
     }

--- a/frontend/src/casedata/components/errand/sidebar/sidebar-history.component.tsx
+++ b/frontend/src/casedata/components/errand/sidebar/sidebar-history.component.tsx
@@ -1,7 +1,7 @@
 import { IErrand } from '@casedata/interfaces/errand';
 import { GenericChangeData, ParsedErrandChange, ParsedErrandHistory } from '@casedata/interfaces/history';
 import { fetchChangeData, getErrandHistory } from '@casedata/services/casedata-history-service';
-import { useAppContext } from '@common/contexts/app.context';
+import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
 import { sanitized } from '@common/services/sanitizer-service';
 import { Admin } from '@common/services/user-service';
 import { Button, Modal, Spinner, cx } from '@sk-web-gui/react';
@@ -10,11 +10,9 @@ import { useEffect, useState } from 'react';
 import { History } from 'lucide-react';
 
 export const SidebarHistory: React.FC<{}> = () => {
-  const {
-    municipalityId,
-    errand,
-    administrators,
-  } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const errand = useCasedataStore((s) => s.errand);
+  const administrators = useUserStore((s) => s.administrators);
   const [history, setHistory] = useState<ParsedErrandHistory>([]);
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);

--- a/frontend/src/casedata/components/errand/sidebar/sidebar-info.component.tsx
+++ b/frontend/src/casedata/components/errand/sidebar/sidebar-info.component.tsx
@@ -9,7 +9,7 @@ import { CreateErrandNoteDto } from '@casedata/interfaces/errandNote';
 import { saveErrandNote } from '@casedata/services/casedata-errand-notes-service';
 import { getErrand, isErrandAdmin, isErrandLocked, validateAction } from '@casedata/services/casedata-errand-service';
 import { setAdministrator } from '@casedata/services/casedata-stakeholder-service';
-import { useAppContext } from '@common/contexts/app.context';
+import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
 import { isAppealEnabled } from '@common/services/feature-flag-service';
 import { Admin } from '@common/services/user-service';
 import { getToastOptions } from '@common/utils/toast-message-settings';
@@ -26,7 +26,7 @@ import {
   useSnackbar,
 } from '@sk-web-gui/react';
 import dayjs from 'dayjs';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { UseFormReturn, useFormContext } from 'react-hook-form';
 import { AppealButtonComponent } from '../appeal-button.component';
 import { PhaseChanger } from '../phasechanger/phasechanger.component';
@@ -36,27 +36,21 @@ import { cancelErrandPhaseChange, phaseChangeInProgress } from '@casedata/servic
 import { ArchiveX, CirclePause, Mail } from 'lucide-react';
 
 export const SidebarInfo: React.FC<{}> = () => {
-  const {
-    municipalityId,
-    user,
-    errand,
-    setErrand,
-    administrators,
-    uiPhase,
-  } = useAppContext();
-  const [selectableStatuses, setSelectableStatuses] = useState<string[]>([]);
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const user = useUserStore((s) => s.user);
+  const errand = useCasedataStore((s) => s.errand);
+  const setErrand = useCasedataStore((s) => s.setErrand);
+  const administrators = useUserStore((s) => s.administrators);
+  const uiPhase = useCasedataStore((s) => s.uiPhase);
   const [showMessageComposer, setShowMessageComposer] = useState<boolean>(false);
   const [dialogIsOpen, setDialogIsOpen] = useState<boolean>(false);
   const [causeIsEmpty, setCauseIsEmpty] = useState<boolean>(false);
   const [loading, setLoading] = useState(false);
   const toastMessage = useSnackbar();
   const { pollDisplayPhase } = useDisplayPhasePoller();
-  const [allowed, setAllowed] = useState(false);
-
-  useEffect(() => {
-    if (!errand) return;
-    const _a = validateAction(errand, user);
-    setAllowed(_a);
+  const allowed = useMemo(() => {
+    if (!errand) return false;
+    return validateAction(errand, user);
   }, [user, errand]);
 
   const { setValue, register, getValues, reset }: UseFormReturn<IErrand, any, undefined> = useFormContext();
@@ -79,7 +73,7 @@ export const SidebarInfo: React.FC<{}> = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [errand, administrators]);
 
-  useEffect(() => {
+  const selectableStatuses = useMemo(() => {
     const s = [ErrandStatus.VantarPaKomplettering, ErrandStatus.InterntAterkoppling, ErrandStatus.Tilldelat];
     if (errand?.phase === ErrandPhase.aktualisering) {
       s.unshift(ErrandStatus.ArendeInkommit);
@@ -99,9 +93,8 @@ export const SidebarInfo: React.FC<{}> = () => {
     if (!s.includes(errand?.status?.statusType as ErrandStatus)) {
       s.unshift(errand?.status?.statusType as ErrandStatus);
     }
-    setSelectableStatuses(s);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [errand]);
+    return s;
+  }, [errand, uiPhase]);
 
   const errandSave = useSaveCasedataErrand(false);
   const selfAssignErrand = async () => {
@@ -243,13 +236,13 @@ export const SidebarInfo: React.FC<{}> = () => {
                 </Button>
               </div>
               <Select
+                {...register('administratorName')}
+                value={getValues().administratorName}
                 className="w-full"
                 size="sm"
                 data-cy="admin-input"
                 placeholder="Tilldela handläggare"
                 aria-label="Tilldela handläggare"
-                {...register('administratorName')}
-                value={getValues().administratorName}
               >
                 {!errand?.administrator?.adAccount ? <Select.Option>Tilldela handläggare</Select.Option> : null}
                 {administrators
@@ -273,13 +266,13 @@ export const SidebarInfo: React.FC<{}> = () => {
             >
               <FormLabel className="text-small">Ärendestatus</FormLabel>
               <Select
+                {...register('status.statusType')}
+                value={getValues().status?.statusType}
                 className="w-full"
                 size="sm"
                 data-cy="status-input"
                 placeholder="Välj status"
                 aria-label="Välj status"
-                {...register('status.statusType')}
-                value={getValues().status?.statusType}
               >
                 {!errand?.status ? <Select.Option>Välj status</Select.Option> : null}
                 {selectableStatuses.map((c: string, index) => (

--- a/frontend/src/casedata/components/errand/sidebar/sidebar-utredning.component.tsx
+++ b/frontend/src/casedata/components/errand/sidebar/sidebar-utredning.component.tsx
@@ -7,17 +7,16 @@ import { CreateStakeholderDto } from '@casedata/interfaces/stakeholder';
 import { renderUtredningPdf, saveDecision } from '@casedata/services/casedata-decision-service';
 import { getErrand, isErrandAdmin, isErrandLocked, validateAction } from '@casedata/services/casedata-errand-service';
 import { getOwnerStakeholder } from '@casedata/services/casedata-stakeholder-service';
-import { useAppContext } from '@common/contexts/app.context';
+import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
 import { Law } from '@common/data-contracts/case-data/data-contracts';
 import { User } from '@common/interfaces/user';
 import { getToastOptions } from '@common/utils/toast-message-settings';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Button, cx, FormControl, FormErrorMessage, Input, useSnackbar } from '@sk-web-gui/react';
-import dynamic from 'next/dynamic';
-import { useEffect, useState } from 'react';
+import TextEditor from '@common/components/dynamic-text-editor';
+import { useEffect, useMemo, useState } from 'react';
 import { useForm, UseFormReturn } from 'react-hook-form';
 import * as yup from 'yup';
-const TextEditor = dynamic(() => import('@sk-web-gui/text-editor'), { ssr: false });
 
 export interface UtredningFormModel {
   id?: string;
@@ -50,20 +49,16 @@ let formSchema = yup
   .required();
 
 export const SidebarUtredning: React.FC = () => {
-  const {
-    municipalityId,
-    errand,
-    setErrand,
-    user,
-  } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const errand = useCasedataStore((s) => s.errand);
+  const setErrand = useCasedataStore((s) => s.setErrand);
+  const user = useUserStore((s) => s.user);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(false);
   const toastMessage = useSnackbar();
-  const [allowed, setAllowed] = useState(false);
-  useEffect(() => {
-    if (!errand) return;
-    const _a = validateAction(errand, user);
-    setAllowed(_a);
+  const allowed = useMemo(() => {
+    if (!errand) return false;
+    return validateAction(errand, user);
   }, [user, errand]);
 
   const {

--- a/frontend/src/casedata/components/errand/tabs/attachments/casedata-attachments.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/attachments/casedata-attachments.component.tsx
@@ -14,7 +14,7 @@ import {
 } from '@casedata/services/casedata-attachment-service';
 import { getErrand, isErrandLocked } from '@casedata/services/casedata-errand-service';
 import { imageMimeTypes } from '@common/components/file-upload/file-upload.component';
-import { useAppContext } from '@common/contexts/app.context';
+import { useCasedataStore, useConfigStore } from '@stores/index';
 import { isMEX } from '@common/services/application-service';
 import { mapAttachmentToUploadFile, validAttachment } from '@common/services/attachment-service';
 import { getToastOptions } from '@common/utils/toast-message-settings';
@@ -47,7 +47,9 @@ export const CasedataAttachments: React.FC = () => {
   const [editIndex, setEditIndex] = useState<number | null>(null);
   const [originalFile, setOriginalFile] = useState<UploadFile | null>(null);
 
-  const { municipalityId, errand, setErrand } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const errand = useCasedataStore((s) => s.errand);
+  const setErrand = useCasedataStore((s) => s.setErrand);
   const removeConfirm = useConfirm();
   const toastMessage = useSnackbar();
 

--- a/frontend/src/casedata/components/errand/tabs/billing/billing-leaseholder.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/billing/billing-leaseholder.component.tsx
@@ -1,7 +1,7 @@
 import { BillingRecipient } from '@casedata/interfaces/billing';
 import { PrettyRole, Role } from '@casedata/interfaces/role';
 import { CasedataOwnerOrContact } from '@casedata/interfaces/stakeholder';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore } from '@stores/index';
 import { FormControl, FormLabel, Select } from '@sk-web-gui/react';
 import { useState } from 'react';
 
@@ -10,7 +10,7 @@ interface BillingLeaseholderProps {
 }
 
 export const BillingLeaseholder: React.FC<BillingLeaseholderProps> = ({ onSelectRecipient }) => {
-  const { errand } = useAppContext();
+  const errand = useCasedataStore((s) => s.errand);
   const [selectedStakeholderId, setSelectedStakeholderId] = useState<string>('');
 
   if (!errand) {

--- a/frontend/src/casedata/components/errand/tabs/billing/billing-specifications.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/billing/billing-specifications.component.tsx
@@ -1,10 +1,10 @@
 import { BillingFormData } from '@casedata/interfaces/billing';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore } from '@stores/index';
 import { Checkbox, DatePicker, FormControl, FormLabel, Input, Textarea } from '@sk-web-gui/react';
 import { useFormContext } from 'react-hook-form';
 
 export const BillingSpecifications: React.FC = () => {
-  const { errand } = useAppContext();
+  const errand = useCasedataStore((s) => s.errand);
   const { register, watch, setValue } = useFormContext<BillingFormData>();
 
   const selectedFacilities = watch('specifications.selectedFacilities') || [];

--- a/frontend/src/casedata/components/errand/tabs/billing/billing-table.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/billing/billing-table.component.tsx
@@ -4,7 +4,7 @@ import {
   deleteCasedataBillingRecord,
   updateCasedataBillingRecord,
 } from '@casedata/services/casedata-billing-service';
-import { useAppContext } from '@contexts/app.context';
+import { useConfigStore } from '@stores/index';
 import {
   Button,
   DatePicker,
@@ -56,7 +56,7 @@ export const BillingTable: React.FC<BillingTableProps> = ({
   onDeleteRecord,
   onUpdateRecord,
 }) => {
-  const { municipalityId } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
   const toastMessage = useSnackbar();
   const confirm = useConfirm();
   const [deletingId, setDeletingId] = useState<string | null>(null);

--- a/frontend/src/casedata/components/errand/tabs/billing/casedata-billing-form.tsx
+++ b/frontend/src/casedata/components/errand/tabs/billing/casedata-billing-form.tsx
@@ -10,7 +10,7 @@ import {
 } from '@casedata/services/casedata-billing-service';
 import { getErrand } from '@casedata/services/casedata-errand-service';
 import { getSSNFromPersonId } from '@casedata/services/casedata-stakeholder-service';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
 import { Button, Divider, useSnackbar } from '@sk-web-gui/react';
 import { useCallback, useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
@@ -23,7 +23,10 @@ import { BillingTable } from './billing-table.component';
 import { Plus } from 'lucide-react';
 
 export const CaseDataBillingForm: React.FC = () => {
-  const { errand, municipalityId, user, setErrand } = useAppContext();
+  const errand = useCasedataStore((s) => s.errand);
+  const setErrand = useCasedataStore((s) => s.setErrand);
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const user = useUserStore((s) => s.user);
   const toastMessage = useSnackbar();
 
   const [billingRecords, setBillingRecords] = useState<CBillingRecord[]>([]);

--- a/frontend/src/casedata/components/errand/tabs/contract/casedata-contract-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/contract/casedata-contract-tab.tsx
@@ -25,7 +25,7 @@ import {
   saveContractToErrand,
 } from '@casedata/services/contract-service';
 import { getToastOptions } from '@common/utils/toast-message-settings';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Checkbox, FormControl, FormLabel, Input, Select, Spinner, useConfirm, useSnackbar } from '@sk-web-gui/react';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
@@ -93,7 +93,10 @@ export const CasedataContractTab: React.FC<CasedataContractProps> = (props) => {
       }),
     })
     .required();
-  const { municipalityId, errand, setErrand, user } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const errand = useCasedataStore((s) => s.errand);
+  const setErrand = useCasedataStore((s) => s.setErrand);
+  const user = useUserStore((s) => s.user);
   const [loading, setIsLoading] = useState<string>();
   const [existingContract, setExistingContract] = useState<ContractData | undefined>(undefined);
   const [sellers, setSellers] = useState<StakeholderWithPersonnumber[]>([]);

--- a/frontend/src/casedata/components/errand/tabs/contract/contract-attachments.tsx
+++ b/frontend/src/casedata/components/errand/tabs/contract/contract-attachments.tsx
@@ -8,7 +8,7 @@ import {
   saveSignedContractAttachment,
 } from '@casedata/services/contract-service';
 import { getToastOptions } from '@common/utils/toast-message-settings';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore, useConfigStore } from '@stores/index';
 import { Button, FileUpload, PopupMenu, UploadFile, useConfirm, useSnackbar } from '@sk-web-gui/react';
 import { useEffect, useState } from 'react';
 import { Eye, FilePen, Trash } from 'lucide-react';
@@ -18,7 +18,9 @@ export const ContractAttachments: React.FC<{
   readOnly?: boolean;
 }> = ({ existingContract, readOnly = false }) => {
   const toastMessage = useSnackbar();
-  const { municipalityId, errand, setErrand } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const errand = useCasedataStore((s) => s.errand);
+  const setErrand = useCasedataStore((s) => s.setErrand);
   const removeConfirm = useConfirm();
 
   const viewFileHandler = (attachment: any) => {

--- a/frontend/src/casedata/components/errand/tabs/contract/contract-form.tsx
+++ b/frontend/src/casedata/components/errand/tabs/contract/contract-form.tsx
@@ -9,7 +9,7 @@ import {
   isLeaseAgreement,
   prettyContractRoles,
 } from '@casedata/services/contract-service';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
 import {
   Button,
   Checkbox,
@@ -25,7 +25,7 @@ import {
   Textarea,
 } from '@sk-web-gui/react';
 import { Calendar, FilePen, Info, MapPin, Receipt, RefreshCcw, Users, Wallet } from 'lucide-react';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { ContractAttachments } from './contract-attachments';
 
@@ -56,7 +56,9 @@ export const ContractForm: React.FC<{
   onUpdateLesseesOnly,
   contractOveriewMode = false,
 }) => {
-  const { municipalityId, errand, user } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const errand = useCasedataStore((s) => s.errand);
+  const user = useUserStore((s) => s.user);
   const { register, setValue, control, handleSubmit, getValues, watch, formState, trigger } =
     useFormContext<ContractData>();
   const [lesseeNoticeIndex, setLesseeNoticeIndex] = useState(0);
@@ -64,7 +66,6 @@ export const ContractForm: React.FC<{
   const [invoiceInfoIndex, setInvoiceInfoIndex] = useState(0);
 
   const [loading, setLoading] = useState<boolean>(false);
-  const [allowed, setAllowed] = useState(false);
   const [updatingParties, setUpdatingParties] = useState<boolean>(false);
 
   const contractType = watch().type;
@@ -80,9 +81,8 @@ export const ContractForm: React.FC<{
     return fieldType === 'billing' || fieldType === 'lessee';
   };
 
-  useEffect(() => {
-    const _a = errand ? validateAction(errand, user) : false;
-    setAllowed(_a);
+  const allowed = useMemo(() => {
+    return errand ? validateAction(errand, user) : false;
   }, [user, errand]);
 
   useEffect(() => {

--- a/frontend/src/casedata/components/errand/tabs/contract/contract-navigation.tsx
+++ b/frontend/src/casedata/components/errand/tabs/contract/contract-navigation.tsx
@@ -1,5 +1,5 @@
 import { ContractType } from '@casedata/interfaces/contracts';
-import { Badge, Link } from '@sk-web-gui/react';
+import { Badge, Link, cx } from '@sk-web-gui/react';
 
 export const ContractNavigation: React.FC<{ contractType: ContractType }> = ({ contractType }) => {
   const headers: { key: string; label: string; initiallyOpen?: boolean }[] =
@@ -27,8 +27,7 @@ export const ContractNavigation: React.FC<{ contractType: ContractType }> = ({ c
             id={`badge-${h.key}`}
             counter=""
             rounded
-            className="!max-w-[10px] !min-w-[10px] !max-h-[10px] !min-h-[10px]"
-            style={{ backgroundColor: h.initiallyOpen ? 'black' : 'lightgray' }}
+            className={cx('!max-w-[10px] !min-w-[10px] !max-h-[10px] !min-h-[10px]', h.initiallyOpen ? 'bg-black' : 'bg-gray-300')}
           />
           <Link variant="tertiary">{h.label}</Link>
         </div>

--- a/frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx
@@ -16,7 +16,7 @@ import {
   updateErrandStatus,
   validateAction,
 } from '@casedata/services/casedata-errand-service';
-import { AppContextInterface, useAppContext } from '@common/contexts/app.context';
+import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
 import { yupResolver } from '@hookform/resolvers/yup';
 import type { RJSFSchema } from '@rjsf/utils';
 import dayjs from 'dayjs';
@@ -58,14 +58,13 @@ import {
   useConfirm,
   useSnackbar,
 } from '@sk-web-gui/react';
-import dynamic from 'next/dynamic';
+import TextEditor from '@common/components/dynamic-text-editor';
 import { CasedataMessageTabFormModel } from '../messages/message-composer.component';
 import { ServiceListComponent } from '../services/casedata-service-list.component';
 import { useErrandServices } from '../services/useErrandService';
 import { SendDecisionDialogComponent } from './send-decision-dialog.component';
 import { ContractData } from '@casedata/interfaces/contract-data';
 import { Download, SendHorizontal } from 'lucide-react';
-const TextEditor = dynamic(() => import('@sk-web-gui/text-editor'), { ssr: false });
 
 export type ContactMeans = 'webmessage' | 'email' | 'digitalmail' | false;
 
@@ -132,7 +131,10 @@ export const CasedataDecisionTab: React.FC<{
   update: () => void;
   onRefetchServices?: (refetch: () => void) => void;
 }> = (props) => {
-  const { municipalityId, user, errand, setErrand } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const user = useUserStore((s) => s.user);
+  const errand = useCasedataStore((s) => s.errand);
+  const setErrand = useCasedataStore((s) => s.setErrand);
   const [isLoading, setIsLoading] = useState(false);
   const [isSaveAndSendLoading, setIsSaveAndSendLoading] = useState(false);
   const [isPreviewLoading, setIsPreviewLoading] = useState(false);
@@ -142,7 +144,6 @@ export const CasedataDecisionTab: React.FC<{
   const quillRef = useRef<any>(null);
   const saveConfirm = useConfirm();
   const toastMessage = useSnackbar();
-  const [allowed, setAllowed] = useState(false);
   const [existingContract, setExistingContract] = useState<ContractData | undefined>(undefined);
   const [controlContractIsOpen, setControlContractIsOpen] = useState(false);
   const [serviceSchema, setServiceSchema] = useState<RJSFSchema | null>(null);
@@ -189,10 +190,9 @@ export const CasedataDecisionTab: React.FC<{
     }
   }, [props, refetchServices]);
 
-  useEffect(() => {
-    if (!errand) return;
-    const _a = validateAction(errand, user);
-    setAllowed(_a);
+  const allowed = useMemo(() => {
+    if (!errand) return false;
+    return validateAction(errand, user);
   }, [user, errand]);
 
   const {
@@ -460,8 +460,8 @@ export const CasedataDecisionTab: React.FC<{
       .then(async (confirmed) => {
         if (confirmed) {
           setIsLoading(true);
-          await saveCasedataErrand();
           const data = getValues();
+          await saveCasedataErrand();
           await save(data);
 
           return Promise.resolve(true);

--- a/frontend/src/casedata/components/errand/tabs/details/casedata-details-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/details/casedata-details-tab.tsx
@@ -7,20 +7,19 @@ import {
 } from '@casedata/services/casedata-extra-parameters-service';
 import { saveFacilities } from '@casedata/services/casedata-facilities-service';
 import Facilities from '@common/components/facilities/facilities';
-import { useAppContext } from '@common/contexts/app.context';
+import { useCasedataStore, useConfigStore } from '@stores/index';
 import { FacilityDTO } from '@common/interfaces/facilities';
 import { getToastOptions } from '@common/utils/toast-message-settings';
 import { appConfig } from '@config/appconfig';
 import { Disclosure, FormControl, FormLabel, Input, cx, useSnackbar } from '@sk-web-gui/react';
 import { IconName } from 'lucide-react/dynamic';
-import dynamic from 'next/dynamic';
+import TextEditor from '@common/components/dynamic-text-editor';
 import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { baseDetails } from '../../extraparameter-templates/base-template';
 import { CasedataFormFieldRenderer } from './casedata-formfield-renderer';
 import { MapPin } from 'lucide-react';
 import iconMap from '@common/components/lucide-icon-map/lucide-icon-map.component';
-const TextEditor = dynamic(() => import('@sk-web-gui/text-editor'), { ssr: false });
 
 interface CasedataDetailsProps {
   update: () => void;
@@ -29,7 +28,9 @@ interface CasedataDetailsProps {
 }
 
 export const CasedataDetailsTab: React.FC<CasedataDetailsProps> = (props) => {
-  const { municipalityId, errand, setErrand, user } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const errand = useCasedataStore((s) => s.errand);
+  const setErrand = useCasedataStore((s) => s.setErrand);
   const [fields, setFields] = useState<UppgiftField[]>([]);
   const toastMessage = useSnackbar();
 

--- a/frontend/src/casedata/components/errand/tabs/details/casedata-formfield-renderer.tsx
+++ b/frontend/src/casedata/components/errand/tabs/details/casedata-formfield-renderer.tsx
@@ -249,17 +249,24 @@ export const CasedataFormFieldRenderer: React.FC<Props> = ({ detail, idx, form, 
       {detail.formField.type === 'radio' && (
         <>
           <RadioButton.Group
-            defaultValue={getValues(detail.field)}
+            name={fieldKey}
+            value={allFormValues[fieldKey] ?? ''}
             data-cy={`${detail.field}-radio-button-group`}
             inline={!!detail.formField.inline}
           >
             {detail.formField.options.map((option, i) => (
               <RadioButton
                 value={option.value}
-                {...register(fieldKey, validationRules)}
+                name={fieldKey}
                 key={`${option}-${i}`}
                 data-cy={`${detail.field}-radio-button-${i}`}
                 readOnly={isDisabled}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  setValue(fieldKey, e.target.value, {
+                    shouldDirty: true,
+                    shouldValidate: true,
+                  });
+                }}
               >
                 {option.label}
               </RadioButton>

--- a/frontend/src/casedata/components/errand/tabs/details/repeatable-field-group.tsx
+++ b/frontend/src/casedata/components/errand/tabs/details/repeatable-field-group.tsx
@@ -1,6 +1,6 @@
 import { isErrandLocked, isFTNotificationErrand } from '@casedata/services/casedata-errand-service';
 import { EXTRAPARAMETER_SEPARATOR, UppgiftField } from '@casedata/services/casedata-extra-parameters-service';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore } from '@stores/index';
 import { Button } from '@sk-web-gui/react';
 import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
@@ -27,7 +27,7 @@ export const RepeatableFieldGroup: React.FC<RepeatableFieldGroupProps> = ({
   initialData,
 }) => {
   const { unregister, setValue } = useFormContext();
-  const { errand } = useAppContext();
+  const errand = useCasedataStore((s) => s.errand);
   const isReadOnly = (errand ? isErrandLocked(errand) : false) || (errand ? isFTNotificationErrand(errand) : false);
   const [itemIndices, setItemIndices] = useState<number[]>(() => {
     if (initialData && Object.keys(initialData).length > 0) {

--- a/frontend/src/casedata/components/errand/tabs/investigation/casedata-investigation-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/investigation/casedata-investigation-tab.tsx
@@ -16,7 +16,7 @@ import { getErrand, isErrandLocked, isFTErrand, validateAction } from '@casedata
 import { FT_INVESTIGATION_TEXT } from '@casedata/utils/investigation-text';
 import { Law } from '@common/data-contracts/case-data/data-contracts';
 import { getToastOptions } from '@common/utils/toast-message-settings';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
 import { yupResolver } from '@hookform/resolvers/yup';
 import {
   Button,
@@ -30,12 +30,11 @@ import {
   useConfirm,
   useSnackbar,
 } from '@sk-web-gui/react';
-import dynamic from 'next/dynamic';
-import { useEffect, useRef, useState } from 'react';
+import TextEditor from '@common/components/dynamic-text-editor';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Resolver, useForm } from 'react-hook-form';
 import * as yup from 'yup';
 import { Check, ClipboardPenLine, Download, Info } from 'lucide-react';
-const TextEditor = dynamic(() => import('@sk-web-gui/text-editor'), { ssr: false });
 
 export interface UtredningFormModel {
   id?: string;
@@ -75,8 +74,10 @@ export const CasedataInvestigationTab: React.FC<{
 }> = (props) => {
   const toastMessage = useSnackbar();
   const saveConfirm = useConfirm();
-  const { municipalityId, errand, user } = useAppContext();
-  const { setErrand } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const errand = useCasedataStore((s) => s.errand);
+  const user = useUserStore((s) => s.user);
+  const setErrand = useCasedataStore((s) => s.setErrand);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(false);
   const [previewError, setPreviewError] = useState(false);
@@ -91,11 +92,9 @@ export const CasedataInvestigationTab: React.FC<{
     content: 'Vill du återställa den här mallen?',
   };
 
-  const [allowed, setAllowed] = useState(false);
-  useEffect(() => {
-    if (!errand) return;
-    const _a = validateAction(errand, user) && !!errand.administrator;
-    setAllowed(_a);
+  const allowed = useMemo(() => {
+    if (!errand) return false;
+    return validateAction(errand, user) && !!errand.administrator;
   }, [user, errand]);
   const {
     register,

--- a/frontend/src/casedata/components/errand/tabs/messages/casedata-messages-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/messages/casedata-messages-tab.tsx
@@ -6,9 +6,9 @@ import {
   fetchMessagesTree,
   setMessageViewStatus,
 } from '@casedata/services/casedata-message-service';
-import { useAppContext } from '@common/contexts/app.context';
+import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
 import { Button, Divider, FormLabel, Select, useSnackbar } from '@sk-web-gui/react';
-import React, { useEffect, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { MessageResponse } from 'src/data-contracts/backend/data-contracts';
 import { MessageComposer } from './message-composer.component';
 import MessageTreeComponent from './tree.component';
@@ -18,38 +18,33 @@ export const CasedataMessagesTab: React.FC<{
   setUnsaved: (unsaved: boolean) => void;
   update: () => void;
 }> = (props) => {
-  const {
-    municipalityId,
-    errand,
-    messages,
-    messageTree,
-    setMessages,
-    setMessageTree,
-    conversation,
-    conversationTree,
-    user,
-  } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const errand = useCasedataStore((s) => s.errand);
+  const messages = useCasedataStore((s) => s.messages);
+  const messageTree = useCasedataStore((s) => s.messageTree);
+  const setMessages = useCasedataStore((s) => s.setMessages);
+  const setMessageTree = useCasedataStore((s) => s.setMessageTree);
+  const conversation = useCasedataStore((s) => s.conversation);
+  const conversationTree = useCasedataStore((s) => s.conversationTree);
+  const user = useUserStore((s) => s.user);
   const [selectedMessage, setSelectedMessage] = useState<MessageNode>();
   const [showMessageComposer, setShowMessageComposer] = useState<boolean>(false);
   const [sortMessages, setSortMessages] = useState<number>(0);
   const [filterSource, setFilterSource] = useState<number>(0);
-  const [sortedMessages, setSortedMessages] = useState(messages);
   const toastMessage = useSnackbar();
-  const [allowed, setAllowed] = useState(false);
 
-  const combinedMessages = React.useMemo(
+  const combinedMessages = useMemo(
     () => [...(messages || []), ...(conversation || [])],
     [messages, conversation]
   );
 
-  const combinedMessageTree = React.useMemo(
+  const combinedMessageTree = useMemo(
     () => [...(messageTree || []), ...(conversationTree || [])],
     [messageTree, conversationTree]
   );
 
-  useEffect(() => {
-    const _a = errand ? validateAction(errand, user) && !!errand.administrator : false;
-    setAllowed(_a);
+  const allowed = useMemo(() => {
+    return errand ? validateAction(errand, user) && !!errand.administrator : false;
   }, [user, errand]);
 
   const setMessageViewed = (msg: MessageNode) => {
@@ -94,76 +89,43 @@ export const CasedataMessagesTab: React.FC<{
     }
   };
 
-  useEffect(() => {
-    if (combinedMessages && combinedMessageTree) {
-      if (sortMessages === 1) {
-        let filteredMessages = combinedMessages.filter((message: MessageResponse) => message.direction === 'INBOUND');
-        setSortedMessages(filteredMessages);
-      } else if (sortMessages === 2) {
-        let filteredMessages = combinedMessages.filter((message: MessageResponse) => message.direction === 'OUTBOUND');
-        setSortedMessages(filteredMessages);
-      } else {
-        setSortedMessages(combinedMessageTree);
-      }
+  const filterBySource = (message: MessageResponse) => {
+    switch (filterSource) {
+      case 1:
+        return message.messageType === 'DRAKEN';
+      case 2:
+        return message.messageType === 'DIGITAL_MAIL';
+      case 3:
+        return message.messageType === 'EMAIL';
+      case 4:
+        return message.messageType === 'MINASIDOR';
+      case 5:
+        return message.messageType === 'SMS';
+      case 6:
+        return message.messageType === 'WEBMESSAGE' || !!message.externalCaseId;
+      default:
+        return true;
     }
-  }, [combinedMessages, combinedMessageTree, sortMessages]);
+  };
 
-  useEffect(() => {
-    if (combinedMessages && combinedMessageTree) {
-      let filtered = combinedMessages;
+  const sortedMessages = useMemo(() => {
+    if (!combinedMessages || !combinedMessageTree) return [];
 
+    let filtered = combinedMessages;
+
+    if (filterSource !== 0) {
+      filtered = filtered.filter(filterBySource);
+    }
+
+    if (sortMessages === 1) {
+      return filtered.filter((message: MessageResponse) => message.direction === 'INBOUND');
+    } else if (sortMessages === 2) {
+      return filtered.filter((message: MessageResponse) => message.direction === 'OUTBOUND');
+    } else {
       if (filterSource !== 0) {
-        filtered = filtered.filter((message: MessageResponse) => {
-          switch (filterSource) {
-            case 1:
-              return message.messageType === 'DRAKEN';
-            case 2:
-              return message.messageType === 'DIGITAL_MAIL';
-            case 3:
-              return message.messageType === 'EMAIL';
-            case 4:
-              return message.messageType === 'MINASIDOR';
-            case 5:
-              return message.messageType === 'SMS';
-            case 6:
-              return message.messageType === 'WEBMESSAGE' || !!message.externalCaseId;
-            default:
-              return true;
-          }
-        });
+        return combinedMessageTree.filter(filterBySource);
       }
-
-      if (sortMessages === 1) {
-        filtered = filtered.filter((message: MessageResponse) => message.direction === 'INBOUND');
-        setSortedMessages(filtered);
-      } else if (sortMessages === 2) {
-        filtered = filtered.filter((message: MessageResponse) => message.direction === 'OUTBOUND');
-        setSortedMessages(filtered);
-      } else {
-        if (filterSource !== 0) {
-          const filteredTree = combinedMessageTree.filter((node: MessageNode) => {
-            switch (filterSource) {
-              case 1:
-                return node.messageType === 'DRAKEN';
-              case 2:
-                return node.messageType === 'DIGITAL_MAIL';
-              case 3:
-                return node.messageType === 'EMAIL';
-              case 4:
-                return node.messageType === 'MINASIDOR';
-              case 5:
-                return node.messageType === 'SMS';
-              case 6:
-                return node.messageType === 'WEBMESSAGE' || !!node.externalCaseId;
-              default:
-                return true;
-            }
-          });
-          setSortedMessages(filteredTree);
-        } else {
-          setSortedMessages(combinedMessageTree);
-        }
-      }
+      return combinedMessageTree;
     }
   }, [combinedMessages, combinedMessageTree, sortMessages, filterSource]);
 

--- a/frontend/src/casedata/components/errand/tabs/messages/message-composer.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/messages/message-composer.component.tsx
@@ -19,7 +19,7 @@ import CommonNestedEmailArrayV2 from '@common/components/commonNestedEmailArrayV
 import CommonNestedPhoneArrayV2 from '@common/components/commonNestedPhoneArrayV2';
 import FileUpload from '@common/components/file-upload/file-upload.component';
 import { MessageWrapper } from '@common/components/message/message-wrapper.component';
-import { useAppContext } from '@common/contexts/app.context';
+import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
 import { User } from '@common/interfaces/user';
 import { isMEX, isPT } from '@common/services/application-service';
 import {
@@ -45,13 +45,12 @@ import {
   useConfirm,
   useSnackbar,
 } from '@sk-web-gui/react';
-import { useTranslation } from 'next-i18next';
-import dynamic from 'next/dynamic';
-import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import TextEditor from '@common/components/dynamic-text-editor';
+import { useEffect, useMemo, useState } from 'react';
 import { Resolver, useFieldArray, useForm } from 'react-hook-form';
 import * as yup from 'yup';
 import { File, Paperclip, X } from 'lucide-react';
-const TextEditor = dynamic(() => import('@sk-web-gui/text-editor'), { ssr: false });
 
 export interface CasedataMessageTabFormModel {
   contactMeans: 'email' | 'sms' | 'webmessage' | 'digitalmail' | 'paper' | 'draken' | 'minasidor' | 'katla';
@@ -164,7 +163,9 @@ export const MessageComposer: React.FC<{
   setUnsaved: (unsaved: boolean) => void;
   update: () => void;
 }> = (props) => {
-  const { municipalityId, errand, user } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const errand = useCasedataStore((s) => s.errand);
+  const user = useUserStore((s) => s.user);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(false);
   const [replying, setReplying] = useState(false);
@@ -172,12 +173,11 @@ export const MessageComposer: React.FC<{
 
   const closeConfirm = useConfirm();
   const toastMessage = useSnackbar();
-  const [allowed, setAllowed] = useState(false);
   const { t } = useTranslation();
-  useEffect(() => {
-    if (!errand) return;
-    const _a = validateAction(errand, user) && !!errand.administrator;
-    setAllowed(_a);
+
+  const allowed = useMemo(() => {
+    if (!errand) return false;
+    return validateAction(errand, user) && !!errand.administrator;
   }, [user, errand]);
 
   const [isAttachmentModalOpen, setIsAttachmentModalOpen] = useState<boolean>(false);

--- a/frontend/src/casedata/components/errand/tabs/messages/rendered-message.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/messages/rendered-message.component.tsx
@@ -7,7 +7,7 @@ import { MessageNode } from '@casedata/services/casedata-message-service';
 import { MessageAvatar } from '@common/components/message/message-avatar.component';
 import { MessageResponseDirectionEnum } from '@common/data-contracts/case-data/data-contracts';
 import sanitized, { formatMessage } from '@common/services/sanitizer-service';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
 import { Button, cx, Icon, useSnackbar } from '@sk-web-gui/react';
 import dayjs from 'dayjs';
 import { CornerDownRight, Image, Mail, Monitor, Paperclip, Smartphone, SquareMinus, SquarePlus } from 'lucide-react';
@@ -21,7 +21,9 @@ export const RenderedMessage: React.FC<{
   root?: boolean;
   children: any;
 }> = ({ message, onSelect, setShowMessageComposer, root = false, children }) => {
-  const { user, errand, municipalityId } = useAppContext();
+  const user = useUserStore((s) => s.user);
+  const errand = useCasedataStore((s) => s.errand);
+  const municipalityId = useConfigStore((s) => s.municipalityId);
   const [allowed, setAllowed] = useState<boolean>(false);
 
   // Changed logic for expanded message to see if it solve problem with unread message counter

--- a/frontend/src/casedata/components/errand/tabs/overview/casedata-contacts.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/overview/casedata-contacts.component.tsx
@@ -8,7 +8,7 @@ import { MEXRelation, PTRelation, Role } from '@casedata/interfaces/role';
 import { CasedataOwnerOrContact } from '@casedata/interfaces/stakeholder';
 import { isErrandLocked } from '@casedata/services/casedata-errand-service';
 import { getStakeholderRelation } from '@casedata/services/casedata-stakeholder-service';
-import { useAppContext } from '@common/contexts/app.context';
+import { useCasedataStore } from '@stores/index';
 import { appConfig } from '@config/appconfig';
 import { Avatar, Button, Disclosure, FormControl, FormLabel, useConfirm } from '@sk-web-gui/react';
 import { useEffect, useState } from 'react';
@@ -25,7 +25,7 @@ interface CasedataContactsProps {
 export const CasedataContactsComponent: React.FC<CasedataContactsProps> = (props) => {
   const [addContact, setAddContact] = useState(false);
   const [selectedContact, setSelectedContact] = useState<CasedataOwnerOrContact>();
-  const { errand } = useAppContext();
+  const errand = useCasedataStore((s) => s.errand);
   const deleteConfirm = useConfirm();
   const updateConfirm = useConfirm();
   const avatarColorArray = ['vattjom', 'juniskar', 'gronsta', 'bjornstigen'];
@@ -366,7 +366,7 @@ export const CasedataContactsComponent: React.FC<CasedataContactsProps> = (props
                   </div>
                 )}
                 <SimplifiedContactForm
-                  key={Math.random()}
+                  key="new-contact-form"
                   allowOrganization={appConfig.features.useOrganizationStakeholders}
                   disabled={(errand ? isErrandLocked(errand) : false)}
                   setUnsaved={props.setUnsaved}

--- a/frontend/src/casedata/components/errand/tabs/overview/casedata-form.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/overview/casedata-form.component.tsx
@@ -6,7 +6,7 @@ import { Priority } from '@casedata/interfaces/priority';
 import { Stakeholder } from '@casedata/interfaces/stakeholder';
 import { defaultMunicipality, getCaseLabels, isErrandLocked } from '@casedata/services/casedata-errand-service';
 import { LinkedErrandsDisclosure } from '@common/components/linked-errands-disclosure/linked-errands-disclosure.component';
-import { useAppContext } from '@common/contexts/app.context';
+import { useConfigStore } from '@stores/index';
 import { appConfig } from '@config/appconfig';
 import { cx, Disclosure, FormControl, FormErrorMessage, FormLabel, Input, Select } from '@sk-web-gui/react';
 import { CircleAlert } from 'lucide-react';
@@ -39,7 +39,8 @@ const CasedataForm: React.FC<CasedataFormProps> = ({
   registeringNewErrand,
   setFormIsValid,
 }) => {
-  const { municipalityId, setMunicipalityId } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const setMunicipalityId = useConfigStore((s) => s.setMunicipalityId);
 
   useEffect(() => {
     if (errand) {

--- a/frontend/src/casedata/components/errand/tabs/permits-services/casedata-permits-services-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/permits-services/casedata-permits-services-tab.tsx
@@ -1,4 +1,4 @@
-import { useAppContext } from '@common/contexts/app.context';
+import { useCasedataStore, useUserStore } from '@stores/index';
 import { AutoTable, AutoTableHeader } from '@sk-web-gui/react';
 import { useEffect, useState } from 'react';
 
@@ -6,7 +6,9 @@ import { assetStatusLabels, assetTypeLabels } from '@casedata/interfaces/asset';
 import { validateAction } from '@casedata/services/casedata-errand-service';
 
 export const CasedataPermitServicesTab: React.FC<{}> = () => {
-  const { errand, assets, user } = useAppContext();
+  const errand = useCasedataStore((s) => s.errand);
+  const assets = useCasedataStore((s) => s.assets);
+  const user = useUserStore((s) => s.user);
   const [allowed, setAllowed] = useState(false);
   useEffect(() => {
     const _a = errand ? validateAction(errand, user) && !!errand.administrator : false;

--- a/frontend/src/casedata/components/errand/tabs/services/casedata-service-item.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/services/casedata-service-item.component.tsx
@@ -48,8 +48,7 @@ export const ServiceListItem: React.FC<Props> = ({ service, onRemove, onEdit, re
           </div>
 
           <div
-            className="text-dark-secondary text-base break-words whitespace-pre-wrap leading-relaxed overflow-hidden"
-            style={{ wordBreak: 'break-word' }}
+            className="text-dark-secondary text-base break-words whitespace-pre-wrap leading-relaxed overflow-hidden [word-break:break-word]"
             dangerouslySetInnerHTML={{ __html: sanitized(service?.comment) }}
           />
 

--- a/frontend/src/casedata/components/errand/tabs/services/casedata-service-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/services/casedata-service-tab.tsx
@@ -15,7 +15,7 @@ import { ServicesObjectFieldTemplate } from '@common/components/json/fields/serv
 import SchemaForm from '@common/components/json/schema/schema-form.component';
 import { getLatestRjsfSchema, getUiSchemaForSchema } from '@common/components/json/utils/schema-utils';
 import { getToastOptions } from '@common/utils/toast-message-settings';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore, useConfigStore } from '@stores/index';
 import type { RJSFSchema, UiSchema } from '@rjsf/utils';
 import { Modal, useSnackbar } from '@sk-web-gui/react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
@@ -53,7 +53,8 @@ function filterSchemaByCase(schema: RJSFSchema | null, caseType: string): RJSFSc
 }
 
 export const CasedataServicesTab: React.FC = () => {
-  const { municipalityId, errand } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const errand = useCasedataStore((s) => s.errand);
   const [schema, setSchema] = useState<RJSFSchema | null>(null);
   const [uiSchema, setUiSchema] = useState<UiSchema | null>(null);
   const [formData, setFormData] = useState<any>({});

--- a/frontend/src/casedata/components/errand/ui-phase/ui-phase-wrapper.tsx
+++ b/frontend/src/casedata/components/errand/ui-phase/ui-phase-wrapper.tsx
@@ -1,10 +1,11 @@
 import { UiPhase } from '@casedata/interfaces/errand-phase';
 import { ErrandStatus } from '@casedata/interfaces/errand-status';
-import { useAppContext } from '@common/contexts/app.context';
+import { useCasedataStore } from '@stores/index';
 import { UiPhaseComponent } from '../ui-phase.component';
 
 export const UiPhaseWrapper = () => {
-  const { errand, uiPhase } = useAppContext();
+  const errand = useCasedataStore((s) => s.errand);
+  const uiPhase = useCasedataStore((s) => s.uiPhase);
   const arrow = <span className="border-t-2 border-r-2 h-[26px] w-[28px] rotate-45"></span>;
 
   return (

--- a/frontend/src/casedata/components/ongoing-casedata-errands/components/errands-table.component.tsx
+++ b/frontend/src/casedata/components/ongoing-casedata-errands/components/errands-table.component.tsx
@@ -8,7 +8,7 @@ import { PriorityComponent } from '@common/components/priority/priority.componen
 import type { Errand } from '@common/data-contracts/case-data/data-contracts';
 import { isMEX, isPT } from '@common/services/application-service';
 import { sortBy, truncate } from '@common/services/helper-service';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore, useConfigStore } from '@stores/index';
 import { Input, Pagination, Select, Spinner, Table, cx } from '@sk-web-gui/react';
 import { SortMode } from '@sk-web-gui/table';
 import dayjs from 'dayjs';
@@ -19,7 +19,8 @@ import { CasedataStatusLabelComponent } from './casedata-status-label.component'
 
 export const ErrandsTable: React.FC = () => {
   const { watch, setValue, register } = useFormContext<TableForm>();
-  const { municipalityId, errands: data } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const data = useCasedataStore((s) => s.errands);
   const [rowHeight, setRowHeight] = useState<string>('normal');
   const sortOrder = watch('sortOrder');
   const sortColumn = watch('sortColumn');

--- a/frontend/src/casedata/components/ongoing-casedata-errands/ongoing-casedata-errands.component.tsx
+++ b/frontend/src/casedata/components/ongoing-casedata-errands/ongoing-casedata-errands.component.tsx
@@ -1,8 +1,8 @@
 import { ErrandStatus } from '@casedata/interfaces/errand-status';
 import { getStatusLabel, useErrands } from '@casedata/services/casedata-errand-service';
 import { ExportButton } from '@common/components/export-button/export-button.component';
-import { AppContextInterface, useAppContext } from '@common/contexts/app.context';
-import { getMe } from '@common/services/user-service';
+import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
+import { useUserQuery } from '@common/services/use-user-query';
 import { useDebounceEffect } from '@common/utils/useDebounceEffect';
 import { appConfig } from '@config/appconfig';
 import store from '@supportmanagement/services/storage-service';
@@ -24,21 +24,18 @@ export interface TableForm {
 
 export const OngoingCaseDataErrands: React.FC = () => {
   const filterForm = useForm<CaseDataFilter>({ defaultValues: CaseDataValues });
-  const { watch: watchFilter, reset: resetFilter, trigger: triggerFilter, setValue, getValues } = filterForm;
+  const { watch: watchFilter, reset: resetFilter, trigger: triggerFilter, getValues } = filterForm;
   const tableForm = useForm<TableForm>({ defaultValues: { sortColumn: 'updated', sortOrder: 'desc', pageSize: 12 } });
   const { watch: watchTable, setValue: setTableValue } = tableForm;
   const { sortOrder, sortColumn, pageSize, page } = watchTable();
 
-  const {
-    municipalityId,
-    setErrand,
-    administrators,
-    selectedErrandStatuses,
-    setSelectedErrandStatuses,
-    setSidebarLabel,
-    sidebarLabel,
-    closedErrands,
-  }: AppContextInterface = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const setErrand = useCasedataStore((s) => s.setErrand);
+  const administrators = useUserStore((s) => s.administrators);
+  const setSelectedErrandStatuses = useCasedataStore((s) => s.setSelectedErrandStatuses);
+  const setSidebarLabel = useCasedataStore((s) => s.setSidebarLabel);
+  const sidebarLabel = useCasedataStore((s) => s.sidebarLabel);
+  const closedErrands = useCasedataStore((s) => s.closedErrands);
   const startdate = watchFilter('startdate');
   const enddate = watchFilter('enddate');
   const queryFilter = watchFilter('query');
@@ -63,13 +60,16 @@ export const OngoingCaseDataErrands: React.FC = () => {
     });
   };
 
-  useEffect(() => {
-    setValue('status', selectedErrandStatuses);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedErrandStatuses]);
-
   const router = useRouter();
-  const { user, setUser } = useAppContext();
+  const user = useUserStore((s) => s.user);
+  const setUser = useUserStore((s) => s.setUser);
+  const { data: userData } = useUserQuery();
+
+  useEffect(() => {
+    if (userData) {
+      setUser(userData);
+    }
+  }, [userData]);
 
   useEffect(() => {
     const filterdata = store.get('filter');
@@ -90,7 +90,6 @@ export const OngoingCaseDataErrands: React.FC = () => {
           phase: filter?.phase !== '' ? filter?.phase?.split(',') || CaseDataValues.phase : CaseDataValues.phase,
         };
         const filterStatuses = filter?.status?.split(',') || CaseDataValues.status;
-        setSelectedErrandStatuses(filterStatuses);
         const selectedStatusLabel = getStatusLabel(
           filterStatuses.map((s: string) => (ErrandStatus as Record<string, string>)[s])
         );
@@ -143,11 +142,6 @@ export const OngoingCaseDataErrands: React.FC = () => {
     //       the browser will automatically scroll
     //       down to the button.
     setInitialFocus();
-    getMe()
-      .then((user) => {
-        setUser(user);
-      })
-      .catch((e) => {});
     setErrand(undefined);
     //eslint-disable-next-line
   }, [router]);
@@ -207,6 +201,7 @@ export const OngoingCaseDataErrands: React.FC = () => {
       }
       setFilterObject(fObj);
       setExtraFilter(extraFilterObj);
+      setSelectedErrandStatuses(statusFilter);
       store.set('filter', JSON.stringify(fObj));
     },
     200,

--- a/frontend/src/casedata/components/save-button/save-button.component.tsx
+++ b/frontend/src/casedata/components/save-button/save-button.component.tsx
@@ -2,7 +2,7 @@ import { useSaveCasedataErrand } from '@casedata/hooks/useSaveCasedataErrand';
 import { IErrand } from '@casedata/interfaces/errand';
 import { ErrandStatus } from '@casedata/interfaces/errand-status';
 import { isErrandLocked } from '@casedata/services/casedata-errand-service';
-import { useAppContext } from '@common/contexts/app.context';
+import { useCasedataStore } from '@stores/index';
 import { deepFlattenToObject } from '@common/services/helper-service';
 import { Button } from '@sk-web-gui/react';
 import { useRouter } from 'next/navigation';
@@ -19,7 +19,7 @@ export const SaveButtonComponent: React.FC<{
   icon?: JSX.Element;
   loading?: boolean;
 }> = (props) => {
-  const { errand, municipalityId } = useAppContext();
+  const errand = useCasedataStore((s) => s.errand);
   const [errandNumber, setErrandNumber] = useState<string | undefined>(errand?.errandNumber);
   const router = useRouter();
   const [internalLoading, setInternalLoading] = useState(false);

--- a/frontend/src/casedata/components/suspend-errand.tsx
+++ b/frontend/src/casedata/components/suspend-errand.tsx
@@ -3,7 +3,7 @@ import { ErrandStatus } from '@casedata/interfaces/errand-status';
 import { getErrand, isErrandLocked, setErrandStatus } from '@casedata/services/casedata-errand-service';
 import { User } from '@common/interfaces/user';
 import { getToastOptions } from '@common/utils/toast-message-settings';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Button, FormControl, FormLabel, Input, Modal, Textarea, useSnackbar } from '@sk-web-gui/react';
 import dayjs from 'dayjs';
@@ -25,12 +25,10 @@ export interface SuspendFormProps {
 }
 
 export const SuspendErrandComponent: React.FC<{ disabled: boolean }> = ({ disabled }) => {
-  const {
-    municipalityId,
-    errand,
-    setErrand,
-    user,
-  } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const errand = useCasedataStore((s) => s.errand);
+  const setErrand = useCasedataStore((s) => s.setErrand);
+  const user = useUserStore((s) => s.user);
   const [error, setError] = useState(false);
   const toastMessage = useSnackbar();
   const [showModal, setShowModal] = useState(false);

--- a/frontend/src/casedata/hooks/displayPhasePoller.ts
+++ b/frontend/src/casedata/hooks/displayPhasePoller.ts
@@ -1,10 +1,12 @@
 import { IErrand } from '@casedata/interfaces/errand';
 import { UiPhase } from '@casedata/interfaces/errand-phase';
 import { getErrand } from '@casedata/services/casedata-errand-service';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore, useConfigStore } from '@stores/index';
 
 function useDisplayPhasePoller() {
-  const { municipalityId, errand, setErrand } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const errand = useCasedataStore((s) => s.errand);
+  const setErrand = useCasedataStore((s) => s.setErrand);
   const pollDisplayPhase = () => {
     if (!errand) return;
     let displayPhase = errand.extraParameters.find((p) => p.key === 'process.displayPhase')?.values?.[0] as UiPhase;

--- a/frontend/src/casedata/hooks/useSaveCasedataErrand.ts
+++ b/frontend/src/casedata/hooks/useSaveCasedataErrand.ts
@@ -11,7 +11,7 @@ import {
 } from '@casedata/services/casedata-extra-parameters-service';
 import { saveFacilities } from '@casedata/services/casedata-facilities-service';
 import { editStakeholder, removeStakeholder, setAdministrator } from '@casedata/services/casedata-stakeholder-service';
-import { useAppContext } from '@common/contexts/app.context';
+import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
 import { ExtraParameter } from '@common/data-contracts/case-data/data-contracts';
 import { FacilityDTO } from '@common/interfaces/facilities';
 import { getToastOptions } from '@common/utils/toast-message-settings';
@@ -20,7 +20,11 @@ import { useSnackbar } from '@sk-web-gui/react';
 import { useFormContext } from 'react-hook-form';
 
 export function useSaveCasedataErrand(registeringNewErrand: boolean = false) {
-  const { errand, administrators, municipalityId, setErrand, user } = useAppContext();
+  const errand = useCasedataStore((s) => s.errand);
+  const administrators = useUserStore((s) => s.administrators);
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const setErrand = useCasedataStore((s) => s.setErrand);
+  const user = useUserStore((s) => s.user);
   const toastMessage = useSnackbar();
   const { getValues, reset, formState, trigger } = useFormContext<IErrand>();
 

--- a/frontend/src/casedata/services/casedata-errand-service.ts
+++ b/frontend/src/casedata/services/casedata-errand-service.ts
@@ -37,7 +37,7 @@ import { Role } from '@casedata/interfaces/role';
 import { User } from '@common/interfaces/user';
 import { getApplicationEnvironment, isMEX, isPT } from '@common/services/application-service';
 import sanitized from '@common/services/sanitizer-service';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore, useConfigStore } from '@stores/index';
 import { useSnackbar } from '@sk-web-gui/react';
 import dayjs from 'dayjs';
 import { useCallback, useEffect } from 'react';
@@ -392,20 +392,18 @@ export const useErrands = (
   extraParameters?: { [key: string]: string }
 ): ErrandsData => {
   const toastMessage = useSnackbar();
-  const {
-    setIsLoading,
-    setErrands,
-    setNewErrands,
-    setOngoingErrands,
-    setSuspendedErrands,
-    setAssignedErrands,
-    setClosedErrands,
-    errands,
-    newErrands,
-    ongoingErrands,
-    closedErrands,
-    suspendedErrands,
-  } = useAppContext();
+  const setIsLoading = useConfigStore((s) => s.setIsLoading);
+  const setErrands = useCasedataStore((s) => s.setErrands);
+  const setNewErrands = useCasedataStore((s) => s.setNewErrands);
+  const setOngoingErrands = useCasedataStore((s) => s.setOngoingErrands);
+  const setSuspendedErrands = useCasedataStore((s) => s.setSuspendedErrands);
+  const setAssignedErrands = useCasedataStore((s) => s.setAssignedErrands);
+  const setClosedErrands = useCasedataStore((s) => s.setClosedErrands);
+  const errands = useCasedataStore((s) => s.errands);
+  const newErrands = useCasedataStore((s) => s.newErrands);
+  const ongoingErrands = useCasedataStore((s) => s.ongoingErrands);
+  const closedErrands = useCasedataStore((s) => s.closedErrands);
+  const suspendedErrands = useCasedataStore((s) => s.suspendedErrands);
 
   const fetchErrands = useCallback(
     async (page: number = 0) => {

--- a/frontend/src/common/components/commonNestedEmailArrayV2.tsx
+++ b/frontend/src/common/components/commonNestedEmailArrayV2.tsx
@@ -1,6 +1,6 @@
 import { PrettyRole } from '@casedata/interfaces/role';
 import { appConfig } from '@config/appconfig';
-import { AppContextInterface, useAppContext } from '@contexts/app.context';
+import { useMetadataStore } from '@stores/index';
 import { Button, Chip, cx, FormControl, FormErrorMessage, FormLabel, Input, Select } from '@sk-web-gui/react';
 import { ContactChannelType } from '@supportmanagement/services/support-errand-service';
 import { useEffect, useState } from 'react';
@@ -39,7 +39,7 @@ const CommonNestedEmailArrayV2 = ({
   size = 'sm',
 }: CommonNestedEmailArrayV2Props) => {
   const { emails, existingEmail, newEmail } = watch();
-  const { supportMetadata }: AppContextInterface = useAppContext();
+  const supportMetadata = useMetadataStore((s) => s.supportMetadata);
   const { fields, remove, append } = useFieldArray<{ emails: { value: string }[] }>({
     control,
     name: 'emails',

--- a/frontend/src/common/components/dynamic-text-editor.tsx
+++ b/frontend/src/common/components/dynamic-text-editor.tsx
@@ -1,0 +1,8 @@
+import dynamic from 'next/dynamic';
+
+const DynamicTextEditor = dynamic(() => import('@sk-web-gui/text-editor'), {
+  ssr: false,
+  loading: () => <div className="h-[15rem] w-full animate-pulse bg-gray-100 rounded" />,
+});
+
+export default DynamicTextEditor;

--- a/frontend/src/common/components/export/sidebar-export/sidebar-export.component.tsx
+++ b/frontend/src/common/components/export/sidebar-export/sidebar-export.component.tsx
@@ -1,6 +1,6 @@
 import { ErrandStatus } from '@casedata/interfaces/errand-status';
 import { downloadPdf, downloadAttachment, exportSingleErrand } from '@common/services/export-service';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore, useConfigStore } from '@stores/index';
 import { Button, Checkbox, FormControl, useConfirm, useSnackbar } from '@sk-web-gui/react';
 import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -15,7 +15,8 @@ interface ExportParameters {
 }
 
 export const SidebarExport: React.FC = () => {
-  const { municipalityId, errand: contextErrand } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const contextErrand = useCasedataStore((s) => s.errand);
   const errand = contextErrand!;
   const [isExportLoading, setIsExportLoading] = useState<boolean>(false);
   const exportConfirm = useConfirm();

--- a/frontend/src/common/components/facilities/facilities.tsx
+++ b/frontend/src/common/components/facilities/facilities.tsx
@@ -10,7 +10,7 @@ import {
   removeMunicipalityName,
 } from '@common/services/facilities-service';
 import { useDebounceEffect } from '@common/utils/useDebounceEffect';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore, useSupportStore } from '@stores/index';
 import {
   Button,
   FormControl,
@@ -37,13 +37,8 @@ export const Facilities: React.FC<{
   const { setValue, setUnsaved } = props;
   const toastMessage = useSnackbar();
 
-  const {
-    supportErrand,
-    errand,
-  }: {
-    supportErrand: any;
-    errand: any;
-  } = useAppContext();
+  const supportErrand = useSupportStore((s) => s.supportErrand) as any;
+  const errand = useCasedataStore((s) => s.errand) as any;
 
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [searchType, setSearchType] = useState<string>('');
@@ -230,7 +225,9 @@ export const Facilities: React.FC<{
           </Table.Header>
           <Table.Body data-cy={`facility-table`}>
             {realEstates === undefined || realEstates.length === 0 ? (
-              <Table.Column>Inga fastigheter tillagda</Table.Column>
+              <Table.Row>
+                <Table.Column>Inga fastigheter tillagda</Table.Column>
+              </Table.Row>
             ) : (
               <>
                 {realEstates.map((realEstate, index) => (

--- a/frontend/src/common/components/image-cropper/common-image-cropper.component.tsx
+++ b/frontend/src/common/components/image-cropper/common-image-cropper.component.tsx
@@ -3,7 +3,7 @@ import { IErrand } from '@casedata/interfaces/errand';
 import { getImageAspect } from '@casedata/services/casedata-attachment-service';
 import { saveCroppedImage } from '@casedata/services/casedata-errand-service';
 import { useDebounceEffect } from '@common/utils/useDebounceEffect';
-import { useAppContext } from '@contexts/app.context';
+import { useConfigStore } from '@stores/index';
 import { Button, cx, Image } from '@sk-web-gui/react';
 import { useRef, useState } from 'react';
 import ReactCrop, { centerCrop, Crop, makeAspectCrop, PixelCrop } from 'react-image-crop';
@@ -13,7 +13,7 @@ import { ArrowLeft, Check, CircleX } from 'lucide-react';
 export const CommonImageCropper: React.FC<{ errand: IErrand; attachment: Attachment; onClose: () => void }> = (
   props
 ) => {
-  const { municipalityId } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
   const imgRef = useRef<HTMLImageElement>(null);
   const [blob, setBlob] = useState<Blob>();
   const [crop, setCrop] = useState<Crop>();

--- a/frontend/src/common/components/json/widgets/richtext-widget.componant.tsx
+++ b/frontend/src/common/components/json/widgets/richtext-widget.componant.tsx
@@ -1,8 +1,6 @@
 'use client';
 import type { WidgetProps } from '@rjsf/utils';
-import dynamic from 'next/dynamic';
-
-const TextEditor = dynamic(() => import('@sk-web-gui/text-editor'), { ssr: false });
+import TextEditor from '@common/components/dynamic-text-editor';
 
 export function TexteditorWidget(props: WidgetProps) {
   const { value, onChange, options = {}, disabled, readonly } = props;

--- a/frontend/src/common/components/json/widgets/textarea-widget.componant.tsx
+++ b/frontend/src/common/components/json/widgets/textarea-widget.componant.tsx
@@ -1,7 +1,6 @@
 'use client';
 import type { WidgetProps } from '@rjsf/utils';
-import dynamic from 'next/dynamic';
-const TextEditor = dynamic(() => import('@sk-web-gui/text-editor'), { ssr: false });
+import TextEditor from '@common/components/dynamic-text-editor';
 
 export function TextareaWidget({ value, onChange, options }: WidgetProps) {
   const customClassName = (options as any)?.className || 'case-description-editor w-full max-w-[40rem] h-[10rem]';

--- a/frontend/src/common/components/layout/layout.component.tsx
+++ b/frontend/src/common/components/layout/layout.component.tsx
@@ -1,6 +1,6 @@
 import { UiPhaseWrapper } from '@casedata/components/errand/ui-phase/ui-phase-wrapper';
 import { CasedataStatusLabelComponent } from '@casedata/components/ongoing-casedata-errands/components/casedata-status-label.component';
-import { useAppContext } from '@common/contexts/app.context';
+import { useAppContext } from '@contexts/app.context';
 import { getApplicationEnvironment } from '@common/services/application-service';
 import { appConfig } from '@config/appconfig';
 import { Button, CookieConsent, Divider, Link, Logo, PopupMenu, UserMenu, useThemeQueries } from '@sk-web-gui/react';

--- a/frontend/src/common/components/linked-errands-disclosure/linked-errands-disclosure.component.tsx
+++ b/frontend/src/common/components/linked-errands-disclosure/linked-errands-disclosure.component.tsx
@@ -15,7 +15,7 @@ import {
   getTargetRelations,
 } from '@common/services/relations-service';
 import { appConfig } from '@config/appconfig';
-import { useAppContext } from '@contexts/app.context';
+import { useConfigStore } from '@stores/index';
 import { Disclosure, SearchField, Spinner } from '@sk-web-gui/react';
 import { SupportErrand, supportErrandIsEmpty } from '@supportmanagement/services/support-errand-service';
 import { getSupportOwnerStakeholder } from '@supportmanagement/services/support-stakeholder-service';
@@ -27,7 +27,7 @@ import { Link2 } from 'lucide-react';
 export const LinkedErrandsDisclosure: React.FC<{
   errand: SupportErrand | IErrand;
 }> = ({ errand }) => {
-  const { municipalityId } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
   const [isLoadingToErrands, setIsLoadingToErrands] = useState<boolean>(false);
   const [isLoadingFromErrands, setIsLoadingFromErrands] = useState<boolean>(false);
   const [query, setQuery] = useState('');

--- a/frontend/src/common/components/main-errands-sidebar/main-errands-sidebar.component.tsx
+++ b/frontend/src/common/components/main-errands-sidebar/main-errands-sidebar.component.tsx
@@ -6,7 +6,7 @@ import { NotificationsWrapper } from '@common/components/notifications/notificat
 import { getApplicationEnvironment, isMEX } from '@common/services/application-service';
 import { attestationEnabled, contractsEnabled } from '@common/services/feature-flag-service';
 import { appConfig } from '@config/appconfig';
-import { AppContextInterface, useAppContext } from '@contexts/app.context';
+import { useBillingStore, useConfigStore, useUserStore } from '@stores/index';
 import { Badge, Button, cx, Divider, Logo, UserMenu } from '@sk-web-gui/react';
 import { SupportManagementFilterSidebarStatusSelector } from '@supportmanagement/components/supportmanagement-filtering/components/supportmanagement-filter-sidebarstatus-selector.component';
 import {
@@ -30,7 +30,9 @@ export const MainErrandsSidebar: React.FC<{
 }> = ({ showAttestationTable, setShowAttestationTable, showContractTable, setShowContractTable, open, setOpen }) => {
   const suppportManagementFilterForm = useForm<SupportManagementFilter>({ defaultValues: SupportManagementValues });
   const casedataFilterForm = useForm<CaseDataFilter>({ defaultValues: CaseStatusValues });
-  const { user, billingRecords, isLoading }: AppContextInterface = useAppContext();
+  const user = useUserStore((s) => s.user);
+  const billingRecords = useBillingStore((s) => s.billingRecords);
+  const isLoading = useConfigStore((s) => s.isLoading);
   const [showNotifications, setShowNotifications] = useState(false);
   const applicationEnvironment = getApplicationEnvironment();
 

--- a/frontend/src/common/components/notifications/notification-item.tsx
+++ b/frontend/src/common/components/notifications/notification-item.tsx
@@ -6,7 +6,7 @@ import { Notification as CaseDataNotification } from '@common/data-contracts/cas
 import { Notification as SupportNotification } from '@common/data-contracts/supportmanagement/data-contracts';
 import { prettyTime } from '@common/services/helper-service';
 import { appConfig } from '@config/appconfig';
-import { AppContextInterface, useAppContext } from '@contexts/app.context';
+import { useConfigStore, useSupportStore } from '@stores/index';
 import { Checkbox, cx, useSnackbar } from '@sk-web-gui/react';
 import {
   acknowledgeSupportNotification,
@@ -29,7 +29,8 @@ export const NotificationItem: React.FC<NotificationItemProps> = ({
   onToggleSelect,
   showCheckbox = false,
 }) => {
-  const { municipalityId, setNotifications }: AppContextInterface = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const setNotifications = useSupportStore((s) => s.setNotifications);
   const toastMessage = useSnackbar();
 
   const handleAcknowledge = async () => {

--- a/frontend/src/common/components/notifications/notifications-bell.tsx
+++ b/frontend/src/common/components/notifications/notifications-bell.tsx
@@ -1,10 +1,11 @@
-import { AppContextInterface, useAppContext } from '@contexts/app.context';
+import { useSupportStore, useUserStore } from '@stores/index';
 import { Badge, Button } from '@sk-web-gui/react';
 import { getFilteredNotifications } from './notification-utils';
 import { Bell } from 'lucide-react';
 
 export const NotificationsBell = (props: { toggleShow: () => void }) => {
-  const { notifications, user } = useAppContext();
+  const notifications = useSupportStore((s) => s.notifications);
+  const user = useUserStore((s) => s.user);
   const filteredNotifications = getFilteredNotifications(notifications, user?.username || '');
   const newCount = filteredNotifications.filter((n) => !n.acknowledged).length;
 

--- a/frontend/src/common/components/notifications/notifications-wrapper.tsx
+++ b/frontend/src/common/components/notifications/notifications-wrapper.tsx
@@ -6,7 +6,7 @@ import { Notification as CaseDataNotification } from '@common/data-contracts/cas
 import { Notification as SupportNotification } from '@common/data-contracts/supportmanagement/data-contracts';
 import { sortBy } from '@common/services/helper-service';
 import { appConfig } from '@config/appconfig';
-import { AppContextInterface, useAppContext } from '@contexts/app.context';
+import { useConfigStore, useSupportStore, useUserStore } from '@stores/index';
 import { Button, Checkbox, Divider, cx, useSnackbar } from '@sk-web-gui/react';
 import {
   acknowledgeSupportNotification,
@@ -21,8 +21,10 @@ export const NotificationsWrapper: React.FC<{ show: boolean; setShow: (arg0: boo
   show,
   setShow,
 }) => {
-  const { municipalityId, notifications, setNotifications }: AppContextInterface = useAppContext();
-  const { user } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const notifications = useSupportStore((s) => s.notifications);
+  const setNotifications = useSupportStore((s) => s.setNotifications);
+  const user = useUserStore((s) => s.user);
   const toastMessage = useSnackbar();
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [isAcknowledging, setIsAcknowledging] = useState(false);

--- a/frontend/src/common/components/sidebar/sidebar.component.tsx
+++ b/frontend/src/common/components/sidebar/sidebar.component.tsx
@@ -1,7 +1,7 @@
 import iconMap from '@common/components/lucide-icon-map/lucide-icon-map.component';
 import { isPT } from '@common/services/application-service';
 import { appConfig } from '@config/appconfig';
-import { useAppContext } from '@contexts/app.context';
+import { useCasedataStore, useSupportStore } from '@stores/index';
 import { Badge, Button, cx, useGui } from '@sk-web-gui/react';
 import { supportErrandIsEmpty } from '@supportmanagement/services/support-errand-service';
 import { ChevronsLeft, ChevronsRight } from 'lucide-react';
@@ -37,7 +37,9 @@ export const Sidebar: React.FC<{
   const gui = useGui();
   const isLg = useMediaQuery(`screen and (min-width: ${gui.theme.screens.lg})`);
 
-  const { supportErrand, notesCount, serviceNotesCount } = useAppContext();
+  const supportErrand = useSupportStore((s) => s.supportErrand);
+  const notesCount = useCasedataStore((s) => s.notesCount);
+  const serviceNotesCount = useCasedataStore((s) => s.serviceNotesCount);
 
   const badgeCounts: Record<string, number> = {
     'Kommentarer': notesCount,

--- a/frontend/src/common/services/api-service.ts
+++ b/frontend/src/common/services/api-service.ts
@@ -1,6 +1,5 @@
 'use client';
 
-import { appURL } from '@common/utils/app-url';
 import axios, { AxiosError } from 'axios';
 
 export interface Data {
@@ -13,11 +12,13 @@ export interface ApiResponse<T = unknown> {
 }
 
 export const handleError = (error: AxiosError<ApiResponse>) => {
-  //TODO: Refactor to be more compliant with NextJS routing standards
-  if (error?.response?.status === 401 && !window?.location.pathname.includes('login')) {
-    window.location.href = `${appURL()}/login?path=${window.location.pathname}&failMessage=${
-      error.response.data.message
-    }`;
+  if (globalThis.window !== undefined) {
+    if (error?.response?.status === 401 && !globalThis.window.location.pathname.includes('login')) {
+      const basePath = process.env.NEXT_PUBLIC_BASEPATH || '';
+      globalThis.window.location.href = `${globalThis.window.location.origin}${basePath}/login?path=${globalThis.window.location.pathname}&failMessage=${
+        error.response.data.message
+      }`;
+    }
   }
 
   throw error;

--- a/frontend/src/common/services/user-service.ts
+++ b/frontend/src/common/services/user-service.ts
@@ -1,5 +1,4 @@
 import { User } from '@common/interfaces/user';
-import dayjs from 'dayjs';
 import { ApiResponse, apiService } from './api-service';
 
 export const emptyUser: User = {
@@ -9,7 +8,7 @@ export const emptyUser: User = {
   email: '',
   username: '',
   userSettings: {
-    readNotificationsClearedDate: dayjs().toISOString(),
+    readNotificationsClearedDate: '',
   },
   permissions: {
     canEditCasedata: false,

--- a/frontend/src/stores/billing-store.ts
+++ b/frontend/src/stores/billing-store.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand';
+import { CPageBillingRecord } from 'src/data-contracts/backend/data-contracts';
+
+interface BillingState {
+  billingRecords: CPageBillingRecord;
+}
+
+interface BillingActions {
+  setBillingRecords: (records: CPageBillingRecord) => void;
+  reset: () => void;
+}
+
+type BillingStore = BillingState & BillingActions;
+
+const initialState: BillingState = {
+  billingRecords: { content: [] },
+};
+
+export const useBillingStore = create<BillingStore>((set) => ({
+  ...initialState,
+  setBillingRecords: (billingRecords) => set({ billingRecords }),
+  reset: () => set(initialState),
+}));

--- a/frontend/src/stores/casedata-store.ts
+++ b/frontend/src/stores/casedata-store.ts
@@ -1,0 +1,90 @@
+import { create } from 'zustand';
+import { Asset } from '@casedata/interfaces/asset';
+import { ErrandsData, IErrand } from '@casedata/interfaces/errand';
+import { UiPhase } from '@casedata/interfaces/errand-phase';
+import { MessageNode } from '@casedata/services/casedata-message-service';
+
+interface CasedataState {
+  errand: IErrand | undefined;
+  errands: ErrandsData;
+  messages: MessageNode[] | undefined;
+  messageTree: MessageNode[] | undefined;
+  conversation: MessageNode[] | undefined;
+  conversationTree: MessageNode[] | undefined;
+  assets: Asset[] | undefined;
+  selectedErrandStatuses: string[];
+  sidebarLabel: string;
+  newErrands: number | null;
+  ongoingErrands: number | null;
+  suspendedErrands: number | null;
+  assignedErrands: number | null;
+  closedErrands: number | null;
+  uiPhase: UiPhase | undefined;
+  notesCount: number;
+  serviceNotesCount: number;
+}
+
+interface CasedataActions {
+  setErrand: (errand: IErrand | undefined) => void;
+  setErrands: (errands: ErrandsData) => void;
+  setMessages: (messages: MessageNode[]) => void;
+  setMessageTree: (messages: MessageNode[]) => void;
+  setConversation: (conversation: MessageNode[]) => void;
+  setConversationTree: (conversationTree: MessageNode[]) => void;
+  setAssets: (assets: Asset[]) => void;
+  setSelectedErrandStatuses: (statuses: string[]) => void;
+  setSidebarLabel: (label: string) => void;
+  setNewErrands: (count: number | null) => void;
+  setOngoingErrands: (count: number | null) => void;
+  setSuspendedErrands: (count: number | null) => void;
+  setAssignedErrands: (count: number | null) => void;
+  setClosedErrands: (count: number | null) => void;
+  setUiPhase: (phase: UiPhase) => void;
+  setNotesCount: (count: number) => void;
+  setServiceNotesCount: (count: number) => void;
+  reset: () => void;
+}
+
+type CasedataStore = CasedataState & CasedataActions;
+
+const initialState: CasedataState = {
+  errand: undefined,
+  errands: { errands: [], labels: [] },
+  messages: undefined,
+  messageTree: undefined,
+  conversation: undefined,
+  conversationTree: undefined,
+  assets: undefined,
+  selectedErrandStatuses: ['ArendeInkommit'],
+  sidebarLabel: '',
+  newErrands: 0,
+  ongoingErrands: 0,
+  suspendedErrands: 0,
+  assignedErrands: 0,
+  closedErrands: 0,
+  uiPhase: undefined,
+  notesCount: 0,
+  serviceNotesCount: 0,
+};
+
+export const useCasedataStore = create<CasedataStore>((set) => ({
+  ...initialState,
+  setErrand: (errand) => set({ errand }),
+  setErrands: (errands) => set({ errands }),
+  setMessages: (messages) => set({ messages }),
+  setMessageTree: (messageTree) => set({ messageTree }),
+  setConversation: (conversation) => set({ conversation }),
+  setConversationTree: (conversationTree) => set({ conversationTree }),
+  setAssets: (assets) => set({ assets }),
+  setSelectedErrandStatuses: (selectedErrandStatuses) => set({ selectedErrandStatuses }),
+  setSidebarLabel: (sidebarLabel) => set({ sidebarLabel }),
+  setNewErrands: (newErrands) => set({ newErrands }),
+  setOngoingErrands: (ongoingErrands) => set({ ongoingErrands }),
+  setSuspendedErrands: (suspendedErrands) => set({ suspendedErrands }),
+  setAssignedErrands: (assignedErrands) => set({ assignedErrands }),
+  setClosedErrands: (closedErrands) => set({ closedErrands }),
+  setUiPhase: (uiPhase) => set({ uiPhase }),
+  setNotesCount: (notesCount) => set({ notesCount }),
+  setServiceNotesCount: (serviceNotesCount) => set({ serviceNotesCount }),
+  reset: () => set(initialState),
+}));

--- a/frontend/src/stores/config-store.ts
+++ b/frontend/src/stores/config-store.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+
+interface ConfigState {
+  municipalityId: string;
+  isLoading: boolean;
+  isCookieConsentOpen: boolean;
+}
+
+interface ConfigActions {
+  setMunicipalityId: (municipalityId: string) => void;
+  setIsLoading: (isLoading: boolean) => void;
+  setIsCookieConsentOpen: (isOpen: boolean) => void;
+  reset: () => void;
+}
+
+type ConfigStore = ConfigState & ConfigActions;
+
+const initialState: ConfigState = {
+  municipalityId: '',
+  isLoading: false,
+  isCookieConsentOpen: true,
+};
+
+export const useConfigStore = create<ConfigStore>((set) => ({
+  ...initialState,
+  setMunicipalityId: (municipalityId) => set({ municipalityId }),
+  setIsLoading: (isLoading) => set({ isLoading }),
+  setIsCookieConsentOpen: (isCookieConsentOpen) => set({ isCookieConsentOpen }),
+  reset: () => set(initialState),
+}));

--- a/frontend/src/stores/feature-flag-store.ts
+++ b/frontend/src/stores/feature-flag-store.ts
@@ -1,0 +1,107 @@
+import { create } from 'zustand';
+import { FeatureFlagDto } from 'src/data-contracts/backend/data-contracts';
+
+interface AppConfigFeatures {
+  useErrandExport: boolean;
+  useThreeLevelCategorization: boolean;
+  useTwoLevelCategorization: boolean;
+  useExplanationOfTheCause: boolean;
+  useReasonForContact: boolean;
+  useBusinessCase: boolean;
+  useBilling: boolean;
+  useContracts: boolean;
+  useFacilities: boolean;
+  useExtraInformationStakeholders: boolean;
+  useDepartmentEscalation: boolean;
+  useEmployeeSearch: boolean;
+  useOrganizationStakeholders: boolean;
+  useRecruitment: boolean;
+  useEmailContactChannel: boolean;
+  useSmsContactChannel: boolean;
+  useStakeholderRelations: boolean;
+  useRolesForStakeholders: boolean;
+  useDetailsTab: boolean;
+  useEscalation: boolean;
+  useRequireContactChannel: boolean;
+  useRelations: boolean;
+  useMyPages: boolean;
+  useUiPhases: boolean;
+  useClosingMessageCheckbox: boolean;
+  useMultipleContactChannels: boolean;
+  useClosedAsDefaultResolution: boolean;
+}
+
+interface FeatureFlagStore {
+  isCaseData: boolean;
+  isSupportManagement: boolean;
+  reopenSupportErrandLimit: string;
+  features: AppConfigFeatures;
+  applyFlags: (flags: FeatureFlagDto[]) => void;
+}
+
+const defaultFeatures: AppConfigFeatures = {
+  useErrandExport: process.env.NEXT_PUBLIC_USE_ERRAND_EXPORT === 'true',
+  useThreeLevelCategorization: process.env.NEXT_PUBLIC_USE_THREE_LEVEL_CATEGORIZATION === 'true',
+  useTwoLevelCategorization: process.env.NEXT_PUBLIC_USE_TWO_LEVEL_CATEGORIZATION === 'true',
+  useExplanationOfTheCause: process.env.NEXT_PUBLIC_USE_EXPLANATION_OF_THE_CAUSE === 'true',
+  useReasonForContact: process.env.NEXT_PUBLIC_USE_REASON_FOR_CONTACT === 'true',
+  useBusinessCase: process.env.NEXT_PUBLIC_USE_BUSINESS_CASE === 'true',
+  useBilling: process.env.NEXT_PUBLIC_USE_BILLING === 'true',
+  useContracts: process.env.NEXT_PUBLIC_USE_CONTRACTS === 'true',
+  useFacilities: process.env.NEXT_PUBLIC_USE_FACILITIES === 'true',
+  useExtraInformationStakeholders: process.env.NEXT_PUBLIC_USE_EXTRA_INFORMATION_STAKEHOLDERS === 'true',
+  useDepartmentEscalation: process.env.NEXT_PUBLIC_USE_DEPARTMENT_ESCALATION === 'true',
+  useEmployeeSearch: process.env.NEXT_PUBLIC_USE_EMPLOYEE_SEARCH === 'true',
+  useOrganizationStakeholders: process.env.NEXT_PUBLIC_USE_ORGANIZATION_STAKEHOLDER === 'true',
+  useRecruitment: process.env.NEXT_PUBLIC_USE_RECRUITMENT === 'true',
+  useEmailContactChannel: process.env.NEXT_PUBLIC_USE_EMAIL_CONTACT_CHANNEL === 'true',
+  useSmsContactChannel: process.env.NEXT_PUBLIC_USE_SMS_CONTACT_CHANNEL === 'true',
+  useStakeholderRelations: process.env.NEXT_PUBLIC_USE_STAKEHOLDER_RELATIONS === 'true',
+  useRolesForStakeholders: process.env.NEXT_PUBLIC_USE_ROLES_FOR_STAKEHOLDERS === 'true',
+  useDetailsTab: process.env.NEXT_PUBLIC_USE_DETAILS_TAB === 'true',
+  useEscalation: process.env.NEXT_PUBLIC_USE_ESCALATION === 'true',
+  useRequireContactChannel: process.env.NEXT_PUBLIC_USE_REQUIRE_CONTACT_CHANNEL === 'true',
+  useRelations: process.env.NEXT_PUBLIC_USE_RELATIONS === 'true',
+  useMyPages: process.env.NEXT_PUBLIC_USE_MY_PAGES === 'true',
+  useUiPhases: process.env.NEXT_PUBLIC_USE_UI_PHASES === 'true',
+  useClosingMessageCheckbox: process.env.NEXT_PUBLIC_USE_CLOSING_MESSAGE_CHECKBOX === 'true',
+  useMultipleContactChannels: process.env.NEXT_PUBLIC_USE_MULTIPLE_CONTACT_CHANNELS === 'true',
+  useClosedAsDefaultResolution: process.env.NEXT_PUBLIC_USE_CLOSED_AS_DEFAULT_RESOLUTION === 'true',
+};
+
+export const useFeatureFlagStore = create<FeatureFlagStore>((set) => ({
+  isCaseData: process.env.NEXT_PUBLIC_IS_CASEDATA === 'true',
+  isSupportManagement: process.env.NEXT_PUBLIC_IS_SUPPORTMANAGEMENT === 'true',
+  reopenSupportErrandLimit: process.env.NEXT_PUBLIC_REOPEN_SUPPORT_ERRAND_LIMIT || '30',
+  features: defaultFeatures,
+  applyFlags: (flags) => {
+    if (!flags || flags.length === 0) return;
+
+    const resetFeatures: AppConfigFeatures = Object.fromEntries(
+      Object.keys(defaultFeatures).map((key) => [key, false])
+    ) as unknown as AppConfigFeatures;
+
+    let isCaseData = false;
+    let isSupportManagement = false;
+    let reopenSupportErrandLimit = '30';
+
+    flags.forEach((flag) => {
+      if (flag.name === 'isCaseData') {
+        isCaseData = flag.enabled;
+      } else if (flag.name === 'isSupportManagement') {
+        isSupportManagement = flag.enabled;
+      } else if (flag.name === 'reopenSupportErrandLimit' && flag.enabled) {
+        reopenSupportErrandLimit = flag.value ?? '30';
+      } else if (flag.name in resetFeatures) {
+        (resetFeatures as any)[flag.name] = flag.enabled;
+      }
+    });
+
+    set({
+      isCaseData,
+      isSupportManagement,
+      reopenSupportErrandLimit,
+      features: resetFeatures,
+    });
+  },
+}));

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -1,0 +1,7 @@
+export { useUserStore } from './user-store';
+export { useConfigStore } from './config-store';
+export { useCasedataStore } from './casedata-store';
+export { useSupportStore } from './support-store';
+export { useMetadataStore } from './metadata-store';
+export { useBillingStore } from './billing-store';
+export { useFeatureFlagStore } from './feature-flag-store';

--- a/frontend/src/stores/metadata-store.ts
+++ b/frontend/src/stores/metadata-store.ts
@@ -1,0 +1,38 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { SupportMetadata } from '@supportmanagement/services/support-metadata-service';
+
+const STALE_TIME_MS = 30 * 60 * 1000;
+
+interface MetadataState {
+  supportMetadata: SupportMetadata | undefined;
+  lastFetched: number | null;
+}
+
+interface MetadataActions {
+  setSupportMetadata: (metadata: SupportMetadata) => void;
+  isStale: () => boolean;
+  clear: () => void;
+}
+
+type MetadataStore = MetadataState & MetadataActions;
+
+export const useMetadataStore = create(
+  persist<MetadataStore>(
+    (set, get) => ({
+      supportMetadata: undefined,
+      lastFetched: null,
+      setSupportMetadata: (metadata) =>
+        set({ supportMetadata: metadata, lastFetched: Date.now() }),
+      isStale: () => {
+        const { lastFetched } = get();
+        if (!lastFetched) return true;
+        return Date.now() - lastFetched > STALE_TIME_MS;
+      },
+      clear: () => set({ supportMetadata: undefined, lastFetched: null }),
+    }),
+    {
+      name: `${process.env.NEXT_PUBLIC_APPLICATION || 'app'}-metadata-store`,
+    }
+  )
+);

--- a/frontend/src/stores/support-store.ts
+++ b/frontend/src/stores/support-store.ts
@@ -1,0 +1,79 @@
+import { create } from 'zustand';
+import { Notification as SupportNotification } from '@common/data-contracts/supportmanagement/data-contracts';
+import { Notification as CaseDataNotification } from '@common/data-contracts/case-data/data-contracts';
+import { SupportAttachment } from '@supportmanagement/services/support-attachment-service';
+import {
+  Status,
+  SupportErrand,
+  SupportErrandsData,
+  SupportStakeholderFormModel,
+} from '@supportmanagement/services/support-errand-service';
+
+interface SupportState {
+  supportErrand: SupportErrand | undefined;
+  supportErrands: SupportErrandsData;
+  supportAttachments: SupportAttachment[] | undefined;
+  selectedSupportErrandStatuses: Status[];
+  stakeholderContacts: SupportStakeholderFormModel[];
+  stakeholderCustomers: SupportStakeholderFormModel[];
+  notifications: (SupportNotification | CaseDataNotification)[];
+  newSupportErrands: number | null;
+  ongoingSupportErrands: number | null;
+  suspendedSupportErrands: number | null;
+  assignedSupportErrands: number | null;
+  solvedSupportErrands: number | null;
+  notesCount: number;
+}
+
+interface SupportActions {
+  setSupportErrand: (errand: SupportErrand | undefined) => void;
+  setSupportErrands: (errands: SupportErrandsData) => void;
+  setSupportAttachments: (attachments: SupportAttachment[]) => void;
+  setSelectedSupportErrandStatuses: (statuses: Status[]) => void;
+  setStakeholderContacts: (contacts: SupportStakeholderFormModel[]) => void;
+  setStakeholderCustomers: (customers: SupportStakeholderFormModel[]) => void;
+  setNotifications: (notifications: (SupportNotification | CaseDataNotification)[]) => void;
+  setNewSupportErrands: (count: number | null) => void;
+  setOngoingSupportErrands: (count: number | null) => void;
+  setSuspendedSupportErrands: (count: number | null) => void;
+  setAssignedSupportErrands: (count: number | null) => void;
+  setSolvedSupportErrands: (count: number | null) => void;
+  setNotesCount: (count: number) => void;
+  reset: () => void;
+}
+
+type SupportStore = SupportState & SupportActions;
+
+const initialState: SupportState = {
+  supportErrand: undefined,
+  supportErrands: { errands: [], labels: [] },
+  supportAttachments: undefined,
+  selectedSupportErrandStatuses: [Status.NEW],
+  stakeholderContacts: [],
+  stakeholderCustomers: [],
+  notifications: [],
+  newSupportErrands: 0,
+  ongoingSupportErrands: 0,
+  suspendedSupportErrands: 0,
+  assignedSupportErrands: 0,
+  solvedSupportErrands: 0,
+  notesCount: 0,
+};
+
+export const useSupportStore = create<SupportStore>((set) => ({
+  ...initialState,
+  setSupportErrand: (supportErrand) => set({ supportErrand }),
+  setSupportErrands: (supportErrands) => set({ supportErrands }),
+  setSupportAttachments: (supportAttachments) => set({ supportAttachments }),
+  setSelectedSupportErrandStatuses: (selectedSupportErrandStatuses) => set({ selectedSupportErrandStatuses }),
+  setStakeholderContacts: (stakeholderContacts) => set({ stakeholderContacts }),
+  setStakeholderCustomers: (stakeholderCustomers) => set({ stakeholderCustomers }),
+  setNotifications: (notifications) => set({ notifications }),
+  setNewSupportErrands: (newSupportErrands) => set({ newSupportErrands }),
+  setOngoingSupportErrands: (ongoingSupportErrands) => set({ ongoingSupportErrands }),
+  setSuspendedSupportErrands: (suspendedSupportErrands) => set({ suspendedSupportErrands }),
+  setAssignedSupportErrands: (assignedSupportErrands) => set({ assignedSupportErrands }),
+  setSolvedSupportErrands: (solvedSupportErrands) => set({ solvedSupportErrands }),
+  setNotesCount: (notesCount) => set({ notesCount }),
+  reset: () => set(initialState),
+}));

--- a/frontend/src/stores/user-store.ts
+++ b/frontend/src/stores/user-store.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand';
+import { User } from '@common/interfaces/user';
+import { Admin, emptyUser } from '@common/services/user-service';
+
+interface UserState {
+  user: User;
+  avatar: string;
+  administrators: Admin[];
+}
+
+interface UserActions {
+  setUser: (user: User) => void;
+  setAvatar: (avatar: string) => void;
+  setAdministrators: (admins: Admin[]) => void;
+  reset: () => void;
+}
+
+type UserStore = UserState & UserActions;
+
+const initialState: UserState = {
+  user: emptyUser,
+  avatar: '',
+  administrators: [],
+};
+
+export const useUserStore = create<UserStore>((set) => ({
+  ...initialState,
+  setUser: (user) => set({ user }),
+  setAvatar: (avatar) => set({ avatar }),
+  setAdministrators: (administrators) => set({ administrators }),
+  reset: () => set(initialState),
+}));

--- a/frontend/src/styles/ange-symbol.tsx
+++ b/frontend/src/styles/ange-symbol.tsx
@@ -8,7 +8,7 @@ export const AngeSymbol: React.FC<React.SVGProps<SVGSVGElement>> = (props) => {
         viewBox="0 0 93.45 103.83"
         width="85%"
         height="85%"
-        style={{ marginTop: '6px' }}
+        className="mt-[6px]"
         aria-label="Ånge kommun symbol"
         {...props}
       >

--- a/frontend/src/supportmanagement/components/attestation-tab/attestation-invoice-form.component.tsx
+++ b/frontend/src/supportmanagement/components/attestation-tab/attestation-invoice-form.component.tsx
@@ -1,5 +1,4 @@
-import { useAppContext } from '@common/contexts/app.context';
-import { User } from '@common/interfaces/user';
+import { useConfigStore, useUserStore } from '@stores/index';
 import { maybe, prettyTime } from '@common/services/helper-service';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Button, Divider, FormErrorMessage, Select, Table, useSnackbar } from '@sk-web-gui/react';
@@ -25,13 +24,8 @@ export const AttestationInvoiceForm: React.FC<{
   update: (recordId: string) => void;
   selectedrecord: CBillingRecord;
 }> = (props) => {
-  const {
-    municipalityId,
-    user,
-  }: {
-    municipalityId: string;
-    user: User;
-  } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const user = useUserStore((s) => s.user);
 
   const { selectedrecord: selectedRecord } = props;
 

--- a/frontend/src/supportmanagement/components/attestation-tab/attestation-tab.component.tsx
+++ b/frontend/src/supportmanagement/components/attestation-tab/attestation-tab.component.tsx
@@ -1,7 +1,7 @@
 import { DetailPanelWrapper } from '@common/components/detail-panel-wrapper/detail-panel-wrapper.component';
-import { getMe } from '@common/services/user-service';
+import { useUserQuery } from '@common/services/use-user-query';
 import { useDebounceEffect } from '@common/utils/useDebounceEffect';
-import { useAppContext } from '@contexts/app.context';
+import { useBillingStore, useConfigStore, useSupportStore, useUserStore } from '@stores/index';
 import { AttestationInvoiceForm } from '@supportmanagement/components/attestation-tab/attestation-invoice-form.component';
 import AttestationsFilteringComponent, {
   AttestationFilter,
@@ -37,7 +37,10 @@ export const AttestationTab = () => {
   const [showSelectedRecord, setShowSelectedRecord] = useState<boolean>(false);
   const [selectedRecord, setSelectedRecord] = useState<CBillingRecord | undefined>(undefined);
 
-  const { setSupportErrand, setBillingRecords, administrators, municipalityId } = useAppContext();
+  const setSupportErrand = useSupportStore((s) => s.setSupportErrand);
+  const setBillingRecords = useBillingStore((s) => s.setBillingRecords);
+  const administrators = useUserStore((s) => s.administrators);
+  const municipalityId = useConfigStore((s) => s.municipalityId);
 
   const startdate = watchFilter('startdate');
   const enddate = watchFilter('enddate');
@@ -60,7 +63,15 @@ export const AttestationTab = () => {
     });
   };
   const router = useRouter();
-  const { user, setUser } = useAppContext();
+  const user = useUserStore((s) => s.user);
+  const setUser = useUserStore((s) => s.setUser);
+  const { data: userData } = useUserQuery();
+
+  useEffect(() => {
+    if (userData) {
+      setUser(userData);
+    }
+  }, [userData]);
 
   useEffect(() => {
     const filterdata = store.get('attestationFilter');
@@ -104,11 +115,6 @@ export const AttestationTab = () => {
     //       the browser will automatically scroll
     //       down to the button.
     setInitialFocus();
-    getMe()
-      .then((user) => {
-        setUser(user);
-      })
-      .catch(() => {});
     setSupportErrand(undefined as unknown as any);
     getBillingRecords(municipalityId);
     //eslint-disable-next-line

--- a/frontend/src/supportmanagement/components/attestation-tab/components/attestation-filtering/attestations-filtering.component.tsx
+++ b/frontend/src/supportmanagement/components/attestation-tab/components/attestation-filtering/attestations-filtering.component.tsx
@@ -1,5 +1,5 @@
 import { Admin } from '@common/services/user-service';
-import { useAppContext } from '@contexts/app.context';
+import { useUserStore } from '@stores/index';
 import { Button, cx, Link } from '@sk-web-gui/react';
 import {
   AttestationDatesFilter,
@@ -32,7 +32,7 @@ export const AttestationsFilteringComponent: React.FC<{
   ownerFilter?: boolean;
   administrators?: Admin[];
 }> = ({ ownerFilterHandler = () => false, ownerFilter, administrators = [] }) => {
-  const { user } = useAppContext();
+  const user = useUserStore((s) => s.user);
   const [show, setShow] = useState<boolean>(true);
   const [showCreateInvoice, setShowCreateInvoice] = useState<boolean>(false);
 

--- a/frontend/src/supportmanagement/components/attestation-tab/components/attestations-table.component.tsx
+++ b/frontend/src/supportmanagement/components/attestation-tab/components/attestations-table.component.tsx
@@ -1,5 +1,5 @@
 import { formatCurrency, maybe, prettyTime } from '@common/services/helper-service';
-import { AppContextInterface, useAppContext } from '@contexts/app.context';
+import { useBillingStore, useConfigStore } from '@stores/index';
 import { Button, Input, Pagination, Select, Table } from '@sk-web-gui/react';
 import { SortMode } from '@sk-web-gui/table';
 import { attestationLabels, billingrecordStatusToLabel } from '@supportmanagement/services/support-billing-service';
@@ -25,7 +25,8 @@ export const AttestationsTable: React.FC<{
   setShowSelectedRecord: (show: boolean) => void;
 }> = ({ setSelectedRecord, setShowSelectedRecord }) => {
   const { watch, setValue, register } = useFormContext<AttestationTableForm>();
-  const { municipalityId, billingRecords }: AppContextInterface = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const billingRecords = useBillingStore((s) => s.billingRecords);
   const [rowHeight, setRowHeight] = useState<string>('normal');
   const sortOrder = watch('sortOrder');
   const sortColumn = watch('sortColumn');

--- a/frontend/src/supportmanagement/components/billing/billing-form.component.tsx
+++ b/frontend/src/supportmanagement/components/billing/billing-form.component.tsx
@@ -17,11 +17,9 @@ const BillingForm: React.FC<{
   setIsLoading: (isLoading: boolean) => void;
 }> = ({ resetManager, handleChange, setIsLoading }) => {
   const {
-    control,
     register,
     getValues,
     setValue,
-    trigger,
     watch,
     formState: { errors },
   } = useFormContext<CBillingRecord>();
@@ -37,6 +35,7 @@ const BillingForm: React.FC<{
           size="md"
           placeholder={'0'}
           onChange={(e) => {
+            setValue('invoice.description', e.target.value, { shouldDirty: true });
             const selectedInvoiceType = invoiceSettings.invoiceTypes.find((t) => t.invoiceType === e.target.value);
             const selectedDescription = e.target.value;
             const customerId = getValues().invoice.customerId;
@@ -49,15 +48,12 @@ const BillingForm: React.FC<{
               ? selectedInvoiceType?.internal.accountInformation.activity
               : selectedInvoiceType?.external.accountInformation.activity;
             handleChange(selectedDescription, customerId, defaultQuantity, costcenter!, activity!);
-            trigger();
           }}
           readOnly={getValues().status !== 'NEW'}
         >
           <Select.Option value={''}>Välj faktureringstyp</Select.Option>
           {invoiceSettings.invoiceTypes
             .filter((i) => {
-              // Manager is either INTERNAL or EXTERNAL. Only show invoice types that
-              // have invoice rows for the current manager type
               return (
                 (getValues().type === 'INTERNAL' && i?.internal?.invoiceRows?.length > 0) ||
                 (getValues().type === 'EXTERNAL' && i?.external?.invoiceRows?.length > 0)

--- a/frontend/src/supportmanagement/components/new-contacts/support-contact-modal.component.tsx
+++ b/frontend/src/supportmanagement/components/new-contacts/support-contact-modal.component.tsx
@@ -2,7 +2,7 @@ import CommonNestedEmailArrayV2 from '@common/components/commonNestedEmailArrayV
 import CommonNestedPhoneArrayV2 from '@common/components/commonNestedPhoneArrayV2';
 import { AddressResult } from '@common/services/adress-service';
 import { appConfig } from '@config/appconfig';
-import { useAppContext } from '@contexts/app.context';
+import { useMetadataStore, useSupportStore } from '@stores/index';
 import { Button, cx, FormControl, FormErrorMessage, FormLabel, Input, Modal, Select } from '@sk-web-gui/react';
 import { ExternalIdType, SupportStakeholderFormModel } from '@supportmanagement/services/support-errand-service';
 import { UseFieldArrayReplace, UseFormReturn } from 'react-hook-form';
@@ -45,7 +45,8 @@ export const SupportContactModal: React.FC<SupportContactModalProps> = ({
   setSearchResultArray,
   replacePhonenumbers,
 }) => {
-  const { supportMetadata, supportErrand } = useAppContext();
+  const supportMetadata = useMetadataStore((s) => s.supportMetadata);
+  const supportErrand = useSupportStore((s) => s.supportErrand);
 
   const username = form.watch('username');
   const personNumber = form.watch('personNumber');

--- a/frontend/src/supportmanagement/components/new-contacts/support-contact-search-mode-selector.component.tsx
+++ b/frontend/src/supportmanagement/components/new-contacts/support-contact-search-mode-selector.component.tsx
@@ -113,40 +113,40 @@ export const SupportContactSearchModeSelector: React.FC<SupportContactSearchMode
           </RadioButton>
 
           {appConfig.features.useOrganizationStakeholders ? (
-            <>
-              <RadioButton
-                data-cy={`search-enterprise-${inName}-${contact.role}`}
-                size="sm"
-                className="mr-sm"
-                name={`stakeholderType-${id}`}
-                id={`searchEnterprise-${id}-${inName}`}
-                value={'ENTERPRISE'}
-                checked={searchMode === 'enterprise'}
-                onChange={() => {
-                  setSearchMode('enterprise');
-                  form.setValue(`externalIdType`, ExternalIdType.COMPANY);
-                  clearFields('ORGANIZATION');
-                }}
-              >
-                Företag
-              </RadioButton>
-              <RadioButton
-                data-cy={`search-organization-${inName}-${contact.role}`}
-                size="sm"
-                className="mr-sm"
-                name={`stakeholderType-${id}`}
-                id={`searchOrganization-${id}-${inName}`}
-                value={'ORGANIZATION'}
-                checked={searchMode === 'organization'}
-                onChange={() => {
-                  setSearchMode('organization');
-                  form.setValue(`externalIdType`, ExternalIdType.COMPANY);
-                  clearFields('ORGANIZATION');
-                }}
-              >
-                Förening
-              </RadioButton>
-            </>
+            <RadioButton
+              data-cy={`search-enterprise-${inName}-${contact.role}`}
+              size="sm"
+              className="mr-sm"
+              name={`stakeholderType-${id}`}
+              id={`searchEnterprise-${id}-${inName}`}
+              value={'ENTERPRISE'}
+              checked={searchMode === 'enterprise'}
+              onChange={() => {
+                setSearchMode('enterprise');
+                form.setValue(`externalIdType`, ExternalIdType.COMPANY);
+                clearFields('ORGANIZATION');
+              }}
+            >
+              Företag
+            </RadioButton>
+          ) : null}
+          {appConfig.features.useOrganizationStakeholders ? (
+            <RadioButton
+              data-cy={`search-organization-${inName}-${contact.role}`}
+              size="sm"
+              className="mr-sm"
+              name={`stakeholderType-${id}`}
+              id={`searchOrganization-${id}-${inName}`}
+              value={'ORGANIZATION'}
+              checked={searchMode === 'organization'}
+              onChange={() => {
+                setSearchMode('organization');
+                form.setValue(`externalIdType`, ExternalIdType.COMPANY);
+                clearFields('ORGANIZATION');
+              }}
+            >
+              Förening
+            </RadioButton>
           ) : null}
         </RadioButton.Group>
       </div>

--- a/frontend/src/supportmanagement/components/new-contacts/support-contacts.component.tsx
+++ b/frontend/src/supportmanagement/components/new-contacts/support-contacts.component.tsx
@@ -1,7 +1,5 @@
-import { useAppContext } from '@common/contexts/app.context';
-import { User } from '@common/interfaces/user';
+import { useMetadataStore, useSupportStore } from '@stores/index';
 import { Avatar, Button, Disclosure, FormControl, FormLabel, useConfirm } from '@sk-web-gui/react';
-import { SupportAttachment } from '@supportmanagement/services/support-attachment-service';
 import {
   ExternalIdType,
   SupportErrand,
@@ -9,7 +7,6 @@ import {
   emptyContact,
   isSupportErrandLocked,
 } from '@supportmanagement/services/support-errand-service';
-import { SupportMetadata } from '@supportmanagement/services/support-metadata-service';
 import { buildStakeholdersList } from '@supportmanagement/services/support-stakeholder-service';
 import { useEffect, useState } from 'react';
 import { UseFormReturn, useFieldArray, useFormContext } from 'react-hook-form';
@@ -25,31 +22,31 @@ interface SupportContactsProps {
 
 export const SupportContactsComponent: React.FC<SupportContactsProps> = (props) => {
   const [selectedContact, setSelectedContact] = useState<SupportStakeholderFormModel>();
-  const {
-    supportErrand,
-    user,
-    supportMetadata,
-  } = useAppContext();
+  const supportErrand = useSupportStore((s) => s.supportErrand);
+  const supportMetadata = useMetadataStore((s) => s.supportMetadata);
   const deleteConfirm = useConfirm();
   const updateConfirm = useConfirm();
 
-  const { setStakeholderContacts, stakeholderContacts, setStakeholderCustomers, stakeholderCustomers } =
-    useAppContext();
+  const setStakeholderContacts = useSupportStore((s) => s.setStakeholderContacts);
+  const stakeholderContacts = useSupportStore((s) => s.stakeholderContacts);
+  const setStakeholderCustomers = useSupportStore((s) => s.setStakeholderCustomers);
+  const stakeholderCustomers = useSupportStore((s) => s.stakeholderCustomers);
   const avatarColorArray = ['vattjom', 'juniskar', 'gronsta', 'bjornstigen'];
+
+  const { control, setValue, reset }: UseFormReturn<SupportErrand, any, undefined> = useFormContext();
+
+  const errandId = supportErrand?.id;
 
   useEffect(() => {
     setSelectedContact(undefined);
-    reset(supportErrand);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user, supportErrand]);
-
-  useEffect(() => {
+    if (supportErrand) {
+      reset(supportErrand);
+    }
     setStakeholderContacts(supportErrand?.contacts ?? []);
     setStakeholderCustomers(supportErrand?.customer ?? []);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [errandId]);
 
-  const { control, setValue, reset }: UseFormReturn<SupportErrand, any, undefined> = useFormContext();
 
   const contactsFieldArray = useFieldArray({
     control,

--- a/frontend/src/supportmanagement/components/new-contacts/support-search-result.component.tsx
+++ b/frontend/src/supportmanagement/components/new-contacts/support-search-result.component.tsx
@@ -1,7 +1,7 @@
 import CommonNestedEmailArrayV2 from '@common/components/commonNestedEmailArrayV2';
 import CommonNestedPhoneArrayV2 from '@common/components/commonNestedPhoneArrayV2';
 import { AddressResult } from '@common/services/adress-service';
-import { useAppContext } from '@contexts/app.context';
+import { useSupportStore } from '@stores/index';
 import { Button, FormErrorMessage } from '@sk-web-gui/react';
 import { SupportStakeholderFormModel } from '@supportmanagement/services/support-errand-service';
 import { UseFormReturn } from 'react-hook-form';
@@ -26,7 +26,7 @@ export const SupportSearchResult: React.FC<SupportSearchResultProps> = ({
   onSubmit,
   label,
 }) => {
-  const { supportErrand } = useAppContext();
+  const supportErrand = useSupportStore((s) => s.supportErrand);
 
   const username = form.watch('username');
   const administrationName = form.watch('administrationName');

--- a/frontend/src/supportmanagement/components/new-contacts/support-simplified-contact-form.component.tsx
+++ b/frontend/src/supportmanagement/components/new-contacts/support-simplified-contact-form.component.tsx
@@ -12,7 +12,7 @@ import {
   usernamePattern,
 } from '@common/services/helper-service';
 import { appConfig } from '@config/appconfig';
-import { AppContextInterface, useAppContext } from '@contexts/app.context';
+import { useConfigStore, useMetadataStore } from '@stores/index';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Button, FormControl, Input } from '@sk-web-gui/react';
 import {
@@ -142,7 +142,8 @@ export const SupportSimplifiedContactForm: React.FC<{
     ]
   );
 
-  const { municipalityId, setSupportMetadata }: AppContextInterface = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const setSupportMetadata = useMetadataStore((s) => s.setSupportMetadata);
   const [searchMode, setSearchMode] = useState('person');
   const [searching, setSearching] = useState(false);
   const [notFound, setNotFound] = useState(false);

--- a/frontend/src/supportmanagement/components/ongoing-support-errands/components/supporterrands-table.component.tsx
+++ b/frontend/src/supportmanagement/components/ongoing-support-errands/components/supporterrands-table.component.tsx
@@ -1,5 +1,5 @@
 import { isKC } from '@common/services/application-service';
-import { AppContextInterface, useAppContext } from '@contexts/app.context';
+import { useConfigStore, useSupportStore } from '@stores/index';
 import { Input, Pagination, Select, Spinner, Table } from '@sk-web-gui/react';
 import { SortMode } from '@sk-web-gui/table';
 import { useSupportErrandTable } from '@supportmanagement/components/support-errand/useSupportErrandTable';
@@ -11,7 +11,9 @@ import { TableForm } from '../ongoing-support-errands.component';
 
 export const SupportErrandsTable: React.FC = () => {
   const { watch, setValue, register } = useFormContext<TableForm>();
-  const { supportErrands: data, municipalityId, selectedSupportErrandStatuses }: AppContextInterface = useAppContext();
+  const data = useSupportStore((s) => s.supportErrands);
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const selectedSupportErrandStatuses = useSupportStore((s) => s.selectedSupportErrandStatuses);
   const [rowHeight, setRowHeight] = useState<string>('normal');
   const sortOrder = watch('sortOrder');
   const sortColumn = watch('sortColumn');

--- a/frontend/src/supportmanagement/components/ongoing-support-errands/ongoing-support-errands.component.tsx
+++ b/frontend/src/supportmanagement/components/ongoing-support-errands/ongoing-support-errands.component.tsx
@@ -1,7 +1,7 @@
 import { ErrandsData } from '@casedata/interfaces/errand';
-import { useAppContext } from '@common/contexts/app.context';
+import { useBillingStore, useCasedataStore, useConfigStore, useMetadataStore, useSupportStore, useUserStore } from '@stores/index';
 import { attestationEnabled } from '@common/services/feature-flag-service';
-import { getMe } from '@common/services/user-service';
+import { useUserQuery } from '@common/services/use-user-query';
 import { useDebounceEffect } from '@common/utils/useDebounceEffect';
 import store from '@supportmanagement/services/storage-service';
 import { getBillingRecords } from '@supportmanagement/services/support-billing-service';
@@ -33,7 +33,7 @@ export interface TableForm {
 
 export const OngoingSupportErrands: React.FC<{ ongoing: ErrandsData }> = (props) => {
   const filterForm = useForm<SupportManagementFilter>({ defaultValues: SupportManagementValues });
-  const { watch: watchFilter, reset: resetFilter, trigger: triggerFilter, getValues, setValue } = filterForm;
+  const { watch: watchFilter, reset: resetFilter, trigger: triggerFilter, getValues, setValue: setFilterValue } = filterForm;
 
   const sortData = store.get('sort');
   let sort: { sortColumn: string; sortOrder: 'asc' | 'desc'; pageSize: number } | undefined;
@@ -47,23 +47,22 @@ export const OngoingSupportErrands: React.FC<{ ongoing: ErrandsData }> = (props)
       sortColumn: sort?.sortColumn || 'touched',
       sortOrder: sort?.sortOrder || 'desc',
       pageSize: sort?.pageSize || 12,
+      page: 0,
     },
   });
   const { watch: watchTable, setValue: setTableValue } = tableForm;
   const { sortOrder, sortColumn, pageSize, page } = watchTable();
 
-  const {
-    supportMetadata,
-    setSupportErrand,
-    administrators,
-    municipalityId,
-    selectedSupportErrandStatuses,
-    setSelectedSupportErrandStatuses,
-    setSidebarLabel,
-    sidebarLabel,
-    solvedSupportErrands,
-    setBillingRecords,
-  } = useAppContext();
+  const supportMetadata = useMetadataStore((s) => s.supportMetadata);
+  const setSupportErrand = useSupportStore((s) => s.setSupportErrand);
+  const administrators = useUserStore((s) => s.administrators);
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const setSelectedSupportErrandStatuses = useSupportStore((s) => s.setSelectedSupportErrandStatuses);
+  const selectedSupportErrandStatuses = useSupportStore((s) => s.selectedSupportErrandStatuses);
+  const setSidebarLabel = useCasedataStore((s) => s.setSidebarLabel);
+  const sidebarLabel = useCasedataStore((s) => s.sidebarLabel);
+  const solvedSupportErrands = useSupportStore((s) => s.solvedSupportErrands);
+  const setBillingRecords = useBillingStore((s) => s.setBillingRecords);
 
   const startdate = watchFilter('startdate');
   const enddate = watchFilter('enddate');
@@ -86,11 +85,6 @@ export const OngoingSupportErrands: React.FC<{ ongoing: ErrandsData }> = (props)
 
   const initialFocus = useRef<HTMLButtonElement>(null);
 
-  useEffect(() => {
-    setValue('status', selectedSupportErrandStatuses);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedSupportErrandStatuses]);
-
   const setInitialFocus = () => {
     setTimeout(() => {
       initialFocus.current && initialFocus.current.focus();
@@ -98,7 +92,15 @@ export const OngoingSupportErrands: React.FC<{ ongoing: ErrandsData }> = (props)
   };
 
   const router = useRouter();
-  const { user, setUser } = useAppContext();
+  const user = useUserStore((s) => s.user);
+  const setUser = useUserStore((s) => s.setUser);
+  const { data: userData } = useUserQuery();
+
+  useEffect(() => {
+    if (userData) {
+      setUser(userData);
+    }
+  }, [userData]);
 
   useEffect(() => {
     const filterdata = store.get('filter');
@@ -141,7 +143,6 @@ export const OngoingSupportErrands: React.FC<{ ongoing: ErrandsData }> = (props)
               : [],
         };
         const filterStatuses = filter?.status?.split(',') || SupportManagementValues.status;
-        setSelectedSupportErrandStatuses(filterStatuses);
         const selectedStatusLabel = getStatusLabel(
           filterStatuses.map((s: string) => (Status as Record<string, string>)[s])
         );
@@ -165,14 +166,20 @@ export const OngoingSupportErrands: React.FC<{ ongoing: ErrandsData }> = (props)
       if (filter?.stakeholders === user.username) {
         setOwnerFilter(true);
       }
-      if (storedFilters.status) {
-        setSelectedSupportErrandStatuses(storedFilters.status || [Status.ONGOING]);
-      }
       resetFilter(storedFilters);
       triggerFilter();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resetFilter, triggerFilter, user.username, supportMetadata]);
+
+  useEffect(() => {
+    const currentStatus = JSON.stringify(getValues('status'));
+    const storeStatus = JSON.stringify(selectedSupportErrandStatuses);
+    if (currentStatus !== storeStatus) {
+      setFilterValue('status', selectedSupportErrandStatuses);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedSupportErrandStatuses]);
 
   useEffect(() => {
     const sortData = store.get('sort');
@@ -204,11 +211,6 @@ export const OngoingSupportErrands: React.FC<{ ongoing: ErrandsData }> = (props)
     //       the browser will automatically scroll
     //       down to the button.
     setInitialFocus();
-    getMe()
-      .then((user) => {
-        setUser(user);
-      })
-      .catch((e) => {});
     setSupportErrand(undefined as unknown as any);
     //eslint-disable-next-line
   }, [router]);
@@ -294,6 +296,7 @@ export const OngoingSupportErrands: React.FC<{ ongoing: ErrandsData }> = (props)
       }
       setFilterObject(fObj);
       setExtraFilter(extraFilterObj);
+      setSelectedSupportErrandStatuses(statusFilter);
       store.set('filter', JSON.stringify(fObj));
     },
     200,

--- a/frontend/src/supportmanagement/components/support-errand-basics-disclosure/support-errand-basics-about-disclosure.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand-basics-disclosure/support-errand-basics-about-disclosure.component.tsx
@@ -1,20 +1,16 @@
-import { useAppContext } from '@contexts/app.context';
+import { useSupportStore } from '@stores/index';
 import { Disclosure } from '@sk-web-gui/react';
-import { SupportAttachment } from '@supportmanagement/services/support-attachment-service';
 import { ApiSupportErrand, SupportErrand } from '@supportmanagement/services/support-errand-service';
 import React, { useEffect } from 'react';
 import { UseFormReturn, useFormContext } from 'react-hook-form';
 import { SupportErrandBasicsAboutForm } from '../support-errand-basics-form/support-errand-basics-about-form.component';
-import { User } from '@common/interfaces/user';
 import { Info } from 'lucide-react';
 export const SupportErrandBasicsAboutDisclosure: React.FC<{
   errand: ApiSupportErrand;
   setUnsaved: (unsaved: boolean) => void;
   update: () => void;
 }> = () => {
-  const {
-    supportErrand,
-  } = useAppContext();
+  const supportErrand = useSupportStore((s) => s.supportErrand);
 
   const formControls: UseFormReturn<SupportErrand> = useFormContext();
   const { setValue } = formControls;

--- a/frontend/src/supportmanagement/components/support-errand-basics-disclosure/support-errand-basics-realestate-disclosure.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand-basics-disclosure/support-errand-basics-realestate-disclosure.component.tsx
@@ -1,6 +1,6 @@
 import Facilities from '@common/components/facilities/facilities';
 import { FacilityDTO } from '@common/interfaces/facilities';
-import { useAppContext } from '@contexts/app.context';
+import { useSupportStore } from '@stores/index';
 import { Disclosure } from '@sk-web-gui/react';
 import { SupportErrand, supportErrandIsEmpty } from '@supportmanagement/services/support-errand-service';
 
@@ -15,9 +15,7 @@ export const SupportErrandBasicsRealEstateDisclosure: React.FC<{
   const [facilities, setFacilities] = useState<FacilityDTO[]>([]);
   const { setValue, watch, getValues } = useFormContext();
 
-  const {
-    supportErrand,
-  } = useAppContext();
+  const supportErrand = useSupportStore((s) => s.supportErrand);
 
   const fac = watch('facilities');
 

--- a/frontend/src/supportmanagement/components/support-errand-basics-form/ThreeLevelCategorization.tsx
+++ b/frontend/src/supportmanagement/components/support-errand-basics-form/ThreeLevelCategorization.tsx
@@ -4,7 +4,7 @@ import { isSupportErrandLocked, SupportErrand } from '@supportmanagement/service
 import { SupportMetadata } from '@supportmanagement/services/support-metadata-service';
 import { useEffect, useState } from 'react';
 import { useFormContext, UseFormReturn } from 'react-hook-form';
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 const CLASSIFICATIONS = {
   CATEGORY: 'CATEGORY',

--- a/frontend/src/supportmanagement/components/support-errand-basics-form/TwoLevelCategorization.tsx
+++ b/frontend/src/supportmanagement/components/support-errand-basics-form/TwoLevelCategorization.tsx
@@ -1,42 +1,29 @@
-import { Category } from '@common/data-contracts/supportmanagement/data-contracts';
-import { useAppContext } from '@contexts/app.context';
+import { useMetadataStore, useSupportStore } from '@stores/index';
 import { FormControl, FormErrorMessage, FormLabel, Select } from '@sk-web-gui/react';
 import {
-  defaultSupportErrandInformation,
   isSupportErrandLocked,
   SupportErrand,
 } from '@supportmanagement/services/support-errand-service';
-import { getSupportMetadata, SupportType } from '@supportmanagement/services/support-metadata-service';
-import { useTranslation } from 'next-i18next';
-import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useMemo } from 'react';
 import { useFormContext, UseFormReturn } from 'react-hook-form';
 
 export const TwoLevelCategorization: React.FC = () => {
-  const { supportErrand, supportMetadata } = useAppContext();
+  const supportErrand = useSupportStore((s) => s.supportErrand);
+  const supportMetadata = useMetadataStore((s) => s.supportMetadata);
   const formControls: UseFormReturn<SupportErrand> = useFormContext();
-  const { getValues, setValue, trigger, register, watch, formState } = formControls;
+  const { register, setValue, watch, formState } = formControls;
 
   const { errors } = formState;
   const { category } = watch();
 
   const { t } = useTranslation();
 
-  const [categoriesList, setCategoriesList] = useState<Category[]>();
-  const [typesList, setTypesList] = useState<SupportType[]>();
-
-  useEffect(() => {
-    if (supportMetadata) {
-      setCategoriesList(supportMetadata?.categories);
-    } else {
-      getSupportMetadata(defaultSupportErrandInformation.municipalityId).then((data) => {
-        setCategoriesList(data.metadata?.categories);
-      });
-    }
-  }, [supportMetadata]);
-
-  useEffect(() => {
-    setTypesList(categoriesList?.find((c) => c.name === category)?.types || []);
-  }, [category, categoriesList]);
+  const categoriesList = supportMetadata?.categories;
+  const typesList = useMemo(
+    () => categoriesList?.find((c) => c.name === category)?.types || [],
+    [category, categoriesList]
+  );
 
   return (
     <>
@@ -55,12 +42,9 @@ export const TwoLevelCategorization: React.FC = () => {
             className="w-full text-dark-primary"
             variant="primary"
             size="md"
-            value={getValues().category}
             onChange={(e) => {
               setValue('category', e.currentTarget.value, { shouldDirty: true });
               setValue('type', undefined as any, { shouldDirty: true });
-              trigger('category');
-              trigger('type');
             }}
           >
             <Select.Option value="">Välj ärendekategori</Select.Option>
@@ -94,11 +78,6 @@ export const TwoLevelCategorization: React.FC = () => {
             className="w-full text-dark-primary"
             variant="primary"
             size="md"
-            value={getValues().type}
-            onChange={(e) => {
-              setValue('type', e.currentTarget.value, { shouldDirty: true });
-              trigger('type');
-            }}
           >
             <Select.Option value="">Välj ärendetyp</Select.Option>
             {typesList?.map((type) => (

--- a/frontend/src/supportmanagement/components/support-errand-basics-form/support-errand-basics-about-form.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand-basics-form/support-errand-basics-about-form.component.tsx
@@ -1,35 +1,30 @@
-import { useAppContext } from '@common/contexts/app.context';
-import { Category, ContactReason } from '@common/data-contracts/supportmanagement/data-contracts';
+import { useMetadataStore } from '@stores/index';
+import { ContactReason } from '@common/data-contracts/supportmanagement/data-contracts';
 import { appConfig } from '@config/appconfig';
 import { Checkbox, FormControl, FormErrorMessage, FormLabel, Select, Textarea, cx } from '@sk-web-gui/react';
 import {
   Channels,
   ContactChannelType,
   SupportErrand,
-  defaultSupportErrandInformation,
   isSupportErrandLocked,
   supportErrandIsEmpty,
 } from '@supportmanagement/services/support-errand-service';
-import { SupportMetadata, SupportType, getSupportMetadata } from '@supportmanagement/services/support-metadata-service';
-import { useTranslation } from 'next-i18next';
-import dynamic from 'next/dynamic';
+import { useTranslation } from 'react-i18next';
+import TextEditor from '@common/components/dynamic-text-editor';
 import { useEffect, useRef, useState } from 'react';
 import { UseFormReturn, useFormContext } from 'react-hook-form';
 import { ThreeLevelCategorization } from './ThreeLevelCategorization';
 import { TwoLevelCategorization } from './TwoLevelCategorization';
-const TextEditor = dynamic(() => import('@sk-web-gui/text-editor'), { ssr: false });
 
 export const SupportErrandBasicsAboutForm: React.FC<{
   supportErrand: SupportErrand;
   registeringNewErrand?: boolean;
 }> = (props) => {
-  const {
-    supportMetadata,
-  } = useAppContext();
+  const supportMetadata = useMetadataStore((s) => s.supportMetadata);
   const { supportErrand } = props;
   const { t } = useTranslation();
 
-  const [contactReasonList, setContactReasonList] = useState<ContactReason[]>();
+  const contactReasonList = supportMetadata?.contactReasons;
   const [causeDescriptionIsOpen, setCauseDescriptionIsOpen] = useState(
     supportErrand.contactReasonDescription !== undefined
   );
@@ -40,8 +35,6 @@ export const SupportErrandBasicsAboutForm: React.FC<{
     register,
     watch,
     setValue,
-    getValues,
-    trigger,
     formState: { errors },
   } = formControls;
 
@@ -53,17 +46,6 @@ export const SupportErrandBasicsAboutForm: React.FC<{
     userHasEditedDescription.current = false;
   }, [supportErrand.id]);
 
-  useEffect(() => {
-    if (supportMetadata) {
-      setContactReasonList(supportMetadata?.contactReasons);
-    } else {
-      getSupportMetadata(defaultSupportErrandInformation.municipalityId).then((data) => {
-        setContactReasonList(data.metadata?.contactReasons);
-      });
-    }
-  }, [supportMetadata]);
-
-  const checked = document.querySelector('#causecheckbox:checked') !== null;
 
   return (
     <>
@@ -133,11 +115,6 @@ export const SupportErrandBasicsAboutForm: React.FC<{
                 className="w-full text-dark-primary"
                 variant="primary"
                 size="md"
-                value={getValues().contactReason}
-                onChange={(e) => {
-                  setValue('contactReason', e.currentTarget.value, { shouldDirty: true });
-                  trigger('contactReason');
-                }}
               >
                 <Select.Option value="">Välj orsak</Select.Option>
                 {contactReasonList
@@ -169,11 +146,6 @@ export const SupportErrandBasicsAboutForm: React.FC<{
               className="w-full text-dark-primary"
               variant="primary"
               size="md"
-              value={getValues().channel}
-              onChange={(e) => {
-                setValue('channel', e.currentTarget.value, { shouldDirty: true });
-                trigger('channel');
-              }}
             >
               {Object.entries(Channels).map((c: [string, string]) => {
                 const id = c[0];
@@ -206,7 +178,7 @@ export const SupportErrandBasicsAboutForm: React.FC<{
             defaultChecked={supportErrand.contactReasonDescription !== undefined}
             data-cy="show-contactReasonDescription-input"
             className="w-full"
-            onClick={() => (checked ? setCauseDescriptionIsOpen(false) : setCauseDescriptionIsOpen(true))}
+            onClick={() => setCauseDescriptionIsOpen((prev) => !prev)}
           >
             {t(`common:basics_tab.cause_description.description_${process.env.NEXT_PUBLIC_APPLICATION}`)}
           </Checkbox>
@@ -214,11 +186,11 @@ export const SupportErrandBasicsAboutForm: React.FC<{
             <FormControl id="causedescription" className="w-full mt-lg">
               <FormLabel>{t('common:basics_tab.cause_description.title')}</FormLabel>
               <Textarea
+                {...register('contactReasonDescription')}
+                value={watch('contactReasonDescription') ?? ''}
                 data-cy="contactReasonDescription-input"
                 disabled={isSupportErrandLocked(supportErrand)}
                 className="block w-full text-[1.6rem] h-full"
-                value={getValues().contactReasonDescription}
-                {...register('contactReasonDescription')}
                 placeholder="Beskriv orsaken"
                 rows={7}
                 id="causedescription"

--- a/frontend/src/supportmanagement/components/support-errand-basics-form/support-errand-summary.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand-basics-form/support-errand-summary.component.tsx
@@ -1,13 +1,13 @@
 import { PriorityComponent } from '@common/components/priority/priority.component';
 import { prettyTime } from '@common/services/helper-service';
-import { useAppContext } from '@contexts/app.context';
+import { useSupportStore } from '@stores/index';
 import { Priority } from '@supportmanagement/interfaces/priority';
 import { Channels } from '@supportmanagement/services/support-errand-service';
 import { getSupportReporterStakeholder } from '@supportmanagement/services/support-stakeholder-service';
 import { SupportStatusLabelComponent } from '../ongoing-support-errands/components/support-status-label.component';
 
 export const SupportErrandSummary: React.FC<{}> = () => {
-  const { supportErrand } = useAppContext();
+  const supportErrand = useSupportStore((s) => s.supportErrand);
 
   return (
     <>

--- a/frontend/src/supportmanagement/components/support-errand/sidebar/close-errand.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/close-errand.component.tsx
@@ -2,7 +2,7 @@ import { isIK, isKA, isLOP, isROB, isSE } from '@common/services/application-ser
 import { deepFlattenToObject } from '@common/services/helper-service';
 import { getToastOptions } from '@common/utils/toast-message-settings';
 import { appConfig } from '@config/appconfig';
-import { useAppContext } from '@contexts/app.context';
+import { useConfigStore, useSupportStore, useUserStore } from '@stores/index';
 import { Button, Checkbox, FormControl, Modal, RadioButton, useSnackbar } from '@sk-web-gui/react';
 import {
   Resolution,
@@ -42,7 +42,10 @@ const getDefaultResolution = (errand: SupportErrand | undefined): Resolution => 
 };
 
 export const CloseErrandComponent: React.FC<{ disabled: boolean }> = ({ disabled }) => {
-  const { administrators, municipalityId, supportErrand, setSupportErrand } = useAppContext();
+  const administrators = useUserStore((s) => s.administrators);
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const supportErrand = useSupportStore((s) => s.supportErrand);
+  const setSupportErrand = useSupportStore((s) => s.setSupportErrand);
   const toastMessage = useSnackbar();
   const [showModal, setShowModal] = useState(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -197,7 +200,7 @@ export const CloseErrandComponent: React.FC<{ disabled: boolean }> = ({ disabled
                   <Checkbox
                     id="closingmessagecheckbox"
                     disabled={!applicantHasContactChannel(supportErrand!)}
-                    data-cy="show-contactReasonDescription-input"
+                    data-cy="show-closing-message-input"
                     className="w-full"
                     checked={applicantHasContactChannel(supportErrand!) && closingMessage}
                     onChange={() => setClosingMessage(!closingMessage)}

--- a/frontend/src/supportmanagement/components/support-errand/sidebar/forward-errand.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/forward-errand.component.tsx
@@ -7,7 +7,7 @@ import { deepFlattenToObject } from '@common/services/helper-service';
 import sanitized from '@common/services/sanitizer-service';
 import { getToastOptions } from '@common/utils/toast-message-settings';
 import { appConfig } from '@config/appconfig';
-import { useAppContext } from '@contexts/app.context';
+import { useConfigStore, useMetadataStore, useSupportStore, useUserStore } from '@stores/index';
 import { yupResolver } from '@hookform/resolvers/yup';
 import {
   Button,
@@ -30,12 +30,11 @@ import {
 } from '@supportmanagement/services/support-errand-service';
 import { getEscalationEmails, getEscalationMessage } from '@supportmanagement/services/support-escalation-service';
 import { SupportMetadata } from '@supportmanagement/services/support-metadata-service';
-import dynamic from 'next/dynamic';
+import TextEditor from '@common/components/dynamic-text-editor';
 import { useEffect, useState } from 'react';
 import { useForm, useFormContext, UseFormReturn } from 'react-hook-form';
 import * as yup from 'yup';
 import { Forward } from 'lucide-react';
-const TextEditor = dynamic(() => import('@sk-web-gui/text-editor'), { ssr: false });
 
 const yupForwardForm = yup.object().shape(
   {
@@ -77,14 +76,12 @@ export interface ForwardFormProps {
 }
 
 export const ForwardErrandComponent: React.FC<{ disabled: boolean }> = ({ disabled }) => {
-  const {
-    user,
-    municipalityId,
-    supportErrand,
-    setSupportErrand,
-    supportMetadata,
-    supportAttachments,
-  } = useAppContext();
+  const user = useUserStore((s) => s.user);
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const supportErrand = useSupportStore((s) => s.supportErrand);
+  const setSupportErrand = useSupportStore((s) => s.setSupportErrand);
+  const supportMetadata = useMetadataStore((s) => s.supportMetadata);
+  const supportAttachments = useSupportStore((s) => s.supportAttachments);
   const confirm = useConfirm();
   const errandFormControls: UseFormReturn<SupportErrand, any, undefined> = useFormContext();
   const [showModal, setShowModal] = useState(false);

--- a/frontend/src/supportmanagement/components/support-errand/sidebar/message-portal.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/message-portal.component.tsx
@@ -1,11 +1,12 @@
 import { MessageWrapper } from '@common/components/message/message-wrapper.component';
-import { useAppContext } from '@contexts/app.context';
+import { useSupportStore } from '@stores/index';
 import { SupportMessageForm } from '@supportmanagement/components/support-message-form/support-message-form.component';
 import { isSupportErrandLocked } from '@supportmanagement/services/support-errand-service';
 import { useEffect, useState } from 'react';
 
 export const MessagePortal: React.FC = () => {
-  const { supportErrand, setSupportErrand } = useAppContext();
+  const supportErrand = useSupportStore((s) => s.supportErrand);
+  const setSupportErrand = useSupportStore((s) => s.setSupportErrand);
   const [show, setShow] = useState(false);
 
   const close = () => setShow(false);

--- a/frontend/src/supportmanagement/components/support-errand/sidebar/request-internal.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/request-internal.component.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { User } from '@common/interfaces/user';
 import { isIK, isLOP, isSE } from '@common/services/application-service';
 import { invalidPhoneMessage, supportManagementPhonePatternOrCountryCode } from '@common/services/helper-service';
 import { getToastOptions } from '@common/utils/toast-message-settings';
 import { appConfig } from '@config/appconfig';
-import { useAppContext } from '@contexts/app.context';
+import { useConfigStore, useMetadataStore, useSupportStore, useUserStore } from '@stores/index';
 import { yupResolver } from '@hookform/resolvers/yup';
 import {
   Button,
@@ -29,12 +28,11 @@ import {
   SupportErrand,
 } from '@supportmanagement/services/support-errand-service';
 import { SupportMetadata } from '@supportmanagement/services/support-metadata-service';
-import dynamic from 'next/dynamic';
+import TextEditor from '@common/components/dynamic-text-editor';
 import { useEffect, useState } from 'react';
 import { useForm, UseFormReturn } from 'react-hook-form';
 import * as yup from 'yup';
 import { FileInput, Plus } from 'lucide-react';
-const TextEditor = dynamic(() => import('@sk-web-gui/text-editor'), { ssr: false });
 
 const yupRequestFeedbackForm = yup.object().shape(
   {
@@ -77,21 +75,12 @@ export interface RequestInternalFormProps {
 //NOT IN USE?
 
 export const RequestInternalComponent: React.FC<{ disabled: boolean }> = ({ disabled }) => {
-  const {
-    user,
-    municipalityId,
-    supportErrand,
-    setSupportErrand,
-    supportMetadata,
-    supportAttachments,
-  }: {
-    user: User;
-    municipalityId: string;
-    supportErrand: SupportErrand;
-    setSupportErrand: any;
-    supportMetadata: SupportMetadata;
-    supportAttachments: SupportAttachment[];
-  } = useAppContext();
+  const user = useUserStore((s) => s.user);
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const supportErrand = useSupportStore((s) => s.supportErrand) as SupportErrand;
+  const setSupportErrand = useSupportStore((s) => s.setSupportErrand);
+  const supportMetadata = useMetadataStore((s) => s.supportMetadata) as SupportMetadata;
+  const supportAttachments = useSupportStore((s) => s.supportAttachments) as SupportAttachment[];
   const confirm = useConfirm();
   const [error, setError] = useState(false);
   const toastMessage = useSnackbar();

--- a/frontend/src/supportmanagement/components/support-errand/sidebar/sidebar-generic-notes.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/sidebar-generic-notes.component.tsx
@@ -1,6 +1,6 @@
 import { NoteType } from '@casedata/interfaces/errandNote';
 import { noteIsComment, noteIsTjansteanteckning } from '@casedata/services/casedata-errand-notes-service';
-import { useAppContext } from '@common/contexts/app.context';
+import { useConfigStore, useSupportStore, useUserStore } from '@stores/index';
 import { sanitizedInline } from '@common/services/sanitizer-service';
 import { getInitialsFromADUsername } from '@common/services/user-service';
 import { getToastOptions } from '@common/utils/toast-message-settings';
@@ -46,7 +46,10 @@ export const SidebarGenericNotes: React.FC<{
   label_singular: 'Kommentar' | 'Tjänsteanteckning';
   noteType: NoteType;
 }> = ({ label_plural, label_singular, noteType }) => {
-  const { supportErrand, setSupportErrand, administrators, municipalityId } = useAppContext();
+  const supportErrand = useSupportStore((s) => s.supportErrand);
+  const setSupportErrand = useSupportStore((s) => s.setSupportErrand);
+  const administrators = useUserStore((s) => s.administrators);
+  const municipalityId = useConfigStore((s) => s.municipalityId);
   const [selectedNote, setSelectedNote] = useState<GenericNote>();
   const [notes, setNotes] = useState<SupportNote[]>([]);
   const [isLoading, setIsLoading] = useState(false);

--- a/frontend/src/supportmanagement/components/support-errand/sidebar/sidebar-history.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/sidebar-history.component.tsx
@@ -1,4 +1,4 @@
-import { useAppContext } from '@common/contexts/app.context';
+import { useConfigStore, useMetadataStore, useSupportStore, useUserStore } from '@stores/index';
 import { sanitized } from '@common/services/sanitizer-service';
 import { Avatar, Button, Modal, Spinner } from '@sk-web-gui/react';
 import { Priority } from '@supportmanagement/interfaces/priority';
@@ -18,7 +18,10 @@ import { History } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 export const SidebarHistory: React.FC<{}> = () => {
-  const { municipalityId, supportErrand, supportMetadata, administrators } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const supportErrand = useSupportStore((s) => s.supportErrand);
+  const supportMetadata = useMetadataStore((s) => s.supportMetadata);
+  const administrators = useUserStore((s) => s.administrators);
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(false);

--- a/frontend/src/supportmanagement/components/support-errand/sidebar/sidebar-info.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/sidebar-info.component.tsx
@@ -1,5 +1,5 @@
 import iconMap from '@common/components/lucide-icon-map/lucide-icon-map.component';
-import { useAppContext } from '@common/contexts/app.context';
+import { useConfigStore, useMetadataStore, useSupportStore, useUserStore } from '@stores/index';
 import { deepFlattenToObject } from '@common/services/helper-service';
 import { appConfig } from '@config/appconfig';
 import { Button, Divider, FormControl, FormLabel, Label, Select, useConfirm, useSnackbar } from '@sk-web-gui/react';
@@ -33,14 +33,27 @@ export const SidebarInfo: React.FC<{
   unsavedFacility: boolean;
   setUnsavedFacility: Dispatch<SetStateAction<boolean>>;
 }> = (props) => {
-  const { user, supportErrand, setSupportErrand, administrators, municipalityId, supportMetadata } = useAppContext();
-  const [selectablePriorities, setSelectablePriorities] = useState<{ key: string; label: string }[]>([]);
+  const user = useUserStore((s) => s.user);
+  const supportErrand = useSupportStore((s) => s.supportErrand);
+  const setSupportErrand = useSupportStore((s) => s.setSupportErrand);
+  const administrators = useUserStore((s) => s.administrators);
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const supportMetadata = useMetadataStore((s) => s.supportMetadata);
+  const selectablePriorities = useMemo(() => {
+    if (supportErrand?.priority && supportErrand?.status) {
+      return [
+        { key: 'LOW', label: Priority.LOW },
+        { key: 'MEDIUM', label: Priority.MEDIUM },
+        { key: 'HIGH', label: Priority.HIGH },
+      ];
+    }
+    return [];
+  }, [supportErrand]);
   const [isLoading, setIsLoading] = useState<'status' | 'admin' | 'priority' | 'suspend' | false | true>();
   const [error, setError] = useState(false);
   const toastMessage = useSnackbar();
   const confirm = useConfirm();
-  const [allowed, setAllowed] = useState(false);
-  useEffect(() => {
+  const allowed = useMemo(() => {
     if (!supportErrandIsEmpty(supportErrand!)) {
       let _a = validateAction(supportErrand!, user);
       if (supportErrand!.assignedUserId?.toLocaleLowerCase() === undefined) {
@@ -52,12 +65,11 @@ export const SidebarInfo: React.FC<{
           _a = true;
         }
       }
-      setAllowed(_a);
+      return _a;
     } else {
-      setAllowed(isAdmin());
+      return administrators.some((a) => a.adAccount === user.username);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user, supportErrand]);
+  }, [user, supportErrand, administrators]);
 
   const toast = (kind: 'success' | 'error', label: string) =>
     toastMessage({
@@ -211,17 +223,6 @@ export const SidebarInfo: React.FC<{
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [supportErrand, administrators]);
-
-  useEffect(() => {
-    if (supportErrand?.priority && supportErrand?.status) {
-      const prio = [
-        { key: 'LOW', label: Priority.LOW },
-        { key: 'MEDIUM', label: Priority.MEDIUM },
-        { key: 'HIGH', label: Priority.HIGH },
-      ];
-      setSelectablePriorities(prio);
-    }
-  }, [supportErrand]);
 
   const handleAction = (action: () => Promise<boolean>, success: () => void, fail: () => void) => {
     return action()

--- a/frontend/src/supportmanagement/components/support-errand/sidebar/start-process.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/start-process.component.tsx
@@ -1,4 +1,4 @@
-import { useAppContext } from '@contexts/app.context';
+import { useConfigStore, useSupportStore, useUserStore } from '@stores/index';
 import { Button, useSnackbar } from '@sk-web-gui/react';
 import {
   Status,
@@ -14,7 +14,11 @@ export const StartProcessComponent: React.FC<{
   onSubmit: () => Promise<any>;
   onError: () => void;
 }> = ({ disabled, onSubmit, onError }) => {
-  const { user, supportErrand, administrators, municipalityId, setSupportErrand } = useAppContext();
+  const user = useUserStore((s) => s.user);
+  const supportErrand = useSupportStore((s) => s.supportErrand);
+  const administrators = useUserStore((s) => s.administrators);
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const setSupportErrand = useSupportStore((s) => s.setSupportErrand);
   const toast = useSnackbar();
   const { handleSubmit, reset } = useFormContext();
 

--- a/frontend/src/supportmanagement/components/support-errand/sidebar/support-resume-errand-button.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/support-resume-errand-button.component.tsx
@@ -1,4 +1,4 @@
-import { useAppContext } from '@contexts/app.context';
+import { useConfigStore, useSupportStore } from '@stores/index';
 import { useConfirm, useSnackbar, Button } from '@sk-web-gui/react';
 import {
   getSupportErrandById,
@@ -11,7 +11,9 @@ import { getToastOptions } from '@common/utils/toast-message-settings';
 import { CirclePlay } from 'lucide-react';
 
 export const SupportResumeErrandButton: React.FC<{ disabled: boolean }> = ({ disabled }) => {
-  const { municipalityId, supportErrand, setSupportErrand } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const supportErrand = useSupportStore((s) => s.supportErrand);
+  const setSupportErrand = useSupportStore((s) => s.setSupportErrand);
   const confirm = useConfirm();
   const toastMessage = useSnackbar();
   const [isLoading, setIsLoading] = useState(false);

--- a/frontend/src/supportmanagement/components/support-errand/sidebar/suspend-errand.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/suspend-errand.component.tsx
@@ -1,5 +1,5 @@
 import { getToastOptions } from '@common/utils/toast-message-settings';
-import { useAppContext } from '@contexts/app.context';
+import { useConfigStore, useSupportStore } from '@stores/index';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Button, FormControl, FormLabel, Input, Modal, Textarea, useSnackbar } from '@sk-web-gui/react';
 import {
@@ -27,11 +27,9 @@ export interface SuspendFormProps {
 }
 
 export const SuspendErrandComponent: React.FC<{ disabled: boolean }> = ({ disabled }) => {
-  const {
-    municipalityId,
-    supportErrand,
-    setSupportErrand,
-  } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const supportErrand = useSupportStore((s) => s.supportErrand);
+  const setSupportErrand = useSupportStore((s) => s.setSupportErrand);
   const toastMessage = useSnackbar();
   const [showModal, setShowModal] = useState(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/frontend/src/supportmanagement/components/support-errand/tabs/messages/rendered-support-message.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/tabs/messages/rendered-support-message.component.tsx
@@ -1,7 +1,7 @@
 import { MessageAvatar } from '@common/components/message/message-avatar.component';
 import { MessageResponseDirectionEnum } from '@common/data-contracts/case-data/data-contracts';
 import sanitized, { formatMessage } from '@common/services/sanitizer-service';
-import { AppContextInterface, useAppContext } from '@contexts/app.context';
+import { useConfigStore, useSupportStore, useUserStore } from '@stores/index';
 import { Button, cx, Icon, useSnackbar } from '@sk-web-gui/react';
 import { getSupportConversationAttachment } from '@supportmanagement/services/support-conversation-service';
 import { isSupportErrandLocked, validateAction } from '@supportmanagement/services/support-errand-service';
@@ -13,7 +13,7 @@ import {
 } from '@supportmanagement/services/support-message-service';
 import dayjs from 'dayjs';
 import { CornerDownRight, Image, Mail, Monitor, Paperclip, Smartphone, SquareMinus, SquarePlus } from 'lucide-react';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { RenderSupportMessageReciever } from './render-support-message-reciever.component';
 
 export const RenderedSupportMessage: React.FC<{
@@ -25,18 +25,16 @@ export const RenderedSupportMessage: React.FC<{
   root?: boolean;
   children: any;
 }> = ({ update, setShowMessageForm, message, onSelect, root = false, children }) => {
-  const { supportErrand: _supportErrand, municipalityId, user } = useAppContext();
+  const _supportErrand = useSupportStore((s) => s.supportErrand);
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const user = useUserStore((s) => s.user);
   const supportErrand = _supportErrand!;
-  const [allowed, setAllowed] = useState(false);
 
   // Changed logic for expanded message to see if it solve problem with unread message counter
   // const [expanded, setExpanded] = useState(!message?.children?.length ? true : false);
   const [expanded, setExpanded] = useState(false);
 
-  useEffect(() => {
-    const _a = validateAction(supportErrand, user);
-    setAllowed(_a);
-  }, [user, supportErrand]);
+  const allowed = useMemo(() => validateAction(supportErrand, user), [user, supportErrand]);
 
   const toastMessage = useSnackbar();
 

--- a/frontend/src/supportmanagement/components/support-errand/tabs/messages/support-messages-tab.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/tabs/messages/support-messages-tab.tsx
@@ -1,12 +1,12 @@
 import { MessageWrapper } from '@common/components/message/message-wrapper.component';
 import { CommunicationCommunicationTypeEnum } from '@common/data-contracts/supportmanagement/data-contracts';
-import { useAppContext } from '@contexts/app.context';
+import { useConfigStore, useSupportStore, useUserStore } from '@stores/index';
 import { Button, Divider, FormControl, FormLabel, Icon, Select } from '@sk-web-gui/react';
 import { isSupportErrandLocked, Status, validateAction } from '@supportmanagement/services/support-errand-service';
 import { Message, setMessageViewStatus } from '@supportmanagement/services/support-message-service';
 import { Mail } from 'lucide-react';
-import { useTranslation } from 'next-i18next';
-import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import React, { useMemo, useState } from 'react';
 import { SupportMessageForm } from '../../../support-message-form/support-message-form.component';
 import MessageTreeComponent from './support-messages-tree.component';
 
@@ -19,29 +19,26 @@ export const SupportMessagesTab: React.FC<{
   update: () => void;
   municipalityId: string;
 }> = (props) => {
-  const { supportErrand, municipalityId, user } = useAppContext();
+  const supportErrand = useSupportStore((s) => s.supportErrand);
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const user = useUserStore((s) => s.user);
   const [showMessageForm, setShowMessageForm] = useState<boolean>(false);
   const [selectedMessage, setSelectedMessage] = useState<Message>();
-  const [allowed, setAllowed] = useState(false);
   const [sortSendingTypeMessages, setSortSendingTypeMessages] = useState<string>('ALL_SEND_TYPES');
   const [sortChannelMessages, setSortChannelMessages] = useState<string>('all channels');
-  const [sortedMessages, setSortedMessages] = useState<Message[]>();
   const { t } = useTranslation();
 
-  const allMessages = React.useMemo(
+  const allMessages = useMemo(
     () => [...(props.messages || []), ...(props.supportConversations || [])],
     [props.messages, props.supportConversations]
   );
 
-  const allMessagesTree = React.useMemo(
+  const allMessagesTree = useMemo(
     () => [...(props.messageTree || []), ...(props.conversationMessageTree || [])],
     [props.messageTree, props.conversationMessageTree]
   );
 
-  useEffect(() => {
-    const _a = validateAction(supportErrand!, user);
-    setAllowed(_a);
-  }, [user, supportErrand]);
+  const allowed = useMemo(() => supportErrand ? validateAction(supportErrand, user) : false, [user, supportErrand]);
 
   const onSelect = (message: Message) => {
     if (message.conversationId && message.conversationId !== '') {
@@ -61,109 +58,34 @@ export const SupportMessagesTab: React.FC<{
     });
   };
 
-  useEffect(() => {
-    if (allMessages && allMessagesTree) {
-      if (sortSendingTypeMessages === 'INBOUND') {
-        let filteredMessages = allMessages.filter(
-          (message: Message) =>
-            message.direction === 'INBOUND' &&
-            (sortChannelMessages !== 'allchannels'
-              ? message.communicationType === sortChannelMessages
-              : message.communicationType)
-        );
-        setSortedMessages(filteredMessages);
-      } else if (sortSendingTypeMessages === 'OUTBOUND') {
-        let filteredMessages = allMessages.filter(
-          (message: Message) =>
-            message.direction === 'OUTBOUND' &&
-            (sortChannelMessages !== 'allchannels'
-              ? message.communicationType === sortChannelMessages
-              : message.communicationType)
-        );
-        setSortedMessages(filteredMessages);
-      } else {
-        setSortedMessages(
-          sortChannelMessages !== 'allchannels'
-            ? allMessagesTree.filter((x) => x.communicationType === sortChannelMessages)
-            : allMessagesTree
-        );
-      }
-    }
-  }, [allMessages, allMessagesTree, sortSendingTypeMessages, sortChannelMessages]);
+  const sortedMessages = useMemo(() => {
+    if (!allMessages || !allMessagesTree) return [];
 
-  useEffect(() => {
-    if (allMessages && allMessagesTree) {
-      if (sortChannelMessages === CommunicationCommunicationTypeEnum.WEB_MESSAGE) {
-        let filteredMessages = allMessages.filter(
-          (message: Message) => message.communicationType === CommunicationCommunicationTypeEnum.WEB_MESSAGE
+    // Apply channel filter
+    if (sortChannelMessages !== 'allchannels' && sortChannelMessages !== 'all channels') {
+      const filteredMessages = allMessages.filter(
+        (message: Message) =>
+          message.communicationType === sortChannelMessages &&
+          (sortSendingTypeMessages === 'ALL_SEND_TYPES' ? true : message.direction === sortSendingTypeMessages)
+      );
+
+      if (sortSendingTypeMessages !== 'INBOUND' && sortSendingTypeMessages !== 'OUTBOUND') {
+        const filteredMessageTree = allMessagesTree.filter((m) =>
+          filteredMessages.find((x) => x.communicationType === m.communicationType)
         );
-        let filteredMessageTree = allMessagesTree.filter((m) => {
-          return filteredMessages.find(
-            (x) =>
-              x.communicationType === m.communicationType &&
-              (sortSendingTypeMessages !== 'ALL_SEND_TYPES' ? x.direction === sortSendingTypeMessages : x.direction)
-          );
-        });
-        setSortedMessages(filteredMessageTree);
-      } else if (sortChannelMessages === CommunicationCommunicationTypeEnum.EMAIL) {
-        let filteredMessages = allMessages.filter(
-          (message: Message) =>
-            message.communicationType === CommunicationCommunicationTypeEnum.EMAIL &&
-            (sortSendingTypeMessages !== 'ALL_SEND_TYPES'
-              ? message.direction === sortSendingTypeMessages
-              : message.direction)
-        );
-        let filteredMessageTree = allMessagesTree.filter((m) => {
-          return filteredMessages.find(
-            (x) =>
-              x.communicationType === m.communicationType &&
-              (sortSendingTypeMessages !== 'ALL_SEND_TYPES' ? x.direction === sortSendingTypeMessages : x.direction)
-          );
-        });
-        setSortedMessages(
-          sortSendingTypeMessages === 'INBOUND' || sortSendingTypeMessages === 'OUTBOUND'
-            ? filteredMessages
-            : filteredMessageTree
-        );
-      } else if (sortChannelMessages === CommunicationCommunicationTypeEnum.SMS) {
-        let filteredMessages = allMessages.filter(
-          (message: Message) => message.communicationType === CommunicationCommunicationTypeEnum.SMS
-        );
-        let filteredMessageTree = allMessagesTree.filter((m) => {
-          return filteredMessages.find(
-            (x) =>
-              x.communicationType === m.communicationType &&
-              (sortSendingTypeMessages !== 'ALL_SEND_TYPES' ? x.direction === sortSendingTypeMessages : x.direction)
-          );
-        });
-        setSortedMessages(filteredMessageTree);
-      } else if (sortChannelMessages === 'DRAKEN') {
-        let filteredMessages = allMessages.filter((message: Message) => message.communicationType === 'DRAKEN');
-        allMessagesTree.filter((m) => {
-          return filteredMessages.find(
-            (x) =>
-              x.communicationID === m.communicationID &&
-              (sortSendingTypeMessages !== 'ALL_SEND_TYPES' ? x.direction === sortSendingTypeMessages : true)
-          );
-        });
-      } else if (sortChannelMessages === 'MINASIDOR') {
-        let filteredMessages = allMessages.filter((message: Message) => message.communicationType === 'MINASIDOR');
-        allMessagesTree.filter((m) => {
-          return filteredMessages.find(
-            (x) =>
-              x.communicationID === m.communicationID &&
-              (sortSendingTypeMessages !== 'ALL_SEND_TYPES' ? x.direction === sortSendingTypeMessages : true)
-          );
-        });
-      } else {
-        setSortedMessages(
-          sortSendingTypeMessages !== 'ALL_SEND_TYPES'
-            ? allMessages.filter((x) => x.direction === sortSendingTypeMessages)
-            : allMessagesTree
-        );
+        return filteredMessageTree;
       }
+
+      return filteredMessages;
     }
-  }, [allMessages, allMessagesTree, sortChannelMessages, sortSendingTypeMessages]);
+
+    // No channel filter, apply direction filter
+    if (sortSendingTypeMessages === 'INBOUND' || sortSendingTypeMessages === 'OUTBOUND') {
+      return allMessages.filter((message: Message) => message.direction === sortSendingTypeMessages);
+    }
+
+    return allMessagesTree;
+  }, [allMessages, allMessagesTree, sortSendingTypeMessages, sortChannelMessages]);
 
   return (
     <>

--- a/frontend/src/supportmanagement/components/support-errand/tabs/support-errand-attachments-tab.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/tabs/support-errand-attachments-tab.tsx
@@ -1,6 +1,6 @@
 import { FileUploadWrapper } from '@common/components/file-upload/file-upload-dragdrop-context';
 import FileUpload, { imageMimeTypes } from '@common/components/file-upload/file-upload.component';
-import { useAppContext } from '@common/contexts/app.context';
+import { useConfigStore, useSupportStore } from '@stores/index';
 import { isKC } from '@common/services/application-service';
 import { getToastOptions } from '@common/utils/toast-message-settings';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -58,7 +58,10 @@ const defaultAttachmentInformation: SupportAttachmentFormModel = {
 export const SupportErrandAttachmentsTab: React.FC<{
   update: () => void;
 }> = (props) => {
-  const { supportErrand, setSupportErrand, supportAttachments, user, municipalityId } = useAppContext();
+  const supportErrand = useSupportStore((s) => s.supportErrand);
+  const setSupportErrand = useSupportStore((s) => s.setSupportErrand);
+  const supportAttachments = useSupportStore((s) => s.supportAttachments);
+  const municipalityId = useConfigStore((s) => s.municipalityId);
   const [modalAttachment, setModalAttachment] = useState<SingleSupportAttachment>();
   const [addNewAttachment, setAddNewAttachment] = useState(false);
   const [modalFetching, setModalFetching] = useState(false);

--- a/frontend/src/supportmanagement/components/support-errand/tabs/support-errand-basics-tab.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/tabs/support-errand-basics-tab.tsx
@@ -1,5 +1,5 @@
 import { LinkedErrandsDisclosure } from '@common/components/linked-errands-disclosure/linked-errands-disclosure.component';
-import { useAppContext } from '@common/contexts/app.context';
+import { useSupportStore } from '@stores/index';
 import { appConfig } from '@config/appconfig';
 import { SupportContactsComponent } from '@supportmanagement/components/new-contacts/support-contacts.component';
 import { SupportErrandBasicsAboutDisclosure } from '@supportmanagement/components/support-errand-basics-disclosure/support-errand-basics-about-disclosure.component';
@@ -13,9 +13,7 @@ export const SupportErrandBasicsTab: React.FC<{
   setUnsavedFacility: Dispatch<SetStateAction<boolean>>;
   update: () => void;
 }> = (props) => {
-  const {
-    supportErrand,
-  } = useAppContext();
+  const supportErrand = useSupportStore((s) => s.supportErrand);
 
   return (
     <div className="pt-xl pb-64 px-40 flex flex-col">

--- a/frontend/src/supportmanagement/components/support-errand/tabs/support-errand-details-tab.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/tabs/support-errand-details-tab.tsx
@@ -1,14 +1,12 @@
 import { JsonParametersDisplay } from '@common/components/json/schema/json-parameters-display.component';
-import { useAppContext } from '@contexts/app.context';
+import { useConfigStore, useSupportStore } from '@stores/index';
 import { Table } from '@sk-web-gui/react';
 import { isOpenEErrand, SupportErrand } from '@supportmanagement/services/support-errand-service';
 import { useMemo } from 'react';
 
 export const SupportErrandDetailsTab: React.FC<{}> = () => {
-  const {
-    supportErrand: _supportErrand,
-    municipalityId,
-  } = useAppContext();
+  const _supportErrand = useSupportStore((s) => s.supportErrand);
+  const municipalityId = useConfigStore((s) => s.municipalityId);
   const supportErrand = _supportErrand!;
 
   const simpleParams = useMemo(

--- a/frontend/src/supportmanagement/components/support-errand/tabs/support-errand-invoice-tab.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/tabs/support-errand-invoice-tab.tsx
@@ -1,7 +1,6 @@
-import { User } from '@common/interfaces/user';
 import { prettyTime } from '@common/services/helper-service';
 import { getToastOptions } from '@common/utils/toast-message-settings';
-import { useAppContext } from '@contexts/app.context';
+import { useConfigStore, useSupportStore, useUserStore } from '@stores/index';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Button, useSnackbar } from '@sk-web-gui/react';
 import BillingForm from '@supportmanagement/components/billing/billing-form.component';
@@ -37,12 +36,10 @@ export const SupportErrandInvoiceTab: React.FC<{
   setUnsaved: (unsaved: boolean) => void;
   update: () => void;
 }> = (props) => {
-  const {
-    supportErrand,
-    user,
-    municipalityId,
-    setSupportErrand,
-  } = useAppContext();
+  const supportErrand = useSupportStore((s) => s.supportErrand);
+  const setSupportErrand = useSupportStore((s) => s.setSupportErrand);
+  const user = useUserStore((s) => s.user);
+  const municipalityId = useConfigStore((s) => s.municipalityId);
 
   const [record, setRecord] = useState<CBillingRecord | undefined>(emptyBillingRecord);
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/frontend/src/supportmanagement/components/support-errand/tabs/support-errand-recruitment-tab.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/tabs/support-errand-recruitment-tab.tsx
@@ -1,5 +1,5 @@
 import { Parameter } from '@common/data-contracts/supportmanagement/data-contracts';
-import { useAppContext } from '@contexts/app.context';
+import { useSupportStore } from '@stores/index';
 import { Checkbox, Disclosure, FormControl, FormLabel, Input, Label, Textarea } from '@sk-web-gui/react';
 import { getRecruitmentParameters, saveParameters } from '@supportmanagement/services/support-parameter-service';
 import { Text } from 'lucide-react';
@@ -10,7 +10,7 @@ export const SupportErrandRecruitmentTab: React.FC<{
   update: () => void;
   setUnsaved: (unsaved: boolean) => void;
 }> = (props) => {
-  const { supportErrand } = useAppContext();
+  const supportErrand = useSupportStore((s) => s.supportErrand);
   const [recruitmentParameterGroups, setParameters] = React.useState<{ [key: string]: Parameter[] }>({});
   const [loading, setLoading] = React.useState(false);
 

--- a/frontend/src/supportmanagement/components/support-errand/useSupportErrandTable.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/useSupportErrandTable.tsx
@@ -10,7 +10,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { SupportStatusLabelComponent } from '../ongoing-support-errands/components/support-status-label.component';
 import { appConfig } from '@config/appconfig';
-import { useAppContext } from '@contexts/app.context';
+import { useMetadataStore, useUserStore } from '@stores/index';
 import { prettyTime, sortBy, truncate } from '@common/services/helper-service';
 import dayjs from 'dayjs';
 import { getAdminName, primaryStakeholderNameorEmail } from '@supportmanagement/services/support-stakeholder-service';
@@ -19,7 +19,8 @@ import { Admin } from '@common/services/user-service';
 
 export const useSupportErrandTable = (statuses: Status[]) => {
   const { t } = useTranslation();
-  const { supportMetadata, administrators } = useAppContext();
+  const supportMetadata = useMetadataStore((s) => s.supportMetadata);
+  const administrators = useUserStore((s) => s.administrators);
 
   const labels = [
     {

--- a/frontend/src/supportmanagement/components/support-message-form/support-message-form.component.tsx
+++ b/frontend/src/supportmanagement/components/support-message-form/support-message-form.component.tsx
@@ -4,7 +4,7 @@ import { ACCEPTED_UPLOAD_FILETYPES } from '@casedata/services/casedata-attachmen
 import CommonNestedEmailArrayV2 from '@common/components/commonNestedEmailArrayV2';
 import CommonNestedPhoneArrayV2 from '@common/components/commonNestedPhoneArrayV2';
 import FileUpload from '@common/components/file-upload/file-upload.component';
-import { useAppContext } from '@common/contexts/app.context';
+import { useConfigStore, useSupportStore, useUserStore } from '@stores/index';
 import { Relation } from '@common/data-contracts/relations/data-contracts';
 import { isKA, isKC, isLOP } from '@common/services/application-service';
 import { invalidPhoneMessage, supportManagementPhonePattern } from '@common/services/helper-service';
@@ -46,13 +46,12 @@ import {
 import { Message, MessageRequest, sendMessage } from '@supportmanagement/services/support-message-service';
 import { getSupportOwnerStakeholder } from '@supportmanagement/services/support-stakeholder-service';
 import { File, Paperclip, X } from 'lucide-react';
-import dynamic from 'next/dynamic';
+import TextEditor from '@common/components/dynamic-text-editor';
 import { useEffect, useState } from 'react';
 import { Resolver, useFieldArray, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import * as yup from 'yup';
 import { getDefaultEmailBody, getDefaultSmsBody, removeEmailInformation } from '../templates/default-message-template';
-const TextEditor = dynamic(() => import('@sk-web-gui/text-editor'), { ssr: false });
 
 export interface SupportMessageFormModel {
   id: string;
@@ -138,13 +137,11 @@ export const SupportMessageForm: React.FC<{
   setUnsaved?: (unsaved: boolean) => void;
   update?: () => void;
 }> = (props) => {
-  const {
-    municipalityId,
-    user,
-    supportErrand: _supportErrand,
-    supportAttachments: _supportAttachments,
-    setSupportErrand,
-  } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const user = useUserStore((s) => s.user);
+  const _supportErrand = useSupportStore((s) => s.supportErrand);
+  const _supportAttachments = useSupportStore((s) => s.supportAttachments);
+  const setSupportErrand = useSupportStore((s) => s.setSupportErrand);
   const supportErrand = _supportErrand!;
   const supportAttachments = _supportAttachments ?? [];
 

--- a/frontend/src/supportmanagement/components/supportmanagement-filtering/components/supportmanagement-filter-category.component.tsx
+++ b/frontend/src/supportmanagement/components/supportmanagement-filtering/components/supportmanagement-filter-category.component.tsx
@@ -1,11 +1,10 @@
 import { Category } from '@common/data-contracts/supportmanagement/data-contracts';
-import { useAppContext } from '@contexts/app.context';
+import { useMetadataStore } from '@stores/index';
 import { Checkbox, PopupMenu, SearchField } from '@sk-web-gui/react';
-import { SupportMetadata } from '@supportmanagement/services/support-metadata-service';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { SupportManagementFilter } from '../supportmanagement-filtering.component';
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import { ChevronDown } from 'lucide-react';
 export interface CategoryFilter {
   category: string[];
@@ -18,12 +17,10 @@ export const CategoryValues: CategoryFilter = {
 export const SupportManagementFilterCategory: React.FC = () => {
   const { register } = useFormContext<SupportManagementFilter>();
   const [query, setQuery] = useState<string>('');
-  const [allCategories, setAllCategories] = useState<Category[]>();
-  const { supportMetadata } = useAppContext();
+  const supportMetadata = useMetadataStore((s) => s.supportMetadata);
   const { t } = useTranslation();
-  useEffect(() => {
-    setAllCategories(supportMetadata?.categories);
-  }, [supportMetadata]);
+
+  const allCategories = supportMetadata?.categories;
 
   return (
     <PopupMenu>

--- a/frontend/src/supportmanagement/components/supportmanagement-filtering/components/supportmanagement-filter-labelCategory.component.tsx
+++ b/frontend/src/supportmanagement/components/supportmanagement-filtering/components/supportmanagement-filter-labelCategory.component.tsx
@@ -1,8 +1,7 @@
-import { Category, Label } from '@common/data-contracts/supportmanagement/data-contracts';
-import { useAppContext } from '@contexts/app.context';
+import { Label } from '@common/data-contracts/supportmanagement/data-contracts';
+import { useMetadataStore } from '@stores/index';
 import { Checkbox, PopupMenu, SearchField } from '@sk-web-gui/react';
-import { SupportMetadata } from '@supportmanagement/services/support-metadata-service';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { SupportManagementFilter } from '../supportmanagement-filtering.component';
 import { ChevronDown } from 'lucide-react';
@@ -18,12 +17,9 @@ export const LabelCategoryValues: LabelCategoryFilter = {
 export const SupportManagementFilterLabelCategory: React.FC = () => {
   const { register, watch } = useFormContext<SupportManagementFilter>();
   const [query, setQuery] = useState<string>('');
-  const [allLabelCategories, setAllLabelCategories] = useState<Label[]>();
-  const { supportMetadata } = useAppContext();
+  const supportMetadata = useMetadataStore((s) => s.supportMetadata);
 
-  useEffect(() => {
-    setAllLabelCategories(supportMetadata?.labels?.labelStructure);
-  }, [supportMetadata]);
+  const allLabelCategories = supportMetadata?.labels?.labelStructure;
 
   return (
     <PopupMenu>

--- a/frontend/src/supportmanagement/components/supportmanagement-filtering/components/supportmanagement-filter-labelSubType.component.tsx
+++ b/frontend/src/supportmanagement/components/supportmanagement-filtering/components/supportmanagement-filter-labelSubType.component.tsx
@@ -1,9 +1,8 @@
 import { Label } from '@common/data-contracts/supportmanagement/data-contracts';
-import { useAppContext } from '@contexts/app.context';
+import { useMetadataStore } from '@stores/index';
 import { Checkbox, PopupMenu, SearchField } from '@sk-web-gui/react';
 import { getLabelTypeFromDisplayName } from '@supportmanagement/services/support-errand-service';
-import { SupportMetadata } from '@supportmanagement/services/support-metadata-service';
-import { useEffect, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { SupportManagementFilter } from '../supportmanagement-filtering.component';
 import { ChevronDown } from 'lucide-react';
@@ -23,10 +22,9 @@ export const SupportManagementFilterLabelSubType: React.FC = () => {
   const labelSubTypes = watch('labelSubType');
   const { register } = useFormContext<LabelSubTypeFilter>();
   const [query, setQuery] = useState<string>('');
-  const [allStringSubTypes, setAllStringSubTypes] = useState<string[]>();
-  const { supportMetadata } = useAppContext();
+  const supportMetadata = useMetadataStore((s) => s.supportMetadata);
 
-  useEffect(() => {
+  const allStringSubTypes = useMemo(() => {
     const _subTypes: Label[] = [];
     if (labelTypes.length > 0) {
       labelTypes?.forEach((typeDisplayName) => {
@@ -58,11 +56,7 @@ export const SupportManagementFilterLabelSubType: React.FC = () => {
         });
       });
     }
-    // We need a list of displayNames, not objects and not names since the
-    // labelSubType filter works with the displayName and not the names of the types
-    //
-    // See comment in ongoing-support-errands.component.tsx for more information
-    setAllStringSubTypes(Array.from(new Set(_subTypes.map((l) => l.displayName).filter((d): d is string => d !== undefined))));
+    return Array.from(new Set(_subTypes.map((l) => l.displayName).filter((d): d is string => d !== undefined)));
   }, [supportMetadata, labelCategories, labelTypes]);
 
   return (

--- a/frontend/src/supportmanagement/components/supportmanagement-filtering/components/supportmanagement-filter-labelType.component.tsx
+++ b/frontend/src/supportmanagement/components/supportmanagement-filtering/components/supportmanagement-filter-labelType.component.tsx
@@ -1,8 +1,7 @@
 import { Label } from '@common/data-contracts/supportmanagement/data-contracts';
-import { useAppContext } from '@contexts/app.context';
+import { useMetadataStore } from '@stores/index';
 import { Checkbox, PopupMenu, SearchField } from '@sk-web-gui/react';
-import { SupportMetadata } from '@supportmanagement/services/support-metadata-service';
-import { useEffect, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { SupportManagementFilter } from '../supportmanagement-filtering.component';
 import { ChevronDown } from 'lucide-react';
@@ -21,11 +20,9 @@ export const SupportManagementFilterLabelType: React.FC = () => {
   const labelTypes = watch('labelType');
   const { register } = useFormContext<LabelTypeFilter>();
   const [query, setQuery] = useState<string>('');
-  // const [allTypes, setAllTypes] = useState<Label[]>();
-  const [allStringTypes, setAllStringTypes] = useState<string[]>();
-  const { supportMetadata } = useAppContext();
+  const supportMetadata = useMetadataStore((s) => s.supportMetadata);
 
-  useEffect(() => {
+  const allStringTypes = useMemo(() => {
     const _types: Label[] = [];
     if (labelCategories.length > 0) {
       labelCategories?.forEach((category) => {
@@ -39,11 +36,7 @@ export const SupportManagementFilterLabelType: React.FC = () => {
         _types.push(...(category.labels ?? []));
       });
     }
-    // We need a list of displayNames, not objects and not names since the
-    // labelType filter works with the displayName and not the names of the types
-    //
-    // See comment in ongoing-support-errands.component.tsx for more information
-    setAllStringTypes(Array.from(new Set(_types.map((l) => l.displayName).filter((d): d is string => d !== undefined))));
+    return Array.from(new Set(_types.map((l) => l.displayName).filter((d): d is string => d !== undefined)));
   }, [supportMetadata, labelCategories]);
 
   return (

--- a/frontend/src/supportmanagement/components/supportmanagement-filtering/components/supportmanagement-filter-sidebarstatus-selector.component.tsx
+++ b/frontend/src/supportmanagement/components/supportmanagement-filtering/components/supportmanagement-filter-sidebarstatus-selector.component.tsx
@@ -1,6 +1,6 @@
 import { SidebarButton } from '@common/interfaces/sidebar-button';
 import { isROB } from '@common/services/application-service';
-import { AppContextInterface, useAppContext } from '@contexts/app.context';
+import { useCasedataStore, useSupportStore } from '@stores/index';
 import iconMap from '@common/components/lucide-icon-map/lucide-icon-map.component';
 import { Badge, Button, Spinner } from '@sk-web-gui/react';
 import store from '@supportmanagement/services/storage-service';
@@ -29,16 +29,14 @@ export const SupportManagementFilterSidebarStatusSelector: React.FC<{
   setShowAttestationTable: (show: boolean) => void;
   iconButton: boolean;
 }> = ({ showAttestationTable, setShowAttestationTable, iconButton }) => {
-  const {
-    setSidebarLabel,
-    setSelectedSupportErrandStatuses,
-    selectedSupportErrandStatuses,
-    newSupportErrands,
-    ongoingSupportErrands,
-    assignedSupportErrands,
-    suspendedSupportErrands,
-    solvedSupportErrands,
-  }: AppContextInterface = useAppContext();
+  const setSidebarLabel = useCasedataStore((s) => s.setSidebarLabel);
+  const setSelectedSupportErrandStatuses = useSupportStore((s) => s.setSelectedSupportErrandStatuses);
+  const selectedSupportErrandStatuses = useSupportStore((s) => s.selectedSupportErrandStatuses);
+  const newSupportErrands = useSupportStore((s) => s.newSupportErrands);
+  const ongoingSupportErrands = useSupportStore((s) => s.ongoingSupportErrands);
+  const assignedSupportErrands = useSupportStore((s) => s.assignedSupportErrands);
+  const suspendedSupportErrands = useSupportStore((s) => s.suspendedSupportErrands);
+  const solvedSupportErrands = useSupportStore((s) => s.solvedSupportErrands);
 
   const updateStatusFilter = (ss: Status[]) => {
     try {

--- a/frontend/src/supportmanagement/components/supportmanagement-filtering/components/supportmanagement-filter-tags.component.tsx
+++ b/frontend/src/supportmanagement/components/supportmanagement-filtering/components/supportmanagement-filter-tags.component.tsx
@@ -5,10 +5,9 @@ import { Channels, Status } from '@supportmanagement/services/support-errand-ser
 import dayjs from 'dayjs';
 import { Admin } from '@common/services/user-service';
 import { Priority } from '@supportmanagement/interfaces/priority';
-import { SupportMetadata, SupportType } from '@supportmanagement/services/support-metadata-service';
-import { useEffect, useState } from 'react';
-import { useAppContext } from '@contexts/app.context';
-import { Category, Label } from '@common/data-contracts/supportmanagement/data-contracts';
+import { SupportType } from '@supportmanagement/services/support-metadata-service';
+import { useEffect, useMemo } from 'react';
+import { useMetadataStore, useSupportStore } from '@stores/index';
 
 interface SupportManagementFilterTagsProps {
   administrators: Admin[];
@@ -16,6 +15,8 @@ interface SupportManagementFilterTagsProps {
 
 export const SupportManagementFilterTags: React.FC<SupportManagementFilterTagsProps> = ({ administrators }) => {
   const { watch, setValue, reset } = useFormContext<SupportManagementFilter>();
+  const supportMetadata = useMetadataStore((s) => s.supportMetadata);
+  const selectedSupportErrandStatuses = useSupportStore((s) => s.selectedSupportErrandStatuses);
   const categories = watch('category');
   const labelCategories = watch('labelCategory');
   const types = watch('type');
@@ -27,26 +28,14 @@ export const SupportManagementFilterTags: React.FC<SupportManagementFilterTagsPr
   const enddate = watch('enddate');
   const admins = watch('admins');
 
-  const [allCategories, setAllCategories] = useState<Category[]>();
-  const [allTypes, setAllTypes] = useState<SupportType[]>();
-  const [allLabelCategories, setAllLabelCategories] = useState<Label[]>();
-  const {
-    supportMetadata,
-    selectedSupportErrandStatuses,
-  } = useAppContext();
+  const allCategories = supportMetadata?.categories;
+  const allLabelCategories = supportMetadata?.labels?.labelStructure;
 
-  useEffect(() => {
-    setAllCategories(supportMetadata?.categories);
+  const allTypes = useMemo(() => {
     const _types: SupportType[] = [];
     if (categories.length > 0) {
       categories?.forEach((category) => {
         const categoryTypes = supportMetadata?.categories?.find((c) => c.name === category)?.types;
-        types.filter((type) => {
-          if (!categoryTypes?.find((ct) => ct.name === type)) {
-            const newTypes = types.filter((_t) => _t !== type);
-            setValue('type', newTypes);
-          }
-        });
         if (categoryTypes) {
           _types.push(...categoryTypes);
         }
@@ -56,28 +45,23 @@ export const SupportManagementFilterTags: React.FC<SupportManagementFilterTagsPr
         _types.push(...(category.types ?? []));
       });
     }
-    setAllTypes(_types);
+    return _types;
+  }, [supportMetadata, categories]);
 
-    if (supportMetadata?.labels?.labelStructure) {
-      setAllLabelCategories(supportMetadata?.labels.labelStructure);
-      const _labelTypes: string[] = [];
-      if (labelCategories.length > 0) {
-        // Some labelCategory is selected, get labelTypes from those
-        labelCategories?.forEach((category) => {
-          const categoryTypes = supportMetadata?.labels?.labelStructure?.find((c) => c.resourcePath === category)?.labels;
-          if (categoryTypes) {
-            _labelTypes.push(...categoryTypes.map((l) => l.resourcePath!));
+  useEffect(() => {
+    if (categories.length > 0) {
+      categories?.forEach((category) => {
+        const categoryTypes = supportMetadata?.categories?.find((c) => c.name === category)?.types;
+        types.filter((type) => {
+          if (!categoryTypes?.find((ct) => ct.name === type)) {
+            const newTypes = types.filter((_t) => _t !== type);
+            setValue('type', newTypes);
           }
         });
-      } else {
-        // No selected labelCategory, get all label types
-        supportMetadata?.labels?.labelStructure?.forEach((category) => {
-          _labelTypes.push(...(category.labels ?? []).map((l) => l.resourcePath!));
-        });
-      }
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [supportMetadata, categories, types, labelCategories, labelTypes, labelSubTypes]);
+  }, [supportMetadata, categories, types]);
 
   const hasTags =
     categories.length > 0 ||

--- a/frontend/src/supportmanagement/components/supportmanagement-filtering/components/supportmanagement-filter-type.component.tsx
+++ b/frontend/src/supportmanagement/components/supportmanagement-filtering/components/supportmanagement-filter-type.component.tsx
@@ -1,7 +1,7 @@
-import { useAppContext } from '@contexts/app.context';
+import { useMetadataStore } from '@stores/index';
 import { Checkbox, PopupMenu, SearchField } from '@sk-web-gui/react';
-import { SupportMetadata, SupportType } from '@supportmanagement/services/support-metadata-service';
-import { useEffect, useState } from 'react';
+import { SupportType } from '@supportmanagement/services/support-metadata-service';
+import { useEffect, useMemo, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { SupportManagementFilter } from '../supportmanagement-filtering.component';
 import { ChevronDown } from 'lucide-react';
@@ -20,19 +20,13 @@ export const SupportManagementFilterType: React.FC = () => {
   const types = watch('type');
   const { register } = useFormContext<TypeFilter>();
   const [query, setQuery] = useState<string>('');
-  const [allTypes, setAllTypes] = useState<SupportType[]>();
-  const { supportMetadata } = useAppContext();
-  useEffect(() => {
+  const supportMetadata = useMetadataStore((s) => s.supportMetadata);
+
+  const allTypes = useMemo(() => {
     const _types: SupportType[] = [];
     if (categories.length > 0) {
       categories?.forEach((category) => {
         const categoryTypes = supportMetadata?.categories?.find((c) => c.name === category)?.types;
-        types.filter((type) => {
-          if (!categoryTypes?.find((ct) => ct.name === type)) {
-            const newTypes = types.filter((_t) => _t !== type);
-            setValue('type', newTypes);
-          }
-        });
         if (categoryTypes) {
           _types.push(...categoryTypes);
         }
@@ -42,7 +36,21 @@ export const SupportManagementFilterType: React.FC = () => {
         _types.push(...(category.types ?? []));
       });
     }
-    setAllTypes(_types);
+    return _types;
+  }, [supportMetadata, categories]);
+
+  useEffect(() => {
+    if (categories.length > 0) {
+      categories?.forEach((category) => {
+        const categoryTypes = supportMetadata?.categories?.find((c) => c.name === category)?.types;
+        types.filter((type) => {
+          if (!categoryTypes?.find((ct) => ct.name === type)) {
+            const newTypes = types.filter((_t) => _t !== type);
+            setValue('type', newTypes);
+          }
+        });
+      });
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [supportMetadata, categories, types]);
 

--- a/frontend/src/supportmanagement/services/support-billing-service.ts
+++ b/frontend/src/supportmanagement/services/support-billing-service.ts
@@ -3,7 +3,7 @@ import { PortalPersonData } from '@common/data-contracts/employee/data-contracts
 import { User } from '@common/interfaces/user';
 import { ApiResponse, apiService } from '@common/services/api-service';
 import { twoDecimals } from '@common/services/helper-service';
-import { useAppContext } from '@contexts/app.context';
+import { useBillingStore, useConfigStore } from '@stores/index';
 import { useSnackbar } from '@sk-web-gui/react';
 import { useCallback, useEffect } from 'react';
 import {
@@ -500,7 +500,9 @@ export const useBillingRecords = (
   sort?: { [key: string]: 'asc' | 'desc' }
 ): CPageBillingRecord => {
   const toastMessage = useSnackbar();
-  const { setIsLoading, setBillingRecords, billingRecords } = useAppContext();
+  const setIsLoading = useConfigStore((s) => s.setIsLoading);
+  const setBillingRecords = useBillingStore((s) => s.setBillingRecords);
+  const billingRecords = useBillingStore((s) => s.billingRecords);
   const fetchBillingRecords = useCallback(
     async (page: number = 0) => {
       // setIsLoading(true);

--- a/frontend/src/supportmanagement/services/support-errand-service.ts
+++ b/frontend/src/supportmanagement/services/support-errand-service.ts
@@ -4,7 +4,7 @@ import { apiService, Data } from '@common/services/api-service';
 import { isKC, isROB } from '@common/services/application-service';
 import sanitized from '@common/services/sanitizer-service';
 import { appConfig } from '@config/appconfig';
-import { useAppContext } from '@contexts/app.context';
+import { useConfigStore, useSupportStore } from '@stores/index';
 import { useSnackbar } from '@sk-web-gui/react';
 import { ForwardFormProps } from '@supportmanagement/components/support-errand/sidebar/forward-errand.component';
 import { ApiPagingData, RegisterSupportErrandFormModel } from '@supportmanagement/interfaces/errand';
@@ -393,21 +393,19 @@ export const useSupportErrands = (
   extraParameters?: { [key: string]: string }
 ): SupportErrandsData => {
   const toastMessage = useSnackbar();
-  const {
-    setIsLoading,
-    setSupportErrands,
-    supportErrands,
-    setNewSupportErrands,
-    newSupportErrands,
-    setOngoingSupportErrands,
-    ongoingSupportErrands,
-    setSuspendedSupportErrands,
-    suspendedSupportErrands,
-    setAssignedSupportErrands,
-    assignedSupportErrands,
-    setSolvedSupportErrands,
-    solvedSupportErrands,
-  } = useAppContext();
+  const setIsLoading = useConfigStore((s) => s.setIsLoading);
+  const setSupportErrands = useSupportStore((s) => s.setSupportErrands);
+  const supportErrands = useSupportStore((s) => s.supportErrands);
+  const setNewSupportErrands = useSupportStore((s) => s.setNewSupportErrands);
+  const newSupportErrands = useSupportStore((s) => s.newSupportErrands);
+  const setOngoingSupportErrands = useSupportStore((s) => s.setOngoingSupportErrands);
+  const ongoingSupportErrands = useSupportStore((s) => s.ongoingSupportErrands);
+  const setSuspendedSupportErrands = useSupportStore((s) => s.setSuspendedSupportErrands);
+  const suspendedSupportErrands = useSupportStore((s) => s.suspendedSupportErrands);
+  const setAssignedSupportErrands = useSupportStore((s) => s.setAssignedSupportErrands);
+  const assignedSupportErrands = useSupportStore((s) => s.assignedSupportErrands);
+  const setSolvedSupportErrands = useSupportStore((s) => s.setSolvedSupportErrands);
+  const solvedSupportErrands = useSupportStore((s) => s.solvedSupportErrands);
 
   const fetchErrands = useCallback(
     async (page: number = 0) => {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -26,7 +26,8 @@
       "@common/*": ["src/common/*"],
       "@jestRoot/*": [".jest/*"],
       "@styles/*": ["src/styles/*"],
-      "@cypress/*": ["cypress/*"]
+      "@cypress/*": ["cypress/*"],
+      "@stores/*": ["src/stores/*"]
       // "@services/*": ["src/services/*"],
       // "@common/components/*": ["src/components/*"],
       // "@interfaces/*": ["src/interfaces/*"],

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1696,6 +1696,18 @@
   dependencies:
     mini-svg-data-uri "^1.2.3"
 
+"@tanstack/query-core@5.91.2":
+  version "5.91.2"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.91.2.tgz#d83825a928aa49ded38d3910f05284178cce89d3"
+  integrity sha512-Uz2pTgPC1mhqrrSGg18RKCWT/pkduAYtxbcyIyKBhw7dTWjXZIzqmpzO2lBkyWr4hlImQgpu1m1pei3UnkFRWw==
+
+"@tanstack/react-query@^5.91.2":
+  version "5.91.2"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.91.2.tgz#febe35515d611bd3d725a892cc35c37e743fbe62"
+  integrity sha512-GClLPzbM57iFXv+FlvOUL56XVe00PxuTaVEyj1zAObhRiKF008J5vedmaq7O6ehs+VmPHe8+PUQhMuEyv8d9wQ==
+  dependencies:
+    "@tanstack/query-core" "5.91.2"
+
 "@tanstack/react-virtual@^3.13.9":
   version "3.13.12"
   resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz#d372dc2783739cc04ec1a728ca8203937687a819"
@@ -1719,13 +1731,6 @@
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
-
-"@types/hoist-non-react-statics@^3.3.6":
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz#306e3a3a73828522efa1341159da4846e7573a6c"
-  integrity sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==
-  dependencies:
-    hoist-non-react-statics "^3.3.0"
 
 "@types/json-schema@^7.0.15":
   version "7.0.15"
@@ -2719,11 +2724,6 @@ cookie@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.0.2.tgz#27360701532116bd3f1f9416929d176afe1e4610"
   integrity sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==
-
-core-js@^3:
-  version "3.45.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.45.1.tgz#5810e04a1b4e9bc5ddaa4dd12e702ff67300634d"
-  integrity sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==
 
 core-util-is@1.0.2:
   version "1.0.2"
@@ -3998,13 +3998,6 @@ hermes-parser@^0.25.1:
   dependencies:
     hermes-estree "0.25.1"
 
-hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
-  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
-  dependencies:
-    react-is "^16.7.0"
-
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
@@ -4045,11 +4038,6 @@ human-signals@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
-
-i18next-fs-backend@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/i18next-fs-backend/-/i18next-fs-backend-2.6.0.tgz#7b6b54c5ffc2a5073e47eda0673c002376fa1a3c"
-  integrity sha512-3ZlhNoF9yxnM8pa8bWp5120/Ob6t4lVl1l/tbLmkml/ei3ud8IWySCHt2lrY5xWRlSU5D9IV2sm5bEbGuTqwTw==
 
 i18next-resources-to-backend@^1.2.1:
   version "1.2.1"
@@ -4940,17 +4928,6 @@ next-i18n-router@^5.5.6:
     "@formatjs/intl-localematcher" "^0.6.2"
     negotiator "^1.0.0"
 
-next-i18next@^15.4.3:
-  version "15.4.3"
-  resolved "https://registry.yarnpkg.com/next-i18next/-/next-i18next-15.4.3.tgz#2d9aae8fddf2de1cab5336f95dc69569506bcd9c"
-  integrity sha512-ZRmiz72o1Jvh2ZghCUQX1Ua5F/f2W1/Ila/L1ZeKVuSWiH7J4zfUedfDxNBEhj9lajREC7aoJuPXMFtKi2bdIg==
-  dependencies:
-    "@babel/runtime" "^7.23.2"
-    "@types/hoist-non-react-statics" "^3.3.6"
-    core-js "^3"
-    hoist-non-react-statics "^3.3.2"
-    i18next-fs-backend "^2.6.0"
-
 next@16.1.6:
   version "16.1.6"
   resolved "https://registry.yarnpkg.com/next/-/next-16.1.6.tgz#24a861371cbe211be7760d9a89ddf2415e3824de"
@@ -5619,7 +5596,7 @@ react-image-crop@^10.0.7:
   resolved "https://registry.yarnpkg.com/react-image-crop/-/react-image-crop-10.1.8.tgz#6f7b33d069f6cfb887e66faee16a9fb2e6d31137"
   integrity sha512-4rb8XtXNx7ZaOZarKKnckgz4xLMvds/YrU6mpJfGhGAsy2Mg4mIw1x+DCCGngVGq2soTBVVOxx2s/C6mTX9+pA==
 
-react-is@^16.13.1, react-is@^16.7.0:
+react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -7055,3 +7032,8 @@ yup@1.7.0:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.6.tgz#89c56e0aa7d2b05107d894412227087885ab112a"
   integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==
+
+zustand@^5.0.12:
+  version "5.0.12"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-5.0.12.tgz#ed36f647aa89965c4019b671dfc23ef6c6e3af8c"
+  integrity sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==


### PR DESCRIPTION
## Sammanfattning

- Introducera 7 Zustand stores (`user`, `casedata`, `support`, `metadata`, `config`, `billing`, `feature-flag`) som ersätter den monolitiska `AppContext` (33 useState, ~300 rader)
- Migrera ~100 komponentfiler från `useAppContext()` till selektiva store hooks (`useUserStore`, `useCasedataStore`, etc.)
- Varje komponent prenumererar nu bara på de state-fält den faktiskt använder, vilket minskar onödiga re-renders
- Metadata store inkluderar localStorage-persistering med 30 min staleness
- Feature flag store ger ett reaktivt alternativ till den muterbara `appConfig`
- Uppdatera `package.json`: lägga till `zustand` och `@tanstack/react-query`, ta bort `next-i18next`
- Lägga till `@stores/*` path alias i `tsconfig.json`
- Migrera `next-i18next`-imports till `react-i18next` i berörda filer

## Bakgrund

Den här PR:en är **del 2 av 5** i uppdelningen av #866. Bygger på #900.

**Merge-ordning:**
1. #900 — i18n-cleanup ✅
2. **→ Denna PR** — Zustand state management
3. `refactor/3-server-components` — Server components + error boundaries
4. `refactor/4-component-splitting` — Komponent-uppdelning
5. `refactor/5-form-react-query` — React Query + testkonfiguration

## Varför Zustand istället för AppContext?

`AppContext` hade 33 `useState`-anrop i en enda Provider. Varje state-ändring orsakade re-render av samtliga konsumenter, oavsett om de använde det ändrade fältet. Zustand med selektiva selektorer (`useXxxStore((s) => s.field)`) löser detta strukturellt.

## Testplan

- [ ] Verifiera att all state (user, errand, supportErrand, metadata, etc.) fortfarande fungerar korrekt
- [ ] Testa att sidnavigering inte tappar state
- [ ] Verifiera att metadata-caching i localStorage fungerar (inspektera i DevTools)
- [ ] Kör befintliga Cypress-tester för KontaktCenter, MEX och PT