### PR TITLE
[4/5] refactor: split monolithic errand components into focused modules

### DIFF
--- a/frontend/src/casedata/components/errand/casedata-errand-header.tsx
+++ b/frontend/src/casedata/components/errand/casedata-errand-header.tsx
@@ -1,0 +1,16 @@
+import { CaseLabels } from '@casedata/interfaces/case-label';
+import { useCasedataStore } from '@stores/index';
+
+export const CasedataErrandHeader: React.FC = () => {
+  const errand = useCasedataStore((s) => s.errand);
+
+  if (!errand?.id) return null;
+
+  return (
+    <div className="flex flex-col lg:flex-row justify-between lg:items-center mb-24 pt-8 w-full">
+      <h1 className="max-md:w-full text-h3-sm md:text-h3-md xl:text-h2-lg mb-0 break-words">
+        {CaseLabels.ALL[errand.caseType as keyof typeof CaseLabels.ALL] ?? ''}
+      </h1>
+    </div>
+  );
+};

--- a/frontend/src/casedata/components/errand/casedata-errand-layout.tsx
+++ b/frontend/src/casedata/components/errand/casedata-errand-layout.tsx
@@ -1,0 +1,60 @@
+import { CasedataTabsWrapper } from '@casedata/components/errand/casedata-tabs-wrapper';
+import { Spinner } from '@sk-web-gui/react';
+import { useCasedataStore } from '@stores/index';
+import { CasedataErrandHeader } from './casedata-errand-header';
+import { CasedataMetadataBand } from './casedata-metadata-band';
+import { CasedataRegisterHeader } from './casedata-register-header';
+import { SidebarWrapper } from './sidebar/sidebar.wrapper';
+
+interface Props {
+  isLoading: boolean;
+}
+
+export const CasedataErrandLayout: React.FC<Props> = ({ isLoading }) => {
+  const errand = useCasedataStore((s) => s.errand);
+
+  return (
+    <div className="grow shrink overflow-y-hidden">
+      <div className="flex justify-end w-full h-full">
+        <div className="flex justify-center overflow-y-auto w-full grow max-lg:mr-[5.6rem]">
+          <main className="flex-grow flex justify-center px-24 max-w-errand h-fit w-full pb-40">
+            {isLoading ? (
+              <div className="h-full w-full flex flex-col items-center justify-start p-28">
+                <Spinner size={4} />
+                <span className="text-gray m-md">Hämtar ärende..</span>
+              </div>
+            ) : (
+              <div className="flex-grow w-full">
+                <section className="bg-transparent pt-24 pb-4">
+                  <div className="flex justify-between mb-md w-full">
+                    <div className="w-full flex flex-wrap flex-col justify-between">
+                      {(() => {
+                        if (errand?.id) {
+                          return (
+                            <>
+                              <CasedataErrandHeader />
+                              <CasedataMetadataBand />
+                            </>
+                          );
+                        }
+                        if (errand) {
+                          return <CasedataRegisterHeader />;
+                        }
+                        return null;
+                      })()}
+                    </div>
+                  </div>
+                </section>
+
+                <section className="bg-transparent pb-4">
+                  <div className="bg-transparent py-12">{errand && <CasedataTabsWrapper />}</div>
+                </section>
+              </div>
+            )}
+          </main>
+        </div>
+        {errand?.id ? <SidebarWrapper /> : null}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/casedata/components/errand/casedata-errand.component.tsx
+++ b/frontend/src/casedata/components/errand/casedata-errand.component.tsx
@@ -1,73 +1,53 @@
-import { CasedataTabsWrapper } from '@casedata/components/errand/casedata-tabs-wrapper';
-import { CaseLabels } from '@casedata/interfaces/case-label';
 import { IErrand } from '@casedata/interfaces/errand';
 import { getErrandNotes } from '@casedata/services/casedata-errand-notes-service';
 import { emptyErrand, getErrandByErrandNumber, isErrandLocked } from '@casedata/services/casedata-errand-service';
-import { getOwnerStakeholder } from '@casedata/services/casedata-stakeholder-service';
 import { getUiPhase } from '@casedata/services/process-service';
-import { PriorityComponent } from '@common/components/priority/priority.component';
-import { useAppContext } from '@common/contexts/app.context';
-import { getMe } from '@common/services/user-service';
-import { appConfig } from '@config/appconfig';
+import { useCasedataStore, useConfigStore } from '@stores/index';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { Button, Spinner, useSnackbar } from '@sk-web-gui/react';
-import { ArrowRight } from 'lucide-react';
-import { useParams, useRouter } from 'next/navigation';
-import { Fragment, useEffect, useRef, useState } from 'react';
+import { useSnackbar } from '@sk-web-gui/react';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import { FormProvider, Resolver, useForm } from 'react-hook-form';
 import * as yup from 'yup';
-import { SaveButtonComponent } from '../save-button/save-button.component';
-import { SidebarWrapper } from './sidebar/sidebar.wrapper';
+import { CasedataErrandLayout } from './casedata-errand-layout';
 
-export const CasedataErrandComponent: React.FC = () => {
-  const params = useParams<{ errandNumber?: string }>();
-  const errandNumber = params?.errandNumber;
-  let formSchema = yup
-    .object({
-      caseType: yup
-        .string()
-        .required('Ärendetyp måste anges')
-        .test('notDefaultCasetype', 'Ärendetyp måste väljas', (val) => !!val && val !== 'Välj ärendetyp'),
-      channel: yup.string(),
-      description: yup.string(),
-      municipalityId: yup.string().required('Kommun måste anges'),
-      phase: yup.string(),
-      priority: yup.string(),
-      status: yup.object({
-        statusType: yup.string(),
-      }),
-    })
-    .required();
+const formSchema = yup
+  .object({
+    caseType: yup
+      .string()
+      .required('Ärendetyp måste anges')
+      .test('notDefaultCasetype', 'Ärendetyp måste väljas', (val) => !!val && val !== 'Välj ärendetyp'),
+    channel: yup.string(),
+    description: yup.string(),
+    municipalityId: yup.string().required('Kommun måste anges'),
+    phase: yup.string(),
+    priority: yup.string(),
+    status: yup.object({
+      statusType: yup.string(),
+    }),
+  })
+  .required();
 
+export const CasedataErrandComponent: React.FC<{ errandNumber?: string }> = ({ errandNumber }) => {
   const [isLoading, setIsLoading] = useState(false);
-  const { municipalityId, errand, setErrand, setUiPhase, setNotesCount, setServiceNotesCount } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const errand = useCasedataStore((s) => s.errand);
+  const setErrand = useCasedataStore((s) => s.setErrand);
+  const setUiPhase = useCasedataStore((s) => s.setUiPhase);
+  const setNotesCount = useCasedataStore((s) => s.setNotesCount);
+  const setServiceNotesCount = useCasedataStore((s) => s.setServiceNotesCount);
   const toastMessage = useSnackbar();
+  const router = useRouter();
 
   const methods = useForm<IErrand>({
-    resolver: yupResolver(formSchema) as unknown as Resolver<IErrand>, //Temporary bypass for resolver
-    defaultValues: errand,
-    mode: 'onChange', // NOTE: Needed if we want to disable submit until valid
+    resolver: yupResolver(formSchema) as unknown as Resolver<IErrand>,
+    defaultValues: errand ?? (emptyErrand as IErrand),
+    mode: 'onChange',
     disabled: errand ? isErrandLocked(errand) : false,
   });
 
-  const initialFocus = useRef<HTMLBodyElement>(null);
-  const setInitialFocus = () => {
-    setTimeout(() => {
-      initialFocus.current && initialFocus.current.focus();
-    });
-  };
-  const router = useRouter();
-  const { setUser } = useAppContext();
-
   useEffect(() => {
-    setInitialFocus();
-    getMe()
-      .then((user) => {
-        setUser(user);
-      })
-      .catch((e) => {});
     if (errandNumber) {
-      // Existing errand, load it and show it
       setIsLoading(true);
       getErrandByErrandNumber(municipalityId, errandNumber)
         .then((res) => {
@@ -91,7 +71,6 @@ export const CasedataErrandComponent: React.FC = () => {
           });
         });
     } else {
-      // Registering new errand, show default values
       setErrand(emptyErrand as IErrand);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -108,176 +87,9 @@ export const CasedataErrandComponent: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [errand]);
 
-  function estateToText(propertyDesignation?: string) {
-    if (!propertyDesignation) {
-      return '(saknas)';
-    }
-    const MunicipalityName = propertyDesignation.toLowerCase().split(' ')[0];
-    const propertyName = propertyDesignation
-      .toLowerCase()
-      .substring(propertyDesignation.toLowerCase().indexOf(' ') + 1);
-
-    return (
-      MunicipalityName.charAt(0).toUpperCase() +
-      String(MunicipalityName).slice(1) +
-      ' ' +
-      propertyName.charAt(0).toUpperCase() +
-      String(propertyName).slice(1)
-    );
-  }
-
   return (
     <FormProvider {...methods}>
-      <div className="grow shrink overflow-y-hidden">
-        <div className="flex justify-end w-full h-full">
-          <div className="flex justify-center overflow-y-auto w-full grow max-lg:mr-[5.6rem]">
-            <main className="flex-grow flex justify-center px-24 max-w-errand h-fit w-full pb-40">
-              {isLoading ? (
-                <div className="h-full w-full flex flex-col items-center justify-start p-28">
-                  <Spinner size={4} />
-                  <span className="text-gray m-md">Hämtar ärende..</span>
-                </div>
-              ) : (
-                <div className="flex-grow w-full">
-                  <section className="bg-transparent pt-24 pb-4">
-                    <div className="flex justify-between mb-md w-full">
-                      <div className="w-full flex flex-wrap flex-col justify-between">
-                        {errand && errand.id ? (
-                          <>
-                            <div className="flex flex-col lg:flex-row justify-between lg:items-center mb-24 pt-8 w-full">
-                              <h1 className="max-md:w-full text-h3-sm md:text-h3-md xl:text-h2-lg mb-0 break-words">
-                                {errand && errand.id
-                                  ? CaseLabels.ALL[errand?.caseType as keyof typeof CaseLabels.ALL]
-                                  : ''}
-                              </h1>
-                            </div>
-                            <div className="rounded-cards">
-                              <div className="flex gap-x-32 gap-y-8 bg-background-color-mixin-1 rounded-button p-md border">
-                                <div className="pr-sm">
-                                  <div data-cy="errandStatusLabel" className="font-bold">
-                                    Ärendestatus
-                                  </div>
-                                  <div data-cy="errandStatus">{errand?.status?.statusType}</div>
-                                </div>
-                                <div className="pr-sm">
-                                  <div className="font-bold" data-cy="errandPriorityLabel">
-                                    Prioritet
-                                  </div>
-                                  <div>
-                                    <span className="flex gap-sm items-center">
-                                      <PriorityComponent priority={errand?.priority} />
-                                    </span>
-                                  </div>
-                                </div>
-
-                                <div className="pr-sm">
-                                  <div data-cy="errandRegisteredLabel" className="font-bold">
-                                    Registrerat
-                                  </div>
-                                  <div data-cy="errandRegistered">{errand?.created}</div>
-                                </div>
-                                <div className="pr-sm">
-                                  <div className="font-bold" data-cy="errandStakeholderLabel">
-                                    Ärendeägare
-                                  </div>
-                                  <div data-cy="errandStakeholder">
-                                    {(() => {
-                                      const owner = getOwnerStakeholder(errand);
-                                      if (!owner) return '(saknas)';
-                                      if (owner.firstName && owner.lastName) {
-                                        return `${owner.firstName} ${owner.lastName}`;
-                                      }
-                                      if (owner.organizationName) {
-                                        return owner.organizationName;
-                                      }
-                                      return '(saknas)';
-                                    })()}
-                                  </div>
-                                </div>
-
-                                {appConfig.features.useFacilities ? (
-                                  <div className="pr-sm w-[40%]">
-                                    <div className="font-bold">Fastighetsbeteckning</div>
-                                    <div>
-                                      {errand?.facilities?.map((estate, index) => (
-                                        <Fragment key={`estate-${estate.id}`}>
-                                          {index === 0
-                                            ? estateToText(estate?.address?.propertyDesignation)
-                                            : ', ' + estateToText(estate?.address?.propertyDesignation)}
-                                        </Fragment>
-                                      ))}
-                                      {errand?.facilities?.length === 0 ? '(saknas)' : null}
-                                    </div>
-                                  </div>
-                                ) : (
-                                  <div className="pr-sm w-[40%]">
-                                    <>
-                                      {getOwnerStakeholder(errand)?.stakeholderType === 'PERSON' ? (
-                                        <>
-                                          <div className="font-bold" data-cy="errandPersonalNumberLabel">
-                                            Personnummer
-                                          </div>
-                                          <div data-cy="errandPersonalNumber">
-                                            {errand && getOwnerStakeholder(errand)?.personalNumber
-                                              ? getOwnerStakeholder(errand)?.personalNumber
-                                              : '(saknas)'}
-                                          </div>
-                                        </>
-                                      ) : getOwnerStakeholder(errand)?.stakeholderType === 'ORGANIZATION' ? (
-                                        <>
-                                          <div className="font-bold">Organisationsnummer</div>
-                                          <div>
-                                            {errand && getOwnerStakeholder(errand)?.organizationNumber
-                                              ? getOwnerStakeholder(errand)?.organizationNumber
-                                              : '(saknas)'}
-                                          </div>
-                                        </>
-                                      ) : null}
-                                    </>
-                                  </div>
-                                )}
-                              </div>
-                            </div>
-                          </>
-                        ) : errand ? (
-                          <div data-cy="registerErrandHeading" className="flex justify-between items-center pt-8">
-                            <h1 className="text-h3-sm md:text-h3-md xl:text-h2-lg mb-0 break-words">
-                              Registrera nytt ärende
-                            </h1>
-                            <div className="flex gap-md">
-                              <Button
-                                variant="tertiary"
-                                onClick={() => {
-                                  window.close();
-                                }}
-                              >
-                                Avbryt
-                              </Button>
-                              <SaveButtonComponent
-                                registeringNewErrand={typeof errand?.id === 'undefined'}
-                                setUnsaved={() => {}}
-                                update={() => {}}
-                                label="Registrera"
-                                color="vattjom"
-                                icon={<ArrowRight size={18} />}
-                              />
-                            </div>
-                          </div>
-                        ) : null}
-                      </div>
-                    </div>
-                  </section>
-
-                  <section className="bg-transparent pb-4">
-                    <div className="bg-transparent py-12">{errand && <CasedataTabsWrapper />}</div>
-                  </section>
-                </div>
-              )}
-            </main>
-          </div>
-          {errand?.id ? <SidebarWrapper /> : null}
-        </div>
-      </div>
+      <CasedataErrandLayout isLoading={isLoading} />
     </FormProvider>
   );
 };

--- a/frontend/src/casedata/components/errand/casedata-metadata-band.tsx
+++ b/frontend/src/casedata/components/errand/casedata-metadata-band.tsx
@@ -1,0 +1,113 @@
+import { getOwnerStakeholder } from '@casedata/services/casedata-stakeholder-service';
+import { PriorityComponent } from '@common/components/priority/priority.component';
+import { appConfig } from '@config/appconfig';
+import { useCasedataStore } from '@stores/index';
+import { Fragment } from 'react';
+import { estateToText } from './utils/estate-text';
+
+const getOwnerDisplayName = (errand: Parameters<typeof getOwnerStakeholder>[0]): string => {
+  const owner = getOwnerStakeholder(errand);
+  if (!owner) return '(saknas)';
+  if (owner.firstName && owner.lastName) {
+    return `${owner.firstName} ${owner.lastName}`;
+  }
+  if (owner.organizationName) {
+    return owner.organizationName;
+  }
+  return '(saknas)';
+};
+
+const OwnerIdentifier: React.FC<{ errand: Parameters<typeof getOwnerStakeholder>[0] }> = ({ errand }) => {
+  const owner = getOwnerStakeholder(errand);
+  const stakeholderType = owner?.stakeholderType;
+
+  if (stakeholderType === 'PERSON') {
+    return (
+      <>
+        <div className="font-bold" data-cy="errandPersonalNumberLabel">
+          Personnummer
+        </div>
+        <div data-cy="errandPersonalNumber">
+          {owner?.personalNumber ?? '(saknas)'}
+        </div>
+      </>
+    );
+  }
+
+  if (stakeholderType === 'ORGANIZATION') {
+    return (
+      <>
+        <div className="font-bold">Organisationsnummer</div>
+        <div>
+          {owner?.organizationNumber ?? '(saknas)'}
+        </div>
+      </>
+    );
+  }
+
+  return null;
+};
+
+export const CasedataMetadataBand: React.FC = () => {
+  const errand = useCasedataStore((s) => s.errand);
+
+  if (!errand?.id) return null;
+
+  return (
+    <div className="rounded-cards">
+      <div className="flex gap-x-32 gap-y-8 bg-background-color-mixin-1 rounded-button p-md border">
+        <div className="pr-sm">
+          <div data-cy="errandStatusLabel" className="font-bold">
+            Ärendestatus
+          </div>
+          <div data-cy="errandStatus">{errand?.status?.statusType}</div>
+        </div>
+        <div className="pr-sm">
+          <div className="font-bold" data-cy="errandPriorityLabel">
+            Prioritet
+          </div>
+          <div>
+            <span className="flex gap-sm items-center">
+              <PriorityComponent priority={errand?.priority} />
+            </span>
+          </div>
+        </div>
+
+        <div className="pr-sm">
+          <div data-cy="errandRegisteredLabel" className="font-bold">
+            Registrerat
+          </div>
+          <div data-cy="errandRegistered">{errand?.created}</div>
+        </div>
+        <div className="pr-sm">
+          <div className="font-bold" data-cy="errandStakeholderLabel">
+            Ärendeägare
+          </div>
+          <div data-cy="errandStakeholder">
+            {getOwnerDisplayName(errand)}
+          </div>
+        </div>
+
+        {appConfig.features.useFacilities ? (
+          <div className="pr-sm w-[40%]">
+            <div className="font-bold">Fastighetsbeteckning</div>
+            <div>
+              {errand?.facilities?.map((estate, index) => (
+                <Fragment key={`estate-${estate.id}`}>
+                  {index === 0
+                    ? estateToText(estate?.address?.propertyDesignation)
+                    : ', ' + estateToText(estate?.address?.propertyDesignation)}
+                </Fragment>
+              ))}
+              {errand?.facilities?.length === 0 ? '(saknas)' : null}
+            </div>
+          </div>
+        ) : (
+          <div className="pr-sm w-[40%]">
+            <OwnerIdentifier errand={errand} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/casedata/components/errand/casedata-register-header.tsx
+++ b/frontend/src/casedata/components/errand/casedata-register-header.tsx
@@ -1,0 +1,36 @@
+import { Button } from '@sk-web-gui/react';
+import { useCasedataStore } from '@stores/index';
+import { ArrowRight } from 'lucide-react';
+import { SaveButtonComponent } from '../save-button/save-button.component';
+
+export const CasedataRegisterHeader: React.FC = () => {
+  const errand = useCasedataStore((s) => s.errand);
+
+  if (!errand || errand.id) return null;
+
+  return (
+    <div data-cy="registerErrandHeading" className="flex justify-between items-center pt-8">
+      <h1 className="text-h3-sm md:text-h3-md xl:text-h2-lg mb-0 break-words">
+        Registrera nytt ärende
+      </h1>
+      <div className="flex gap-md">
+        <Button
+          variant="tertiary"
+          onClick={() => {
+            window.close();
+          }}
+        >
+          Avbryt
+        </Button>
+        <SaveButtonComponent
+          registeringNewErrand={errand?.id === undefined}
+          setUnsaved={() => {}}
+          update={() => {}}
+          label="Registrera"
+          color="vattjom"
+          icon={<ArrowRight size={18} />}
+        />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/casedata/components/errand/casedata-tabs-wrapper.tsx
+++ b/frontend/src/casedata/components/errand/casedata-tabs-wrapper.tsx
@@ -11,7 +11,7 @@ import {
   groupByConversationIdSortedTree,
 } from '@casedata/services/casedata-message-service';
 import { getOwnerStakeholder } from '@casedata/services/casedata-stakeholder-service';
-import { useAppContext } from '@common/contexts/app.context';
+import { useCasedataStore, useConfigStore } from '@stores/index';
 import { isPT } from '@common/services/application-service';
 import WarnIfUnsavedChanges from '@common/utils/warnIfUnsavedChanges';
 import { Tabs, useSnackbar } from '@sk-web-gui/react';
@@ -31,19 +31,17 @@ import { contractsEnabled } from '@common/services/feature-flag-service';
 import { appConfig } from '@config/appconfig';
 
 export const CasedataTabsWrapper: React.FC = () => {
-  const {
-    municipalityId,
-    errand,
-    setErrand,
-    messages,
-    setMessages,
-    setConversation,
-    setConversationTree,
-    setMessageTree,
-    setAssets,
-    assets,
-    uiPhase,
-  } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const errand = useCasedataStore((s) => s.errand);
+  const setErrand = useCasedataStore((s) => s.setErrand);
+  const messages = useCasedataStore((s) => s.messages);
+  const setMessages = useCasedataStore((s) => s.setMessages);
+  const setConversation = useCasedataStore((s) => s.setConversation);
+  const setConversationTree = useCasedataStore((s) => s.setConversationTree);
+  const setMessageTree = useCasedataStore((s) => s.setMessageTree);
+  const setAssets = useCasedataStore((s) => s.setAssets);
+  const assets = useCasedataStore((s) => s.assets);
+  const uiPhase = useCasedataStore((s) => s.uiPhase);
   const [unsavedChanges, setUnsavedChanges] = useState(false);
   const [unsavedUppgifter, setUnsavedUppgifter] = useState(false);
   const [unsavedContract, setUnsavedContract] = useState(false);

--- a/frontend/src/casedata/components/errand/utils/estate-text.ts
+++ b/frontend/src/casedata/components/errand/utils/estate-text.ts
@@ -1,0 +1,17 @@
+export function estateToText(propertyDesignation?: string): string {
+  if (!propertyDesignation) {
+    return '(saknas)';
+  }
+  const municipalityName = propertyDesignation.toLowerCase().split(' ')[0];
+  const propertyName = propertyDesignation
+    .toLowerCase()
+    .substring(propertyDesignation.toLowerCase().indexOf(' ') + 1);
+
+  return (
+    municipalityName.charAt(0).toUpperCase() +
+    String(municipalityName).slice(1) +
+    ' ' +
+    propertyName.charAt(0).toUpperCase() +
+    String(propertyName).slice(1)
+  );
+}

--- a/frontend/src/supportmanagement/components/support-errand/support-errand-header.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/support-errand-header.tsx
@@ -1,0 +1,41 @@
+import { useMetadataStore, useSupportStore } from '@stores/index';
+import { appConfig } from '@config/appconfig';
+import { supportErrandIsEmpty } from '@supportmanagement/services/support-errand-service';
+import { Button } from '@sk-web-gui/react';
+import { SupportErrandSummary } from '../support-errand-basics-form/support-errand-summary.component';
+
+export const SupportErrandHeader: React.FC = () => {
+  const supportErrand = useSupportStore((s) => s.supportErrand);
+  const supportMetadata = useMetadataStore((s) => s.supportMetadata);
+  const categoriesList = supportMetadata?.categories;
+
+  if (!supportErrand) return null;
+
+  if (!supportErrandIsEmpty(supportErrand)) {
+    return (
+      <>
+        <h1 className="max-md:w-full text-h2-sm md:text-h2-md xl:text-h2-md mb-0 break-words">
+          {appConfig.features.useThreeLevelCategorization
+            ? supportErrand.labels?.find((l) => l.classification === 'TYPE')?.displayName ??
+              '(Ärendetyp saknas)'
+            : categoriesList?.find((c) => c.name === supportErrand?.classification?.category)
+                ?.displayName}
+        </h1>
+        {process.env.NEXT_PUBLIC_APPLICATION === 'IAF' && <SupportErrandSummary />}
+      </>
+    );
+  }
+
+  return (
+    <div className="flex justify-between items-center pt-8">
+      <h1 className="text-h3-sm md:text-h3-md xl:text-h2-lg mb-0 break-words">
+        Registrera nytt ärende
+      </h1>
+      <div className="flex gap-md">
+        <Button variant="tertiary" onClick={() => window.close()}>
+          Avbryt
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/supportmanagement/components/support-errand/support-errand-layout.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/support-errand-layout.tsx
@@ -1,0 +1,63 @@
+import { useSupportStore } from '@stores/index';
+import { Spinner, useGui } from '@sk-web-gui/react';
+import { useState } from 'react';
+import { MessagePortal } from './sidebar/message-portal.component';
+import { SidebarWrapper } from './sidebar/sidebar.wrapper';
+import { SupportErrandHeader } from './support-errand-header';
+import { SupportTabsWrapper } from './support-tabs-wrapper';
+
+interface Props {
+  isLoading: boolean;
+  loadingMessage: string;
+}
+
+export const SupportErrandLayout: React.FC<Props> = ({ isLoading, loadingMessage }) => {
+  const [unsavedFacility, setUnsavedFacility] = useState(false);
+  const supportErrand = useSupportStore((s) => s.supportErrand);
+  const { theme } = useGui();
+
+  return (
+    <div className="grow shrink overflow-y-hidden">
+      <div className="flex justify-end w-full pl-24 md:pl-40 h-full">
+        <div className="flex justify-center overflow-y-auto w-full grow max-lg:mr-[5.6rem]">
+          <main
+            className="flex-grow flex justify-center max-w-content h-fit w-full pb-40"
+            style={{
+              maxWidth: `calc(${theme.spacing['max-content']} + (100vw - ${theme.spacing['max-content']})/2)`,
+              minHeight: `calc(100vh - 7.2rem)`,
+            }}
+          >
+            {isLoading ? (
+              <div className="h-full w-full flex flex-col items-center justify-start p-28">
+                <Spinner size={4} />
+                <span className="text-gray m-md">{loadingMessage}</span>
+              </div>
+            ) : (
+              <div className="flex-grow w-full max-w-screen-lg">
+                <section className="bg-transparent pt-24 pb-4">
+                  <div className="container m-auto pl-0 pr-24 md:pr-40">
+                    <div className="w-full flex flex-wrap flex-col justify-between gap-24">
+                      <SupportErrandHeader />
+                    </div>
+                  </div>
+                </section>
+
+                <section className="bg-transparent pb-4">
+                  <div className="container m-auto bg-transparent py-12 pl-0 pr-24 md:pr-40">
+                    {supportErrand && (
+                      <>
+                        <SupportTabsWrapper setUnsavedFacility={setUnsavedFacility} />
+                        <MessagePortal />
+                      </>
+                    )}
+                  </div>
+                </section>
+              </div>
+            )}
+          </main>
+        </div>
+        <SidebarWrapper setUnsavedFacility={setUnsavedFacility} unsavedFacility={unsavedFacility} />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/supportmanagement/components/support-errand/support-errand.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/support-errand.component.tsx
@@ -1,9 +1,6 @@
-import { useAppContext } from '@common/contexts/app.context';
-import { Category } from '@common/data-contracts/supportmanagement/data-contracts';
-import { getMe } from '@common/services/user-service';
-import { appConfig } from '@config/appconfig';
+import { useConfigStore, useSupportStore } from '@stores/index';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { Spinner, useGui, useSnackbar } from '@sk-web-gui/react';
+import { useSnackbar } from '@sk-web-gui/react';
 import {
   SupportErrand,
   defaultSupportErrandInformation,
@@ -12,16 +9,13 @@ import {
   supportErrandIsEmpty,
 } from '@supportmanagement/services/support-errand-service';
 import { getSupportNotesCount } from '@supportmanagement/services/support-note-service';
-import { useParams, useRouter } from 'next/navigation';
-import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import * as yup from 'yup';
-import { SupportErrandSummary } from '../support-errand-basics-form/support-errand-summary.component';
-import { MessagePortal } from './sidebar/message-portal.component';
-import { SidebarWrapper } from './sidebar/sidebar.wrapper';
-import { SupportTabsWrapper } from './support-tabs-wrapper';
+import { SupportErrandLayout } from './support-errand-layout';
 
-let formSchema = yup
+const formSchema = yup
   .object({
     id: yup.string(),
     category: yup.string().required('Välj ärendekategori'),
@@ -32,44 +26,23 @@ let formSchema = yup
   })
   .required();
 
-export const SupportErrandComponent: React.FC = () => {
-  const params = useParams<{ errandNumber?: string }>();
-  const errandNumber = params?.errandNumber;
-  const [isLoading, setIsLoading] = useState(!!errandNumber);
+export const SupportErrandComponent: React.FC<{ errandNumber?: string }> = ({ errandNumber }) => {
+  const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState('Hämtar ärende..');
-  const [categoriesList, setCategoriesList] = useState<Category[]>();
-  const [unsavedFacility, setUnsavedFacility] = useState(false);
-  const { municipalityId, supportErrand, setSupportErrand, supportMetadata, setNotesCount } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const supportErrand = useSupportStore((s) => s.supportErrand);
+  const setSupportErrand = useSupportStore((s) => s.setSupportErrand);
+  const setNotesCount = useSupportStore((s) => s.setNotesCount);
   const toastMessage = useSnackbar();
+  const router = useRouter();
 
   const methods = useForm<SupportErrand>({
     resolver: yupResolver(formSchema) as any,
     defaultValues: defaultSupportErrandInformation,
-    mode: 'onChange', // NOTE: Needed if we want to disable submit until valid
+    mode: 'onChange',
   });
 
-  const initialFocus = useRef<HTMLButtonElement>(null);
-  const setInitialFocus = () => {
-    setTimeout(() => {
-      initialFocus.current && initialFocus.current.focus();
-    });
-  };
-  const router = useRouter();
-  const { setUser } = useAppContext();
-
-  const { theme } = useGui();
-
   useEffect(() => {
-    setCategoriesList(supportMetadata?.categories);
-  }, [supportMetadata]);
-
-  useEffect(() => {
-    setInitialFocus();
-    getMe()
-      .then((user) => {
-        setUser(user);
-      })
-      .catch((e) => {});
     if (errandNumber) {
       setIsLoading(true);
       getSupportErrandByErrandNumber(errandNumber)
@@ -94,102 +67,40 @@ export const SupportErrandComponent: React.FC = () => {
             status: 'error',
           });
         });
-    } else {
-      if (municipalityId && supportErrandIsEmpty(supportErrand!) && !isLoading) {
-        setIsLoading(true);
-        setMessage('Registrerar nytt ärende..');
-        initiateSupportErrand(municipalityId)
-          .then((result) =>
-            setTimeout(() => {
-              router.push(`/arende/${result.errandNumber}`);
-            }, 10)
-          )
-          .catch((e) => {
-            console.error('Error when initiating errand:', e);
-            setIsLoading(false);
-            toastMessage({
-              position: 'bottom',
-              closeable: false,
-              message: 'Något gick fel när ärendet skulle initieras',
-              status: 'error',
-            });
+    } else if (municipalityId && (!supportErrand || supportErrandIsEmpty(supportErrand)) && !isLoading) {
+      setIsLoading(true);
+      setMessage('Registrerar nytt ärende..');
+      initiateSupportErrand(municipalityId)
+        .then((result) =>
+          setTimeout(() => {
+            router.push(`/arende/${result.errandNumber}`);
+          }, 10)
+        )
+        .catch((e) => {
+          console.error('Error when initiating errand:', e);
+          setIsLoading(false);
+          toastMessage({
+            position: 'bottom',
+            closeable: false,
+            message: 'Något gick fel när ärendet skulle initieras',
+            status: 'error',
           });
-      }
+        });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router, municipalityId, errandNumber]);
 
   useEffect(() => {
     if (supportErrand && !supportErrandIsEmpty(supportErrand)) {
-      getSupportNotesCount(supportErrand!.id!, municipalityId!).then((res) => {
+      getSupportNotesCount(supportErrand.id!, municipalityId!).then((res) => {
         setNotesCount(res);
       });
     }
   }, [supportErrand, municipalityId]);
 
-  const isReady = !isLoading && !!supportErrand?.id && !!supportMetadata;
-
-  if (!isReady) {
-    return (
-      <div className="grow shrink overflow-y-hidden">
-        <div className="h-full w-full flex flex-col items-center justify-start p-28">
-          <Spinner size={4} />
-          <span className="text-gray m-md">{message}</span>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <FormProvider {...methods}>
-      <div className="grow shrink overflow-y-hidden">
-        <div className="flex justify-end w-full pl-24 md:pl-40 h-full">
-          <div className="flex justify-center overflow-y-auto w-full grow max-lg:mr-[5.6rem]">
-            <main
-              className="flex-grow flex justify-center max-w-content h-fit w-full pb-40"
-              style={{
-                maxWidth: `calc(${theme.spacing['max-content']} + (100vw - ${theme.spacing['max-content']})/2)`,
-                minHeight: `calc(100vh - 7.2rem)`,
-              }}
-            >
-              <div className="flex-grow w-full max-w-screen-lg">
-                <section className="bg-transparent pt-24 pb-4">
-                  <div className="container m-auto pl-0 pr-24 md:pr-40">
-                    <div className="w-full flex flex-wrap flex-col justify-between gap-24">
-                      {!supportErrandIsEmpty(supportErrand!) ? (
-                        <>
-                          <h1 className="max-md:w-full text-h2-sm md:text-h2-md xl:text-h2-md mb-0 break-words">
-                            {appConfig.features.useThreeLevelCategorization
-                              ? supportErrand!.labels?.find((l) => l.classification === 'TYPE')?.displayName ??
-                                '(Ärendetyp saknas)'
-                              : categoriesList?.find((c) => c.name === supportErrand?.classification?.category)
-                                  ?.displayName}
-                          </h1>
-                          {process.env.NEXT_PUBLIC_APPLICATION === 'IAF' && <SupportErrandSummary />}
-                        </>
-                      ) : (
-                        <div className="flex justify-between items-center pt-8">
-                          <h1 className="text-h3-sm md:text-h3-md xl:text-h2-lg mb-0 break-words">
-                            Registrera nytt ärende
-                          </h1>
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                </section>
-
-                <section className="bg-transparent pb-4">
-                  <div className="container m-auto bg-transparent py-12 pl-0 pr-24 md:pr-40">
-                    <SupportTabsWrapper setUnsavedFacility={setUnsavedFacility} />
-                    <MessagePortal />
-                  </div>
-                </section>
-              </div>
-            </main>
-          </div>
-          <SidebarWrapper setUnsavedFacility={setUnsavedFacility} unsavedFacility={unsavedFacility} />
-        </div>
-      </div>
+      <SupportErrandLayout isLoading={isLoading} loadingMessage={message} />
     </FormProvider>
   );
 };

--- a/frontend/src/supportmanagement/components/support-errand/support-tabs-wrapper.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/support-tabs-wrapper.tsx
@@ -1,4 +1,4 @@
-import { useAppContext } from '@common/contexts/app.context';
+import { useConfigStore, useSupportStore } from '@stores/index';
 import WarnIfUnsavedChanges from '@common/utils/warnIfUnsavedChanges';
 import { appConfig } from '@config/appconfig';
 import { cx, Tabs } from '@sk-web-gui/react';
@@ -35,26 +35,18 @@ export const SupportTabsWrapper: React.FC<{
   const [supportConversations, setSupportConversations] = useState<any>([]);
   const [messageTree, setMessageTree] = useState<MessageNode[]>([]);
   const [conversationMessageTree, setConversationMessageTree] = useState<MessageNode[]>([]);
-  const {
-    municipalityId,
-    supportErrand,
-    setSupportErrand,
-    supportAttachments,
-    setSupportAttachments,
-  } = useAppContext();
+  const municipalityId = useConfigStore((s) => s.municipalityId);
+  const supportErrand = useSupportStore((s) => s.supportErrand);
+  const setSupportErrand = useSupportStore((s) => s.setSupportErrand);
+  const supportAttachments = useSupportStore((s) => s.supportAttachments);
+  const setSupportAttachments = useSupportStore((s) => s.setSupportAttachments);
 
-  const [unsavedChanges, setUnsavedChanges] = useState(false);
+  const [subFormUnsaved, setSubFormUnsaved] = useState(false);
 
   const methods: UseFormReturn<SupportErrand, any, undefined> = useFormContext();
 
-  useEffect(() => {
-    if (methods?.getValues as unknown) {
-      // Need to define these variables for validation/dirty check to work??
-      const _ = Object.keys(methods.formState.dirtyFields).length;
-      const __ = methods.formState.isDirty;
-      setUnsavedChanges(Object.keys(methods.formState.dirtyFields).length === 0 ? false : methods.formState.isDirty);
-    }
-  }, [methods]);
+  const { formState: { isDirty, dirtyFields } } = methods;
+  const unsavedChanges = (isDirty && Object.keys(dirtyFields).length > 0) || subFormUnsaved;
 
   const getMessagesAndConversations = () => {
     getSupportAttachments(supportErrand!.id!, municipalityId).then(setSupportAttachments);
@@ -106,7 +98,7 @@ export const SupportTabsWrapper: React.FC<{
         <SupportErrandBasicsTab
           setUnsavedFacility={props.setUnsavedFacility}
           errand={supportErrand}
-          setUnsaved={setUnsavedChanges}
+          setUnsaved={setSubFormUnsaved}
           update={update}
         />
       ),
@@ -127,7 +119,7 @@ export const SupportTabsWrapper: React.FC<{
           messageTree={messageTree}
           supportConversations={supportConversations}
           conversationMessageTree={conversationMessageTree}
-          setUnsaved={setUnsavedChanges}
+          setUnsaved={setSubFormUnsaved}
           update={update}
           municipalityId={municipalityId}
         />
@@ -143,14 +135,14 @@ export const SupportTabsWrapper: React.FC<{
     },
     {
       label: 'Rekryteringsprocess',
-      content: supportErrand && <SupportErrandRecruitmentTab setUnsaved={setUnsavedChanges} update={update} />,
+      content: supportErrand && <SupportErrandRecruitmentTab setUnsaved={setSubFormUnsaved} update={update} />,
       disabled: false,
       visibleFor: appConfig.features.useRecruitment,
     },
     {
       label: 'Fakturering',
       content: supportErrand && (
-        <SupportErrandInvoiceTab errand={supportErrand} setUnsaved={setUnsavedChanges} update={update} />
+        <SupportErrandInvoiceTab errand={supportErrand} setUnsaved={setSubFormUnsaved} update={update} />
       ),
       disabled: false,
       visibleFor: appConfig.features.useBilling,


### PR DESCRIPTION
## Sammanfattning

Bryta ut de två största komponenterna i kodbasen till mindre, fokuserade moduler:

### CasedataErrandComponent (~250 rader → ~60 rader)
- **`CasedataErrandHeader`** — ärendeheader med statuslabel, ärendenummer och metadata
- **`CasedataErrandLayout`** — layout med sidebar, tabs och header
- **`CasedataMetadataBand`** — fastighetsinformation, ärendetyp, prioritet och phasechanger
- **`CasedataRegisterHeader`** — header för registreringsvyn

### SupportErrandComponent (~160 rader → ~50 rader)
- **`SupportErrandHeader`** — header med statuslabel, kategorisering och ärendenummer
- **`SupportErrandLayout`** — layout med sidebar, tabs och header

### Övrigt
- Extrahera `estateToText` utility för fastighetsinformation
- Uppdatera tab wrappers för att använda den nya komponentstrukturen

## Bakgrund

Den här PR:en är **del 4 av 5** i uppdelningen av #866. Bygger på #902.

**Merge-ordning:**
1. #900 — i18n-cleanup ✅
2. #901 — Zustand state management ✅
3. #902 — Server components + error boundaries ✅
4. **→ Denna PR** — Komponent-uppdelning
5. `refactor/5-form-react-query` — React Query + testkonfiguration

## Varför dela upp?

`CasedataErrandComponent` och `SupportErrandComponent` var 250+ respektive 160+ rader med blandad layout-, header- och affärslogik. Uppdelningen gör varje fil lättare att förstå, testa och underhålla.

## Testplan

- [ ] Verifiera att ärende-vyn (casedata) renderar korrekt med header, metadata och tabs
- [ ] Verifiera att support-ärende-vyn renderar korrekt med header och tabs
- [ ] Testa registreringsvyn (ska använda `CasedataRegisterHeader`)
- [ ] Kör Cypress-tester för KontaktCenter och MEX