### PR TITLE
fix: lock schema version per service entry on edit

### DIFF
--- a/frontend/src/casedata/components/errand/tabs/services/casedata-service-item.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/services/casedata-service-item.component.tsx
@@ -21,9 +21,16 @@ export const ServiceListItem: React.FC<Props> = ({ service, onRemove, onEdit, re
 
         <div className="flex flex-col gap-4 flex-1">
           <div className="flex justify-between items-center">
-            <div className="text-base font-bold text-dark-secondary">
-              {service.restyp}
-              {service.isWinterService ? ' (Vinterfärdtjänst)' : ''}
+            <div className="text-base font-bold text-dark-secondary flex items-center gap-8">
+              <span>
+                {service.restyp}
+                {service.isWinterService ? ' (Vinterfärdtjänst)' : ''}
+              </span>
+              {service.schemaVersion && (
+                <span className="text-small font-normal text-dark-ghost bg-background-200 rounded px-6 py-2">
+                  v{service.schemaVersion}
+                </span>
+              )}
             </div>
             <div className="text-md font-normal text-dark-secondary whitespace-nowrap">
               {service?.validityType === 'tillsvidare'

--- a/frontend/src/casedata/components/errand/tabs/services/casedata-service-mapper.ts
+++ b/frontend/src/casedata/components/errand/tabs/services/casedata-service-mapper.ts
@@ -13,6 +13,7 @@ export interface Service {
   endDate: string;
   isWinterService: boolean;
   validityType: 'tidsbegransad' | 'tillsvidare';
+  schemaVersion?: string;
 }
 
 function normalizeArray(values: any): string[] {

--- a/frontend/src/casedata/components/errand/tabs/services/casedata-service-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/services/casedata-service-tab.tsx
@@ -13,7 +13,7 @@ import { isErrandLocked } from '@casedata/services/casedata-errand-service';
 import { getOwnerStakeholder } from '@casedata/services/casedata-stakeholder-service';
 import { ServicesObjectFieldTemplate } from '@common/components/json/fields/services-object-field-template.componant';
 import SchemaForm from '@common/components/json/schema/schema-form.component';
-import { getLatestRjsfSchema, getUiSchemaForSchema } from '@common/components/json/utils/schema-utils';
+import { getLatestRjsfSchema, getRjsfSchema, getUiSchemaForSchema } from '@common/components/json/utils/schema-utils';
 import { getToastOptions } from '@common/utils/toast-message-settings';
 import { useAppContext } from '@contexts/app.context';
 import type { RJSFSchema, UiSchema } from '@rjsf/utils';
@@ -59,6 +59,9 @@ export const CasedataServicesTab: React.FC = () => {
   const [formData, setFormData] = useState<any>({});
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editFormData, setEditFormData] = useState<any>(null);
+  const [editSchema, setEditSchema] = useState<RJSFSchema | null>(null);
+  const [editUiSchema, setEditUiSchema] = useState<UiSchema | null>(null);
+  const [editSchemaId, setEditSchemaId] = useState<string>('');
   const [schemaId, setSchemaId] = useState<string>('');
   const toast = useSnackbar();
 
@@ -70,6 +73,10 @@ export const CasedataServicesTab: React.FC = () => {
   const filteredSchema = useMemo(() => {
     return filterSchemaByCase(schema, errand?.caseType ?? '');
   }, [schema, errand?.caseType]);
+
+  const filteredEditSchema = useMemo(() => {
+    return filterSchemaByCase(editSchema, errand?.caseType ?? '');
+  }, [editSchema, errand?.caseType]);
 
   useEffect(() => {
     (async () => {
@@ -201,7 +208,8 @@ export const CasedataServicesTab: React.FC = () => {
           return;
         }
 
-        let value = params[paramIndex]?.value;
+        const param = params[paramIndex];
+        let value = param?.value;
         if (typeof value === 'string') {
           try {
             value = JSON.parse(value);
@@ -210,23 +218,39 @@ export const CasedataServicesTab: React.FC = () => {
           }
         }
 
+        const storedSchemaId = param?.schemaId;
+        if (storedSchemaId) {
+          const fetchedSchema = await getRjsfSchema(municipalityId, storedSchemaId);
+          const fetchedUiSchema = await getUiSchemaForSchema(municipalityId, storedSchemaId);
+          setEditSchema(fetchedSchema);
+          setEditUiSchema(fetchedUiSchema);
+          setEditSchemaId(storedSchemaId);
+        } else {
+          setEditSchema(schema);
+          setEditUiSchema(uiSchema);
+          setEditSchemaId(schemaId);
+        }
+
         setEditFormData(value);
         setEditingId(compositeId);
       } catch {
         toast(getToastOptions({ message: 'Kunde inte hämta insatsdata.', status: 'error' }));
       }
     },
-    [fetchAsset, toast]
+    [fetchAsset, toast, municipalityId, schema, uiSchema, schemaId]
   );
 
   const closeEditModal = useCallback(() => {
     setEditingId(null);
     setEditFormData(null);
+    setEditSchema(null);
+    setEditUiSchema(null);
+    setEditSchemaId('');
   }, []);
 
   const handleEditSubmit = useCallback(
     async (payload: any) => {
-      if (!editingId || !schemaId) return;
+      if (!editingId || !editSchemaId) return;
       try {
         const { assetUuid, paramIndex } = fromCompositeId(editingId);
         const asset = await fetchAsset(assetUuid);
@@ -238,7 +262,7 @@ export const CasedataServicesTab: React.FC = () => {
         const replacePayload = buildReplaceParameterPayload(
           payload,
           paramIndex,
-          { schemaId, assetType, partyId, assetId: errandNr },
+          { schemaId: editSchemaId, assetType, partyId, assetId: errandNr },
           asset
         );
 
@@ -250,7 +274,7 @@ export const CasedataServicesTab: React.FC = () => {
         toast(getToastOptions({ message: 'Något gick fel när insatsen skulle uppdateras.', status: 'error' }));
       }
     },
-    [editingId, schemaId, municipalityId, partyId, errandNr, assetType, fetchAsset, refetch, closeEditModal, toast]
+    [editingId, editSchemaId, municipalityId, partyId, errandNr, assetType, fetchAsset, refetch, closeEditModal, toast]
   );
 
   return (
@@ -289,10 +313,10 @@ export const CasedataServicesTab: React.FC = () => {
 
       <Modal show={editingId !== null} className="w-[80rem]" onClose={closeEditModal} label="Redigera insats">
         <Modal.Content>
-          {editFormData && uiSchema && filteredSchema && (
+          {editFormData && editUiSchema && filteredEditSchema && (
             <SchemaForm
-              schema={filteredSchema}
-              uiSchema={uiSchema}
+              schema={filteredEditSchema}
+              uiSchema={editUiSchema}
               formData={editFormData}
               onChange={(fd) => setEditFormData(fd)}
               onSubmit={handleEditSubmit}

--- a/frontend/src/casedata/components/errand/tabs/services/useErrandService.ts
+++ b/frontend/src/casedata/components/errand/tabs/services/useErrandService.ts
@@ -54,7 +54,10 @@ export function useErrandServices({
           if (!parsed) return;
           const compositeId = `${a.id}#${idx}`;
           const s = mapFormToServiceFromPayload(parsed, schema, compositeId);
-          if (s) mapped.push(s);
+          if (s) {
+            s.schemaVersion = p.schemaId?.split('_').pop() ?? '';
+            mapped.push(s);
+          }
         });
       }
 


### PR DESCRIPTION
## Summary
- Redigering av befintliga insatser använder nu det schema som gällde vid skapandet istället för senaste versionen
- Schemaversion visas som badge i insatslistan så handläggare kan se vilken version varje insats använder
- Nya insatser använder fortfarande senaste schemat

## Test plan
- [ ] Skapa en ny insats — verifiera att senaste schemat används
- [ ] Redigera en befintlig insats — verifiera att formuläret renderas med det ursprungliga schemat
- [ ] Kontrollera att versionsbadge visas korrekt i listan

https://jira.sundsvall.se/browse/DRAKEN-3772