### PR TITLE
fix: lint-staged Windows compatibility

### DIFF
--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,0 +1,20 @@
+import path from 'path';
+
+export default {
+  'frontend/src/**/*.{ts,tsx}': (files) => {
+    const cwd = path.resolve('frontend');
+    const relativePaths = files.map((f) => path.relative(cwd, f).split(path.sep).join('/'));
+    return [
+      `cd frontend && yarn prettier --write ${relativePaths.join(' ')}`,
+      `cd frontend && yarn eslint --no-error-on-unmatched-pattern --fix ${relativePaths.join(' ')}`,
+    ];
+  },
+  'backend/src/**/*.ts': (files) => {
+    const cwd = path.resolve('backend');
+    const relativePaths = files.map((f) => path.relative(cwd, f).split(path.sep).join('/'));
+    return [
+      `cd backend && yarn prettier --write ${relativePaths.join(' ')}`,
+      `cd backend && yarn eslint --no-error-on-unmatched-pattern --fix ${relativePaths.join(' ')}`,
+    ];
+  },
+};

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -5,16 +5,16 @@ export default {
     const cwd = path.resolve('frontend');
     const relativePaths = files.map((f) => path.relative(cwd, f).split(path.sep).join('/'));
     return [
-      `cd frontend && yarn prettier --write ${relativePaths.join(' ')}`,
-      `cd frontend && yarn eslint --no-error-on-unmatched-pattern --fix ${relativePaths.join(' ')}`,
+      `yarn --cwd frontend prettier --write ${relativePaths.join(' ')}`,
+      `yarn --cwd frontend eslint --no-error-on-unmatched-pattern --fix ${relativePaths.join(' ')}`,
     ];
   },
   'backend/src/**/*.ts': (files) => {
     const cwd = path.resolve('backend');
     const relativePaths = files.map((f) => path.relative(cwd, f).split(path.sep).join('/'));
     return [
-      `cd backend && yarn prettier --write ${relativePaths.join(' ')}`,
-      `cd backend && yarn eslint --no-error-on-unmatched-pattern --fix ${relativePaths.join(' ')}`,
+      `yarn --cwd backend prettier --write ${relativePaths.join(' ')}`,
+      `yarn --cwd backend eslint --no-error-on-unmatched-pattern --fix ${relativePaths.join(' ')}`,
     ];
   },
 };

--- a/package.json
+++ b/package.json
@@ -9,15 +9,5 @@
     "@commitlint/config-conventional": "^20.5.0",
     "husky": "^9.1.7",
     "lint-staged": "^15.4.3"
-  },
-  "lint-staged": {
-    "frontend/src/**/*.{ts,tsx}": [
-      "cd frontend && yarn prettier --write",
-      "cd frontend && yarn eslint --no-error-on-unmatched-pattern --fix"
-    ],
-    "backend/src/**/*.ts": [
-      "cd backend && yarn prettier --write",
-      "cd backend && yarn eslint --no-error-on-unmatched-pattern --fix"
-    ]
   }
 }


### PR DESCRIPTION
## Summary
- Moves lint-staged config from `package.json` to `.lintstagedrc.mjs` with a function-based config
- Converts absolute file paths to relative paths before passing to prettier/eslint
- Fixes Windows issue where absolute paths (`C:\...`) after `cd frontend &&` caused cmd.exe to interpret `C:` as a drive change, breaking pre-commit hooks

## Test plan
- [ ] Testa `npx lint-staged` på Windows efter att ha stagat en `.ts`-fil
- [ ] Verifiera att pre-commit hook fungerar vid commit på Windows
- [ ] Verifiera att pre-commit hook fortfarande fungerar på macOS/Linux