### PR TITLE
fix: changing fakturamottagare

### DIFF
--- a/frontend/cypress/e2e/case-data/mex/errandPage-contracts-tab-contract-mex.cy.ts
+++ b/frontend/cypress/e2e/case-data/mex/errandPage-contracts-tab-contract-mex.cy.ts
@@ -836,15 +836,21 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
           cy.get('[data-cy="fees-additional-information-1-input"]').should('have.value', 'Extra info');
         });
 
-        it('does not allow adding or removing parties for ACTIVE contracts but allows editing roles', () => {
+        it('does not allow removing parties for ACTIVE contracts but allows editing roles and adding billing party', () => {
           cy.get('[data-cy="non-draft-warning-banner"]').should('exist');
 
-          // For ACTIVE contracts, add party button should not exist
-          cy.get('[data-cy="add-party-button"]').should('not.exist');
+          // For ACTIVE contracts, add party button should exist (for adding billing party)
+          cy.get('[data-cy="add-party-button"]').should('exist');
           // Remove button should not exist for non-DRAFT contracts
           cy.get('[data-cy="party-0-remove-button"]').should('not.exist');
           // Edit button should still exist (for editing roles like billing party)
           cy.get('[data-cy="party-0-edit-button"]').should('exist');
+
+          // Opening the add party modal should only show Fakturamottagare role
+          cy.get('[data-cy="add-party-button"]').click();
+          cy.get('[data-cy="party-modal-role-PRIMARY_BILLING_PARTY"]').should('exist');
+          cy.get('[data-cy="party-modal-role-LESSEE"]').should('not.exist');
+          cy.get('[data-cy="party-modal-role-LESSOR"]').should('not.exist');
         });
       });
     });

--- a/frontend/src/casedata/components/errand/tabs/contract/contract-form.tsx
+++ b/frontend/src/casedata/components/errand/tabs/contract/contract-form.tsx
@@ -362,7 +362,7 @@ export const ContractForm: FC<{
           )}
         </Table.Body>
       </Table>
-      {!readOnly && isDraft && onAddParty && (
+      {!readOnly && onAddParty && (
         <div className="mt-12">
           <Button size="sm" variant="secondary" data-cy="add-party-button" onClick={handleOpenAddModal}>
             Lägg till ny part
@@ -1066,6 +1066,7 @@ export const ContractForm: FC<{
         existingParty={editingParty}
         contractType={getValues().type}
         existingParties={contractParties}
+        isDraft={isDraft}
       />
     </>
   );

--- a/frontend/src/casedata/components/errand/tabs/contract/contract-party-modal.tsx
+++ b/frontend/src/casedata/components/errand/tabs/contract/contract-party-modal.tsx
@@ -15,6 +15,7 @@ interface ContractPartyModalProps {
   existingParty?: UnifiedContractParty;
   contractType: ContractType;
   existingParties?: UnifiedContractParty[];
+  isDraft?: boolean;
 }
 
 export const ContractPartyModal: React.FC<ContractPartyModalProps> = ({
@@ -26,12 +27,16 @@ export const ContractPartyModal: React.FC<ContractPartyModalProps> = ({
   existingParty,
   contractType,
   existingParties = [],
+  isDraft = true,
 }) => {
   const [selectedStakeholderId, setSelectedStakeholderId] = useState<string>('');
   const [selectedRoles, setSelectedRoles] = useState<StakeholderRole[]>([]);
 
-  // Get available roles based on contract type
+  // Get available roles based on contract type and draft status
   const getAvailableRoles = (): StakeholderRole[] => {
+    if (!isDraft) {
+      return [StakeholderRole.PRIMARY_BILLING_PARTY];
+    }
     if (contractType === ContractType.PURCHASE_AGREEMENT) {
       return [StakeholderRole.BUYER, StakeholderRole.SELLER];
     }
@@ -106,8 +111,8 @@ export const ContractPartyModal: React.FC<ContractPartyModalProps> = ({
   const filteredStakeholderOptions = stakeholderOptions
     .filter((s) => s.id && !s.roles.includes(Role.ADMINISTRATOR))
     .filter((s) => {
-      if (mode === 'add') {
-        // In add mode, exclude stakeholders that are already parties
+      if (mode === 'add' && isDraft) {
+        // In add mode for DRAFT contracts, exclude stakeholders that are already parties
         return !existingParties.some((p) => stakeholderMatchesParty(s, p));
       }
       return true;

--- a/frontend/src/casedata/services/contract-service.ts
+++ b/frontend/src/casedata/services/contract-service.ts
@@ -564,10 +564,11 @@ export const getContractStakeholderName: (c: StakeholderWithPersonnumber) => str
     : `${c.firstName} ${c.lastName}`;
 
 // Centralized converter: API stakeholder -> UnifiedContractParty
+let internalIdCounter = 0;
 export const contractStakeholderToUnifiedParty = (stakeholder: StakeholderWithPersonnumber): UnifiedContractParty => {
   const name = getContractStakeholderName(stakeholder);
   return {
-    stakeholderId: stakeholder.stakeholderId || stakeholder.partyId || '',
+    stakeholderId: stakeholder.stakeholderId || stakeholder.partyId || `_internal-${++internalIdCounter}`,
     name,
     personalNumber: stakeholder.personalNumber,
     organizationNumber: stakeholder.organizationNumber,


### PR DESCRIPTION
* Möjliggör ändring av fakturamottagare även på aktiva avtal.

* Hantera manuellt tillagda stakeholders (som saknar partyId och därför inte får något unikt id i avtals-formuläret). Använd ett genererat, internt id i frontend istället.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
