### PR TITLE
fix(DRAKEN-3803): hide personnummer field when manually adding private person

### DIFF
--- a/frontend/cypress/e2e/kontaktcenter/errandPage-base-info-tab-kc.cy.ts
+++ b/frontend/cypress/e2e/kontaktcenter/errandPage-base-info-tab-kc.cy.ts
@@ -461,8 +461,8 @@ onlyOn(Cypress.env('application_name') === 'KC', () => {
       // Click add manually button
       cy.get('[data-cy="add-manually-button-owner"]').click();
 
-      // Verify modal opened and person number is empty
-      cy.get('[data-cy="contact-personNumber"]').should('have.value', '');
+      // Verify modal opened and person number field is hidden (manual mode, person)
+      cy.get('[data-cy="contact-personNumber"]').should('not.exist');
 
       // Close modal
       cy.get('[data-cy="cancel-contact-button"]').click();
@@ -530,8 +530,7 @@ onlyOn(Cypress.env('application_name') === 'KC', () => {
       cy.get('[data-cy="save-button"]').should('be.disabled');
       cy.get('[data-cy="add-manually-button-person"]').click();
 
-      cy.get('[data-cy="contact-personNumber"]').should('have.attr', 'readonly');
-      cy.get('[data-cy="contact-personNumber"]').should('have.value', '');
+      cy.get('[data-cy="contact-personNumber"]').should('not.exist');
       cy.get('[data-cy="contact-firstName"]').type('Test');
       cy.get('[data-cy="contact-lastName"]').type('Testsson');
       cy.get('[data-cy="contact-address"]').type('Testaddress');
@@ -695,8 +694,7 @@ onlyOn(Cypress.env('application_name') === 'KC', () => {
       cy.get('[data-cy="add-manually-button-person"]').click();
 
       cy.get('[data-cy="submit-contact-button"]').should('be.disabled');
-      cy.get('[data-cy="contact-personNumber"]').should('have.attr', 'readonly');
-      cy.get('[data-cy="contact-personNumber"]').should('have.value', '');
+      cy.get('[data-cy="contact-personNumber"]').should('not.exist');
       cy.get('[data-cy="contact-firstName"]').type('Test');
       cy.get('[data-cy="contact-lastName"]').type('Testsson');
       cy.get('[data-cy="contact-address"]').type('Testaddress');

--- a/frontend/cypress/e2e/lop/errandPage-base-info-tab-lop.cy.ts
+++ b/frontend/cypress/e2e/lop/errandPage-base-info-tab-lop.cy.ts
@@ -488,8 +488,7 @@ onlyOn(Cypress.env('application_name') === 'LOP', () => {
       cy.get('[data-cy="search-person-form-PRIMARY"').click();
       cy.get('[data-cy="add-manually-button-person"]').should('be.enabled').click();
 
-      cy.get('[data-cy="contact-personNumber"]').should('have.attr', 'readonly');
-      cy.get('[data-cy="contact-personNumber"]').should('have.value', '');
+      cy.get('[data-cy="contact-personNumber"]').should('not.exist');
       cy.get('[data-cy="contact-firstName"]').type('Test');
       cy.get('[data-cy="contact-lastName"]').type('Testsson');
       cy.get('[data-cy="contact-address"]').type('Testaddress');

--- a/frontend/cypress/e2e/utils/stakeholder-search-cy.ts
+++ b/frontend/cypress/e2e/utils/stakeholder-search-cy.ts
@@ -59,7 +59,7 @@ export const displayManuallyAddStakeholderModal = () => {
   cy.get('[data-cy="contact-role-owner"]').should('exist');
   cy.get('[data-cy="contact-role-owner"]').should('have.value', 'PRIMARY');
   cy.get('[data-cy="contact-externalId-owner"]').should('exist');
-  cy.get('[data-cy="contact-personNumber"]').should('exist');
+  cy.get('[data-cy="contact-personNumber"]').should('not.exist');
   cy.get('[data-cy="contact-firstName"]').should('exist');
   cy.get('[data-cy="contact-lastName"]').should('exist');
   cy.get('[data-cy="contact-address"]').should('exist');
@@ -144,8 +144,7 @@ export const clearSearchResultOnPersonNumberChange = (mockAdressResponse: any) =
 
   // Open manual form, it should be empty
   cy.get('[data-cy="add-manually-button-owner"]').click();
-  cy.get('[data-cy="contact-personNumber"]').should('have.attr', 'readonly');
-  cy.get('[data-cy="contact-personNumber"]').should('have.value', '');
+  cy.get('[data-cy="contact-personNumber"]').should('not.exist');
   cy.get('[data-cy="contact-firstName"]').should('have.value', '');
   cy.get('[data-cy="contact-lastName"]').should('have.value', '');
   cy.get('[data-cy="contact-address"]').should('have.value', '');
@@ -154,8 +153,7 @@ export const clearSearchResultOnPersonNumberChange = (mockAdressResponse: any) =
 };
 
 export const sendCorrectDataOnManualAddPerson = () => {
-  cy.get('[data-cy="contact-personNumber"]').should('have.attr', 'readonly');
-  cy.get('[data-cy="contact-personNumber"]').should('have.value', '');
+  cy.get('[data-cy="contact-personNumber"]').should('not.exist');
   cy.get('[data-cy="contact-firstName"]').type('Test');
   cy.get('[data-cy="contact-lastName"]').type('Testsson');
   cy.get('[data-cy="contact-address"]').type('Testaddress');

--- a/frontend/src/casedata/components/errand/forms/contact-modal.component.tsx
+++ b/frontend/src/casedata/components/errand/forms/contact-modal.component.tsx
@@ -3,8 +3,8 @@ import { CasedataOwnerOrContact } from '@casedata/interfaces/stakeholder';
 import CommonNestedEmailArrayV2 from '@common/components/commonNestedEmailArrayV2';
 import CommonNestedPhoneArrayV2 from '@common/components/commonNestedPhoneArrayV2';
 import { appConfig } from '@config/appconfig';
-import { useCasedataStore } from '@stores/index';
 import { Button, cx, FormControl, FormErrorMessage, FormLabel, Input, Modal } from '@sk-web-gui/react';
+import { useCasedataStore } from '@stores/index';
 import { Dispatch, FC, SetStateAction } from 'react';
 import { UseFieldArrayReplace, UseFormReturn } from 'react-hook-form';
 
@@ -50,6 +50,9 @@ export const ContactModal: FC<ContactModalProps> = ({
   const { control, register, formState, watch, setValue, trigger } = form;
   const errors = formState.errors;
   const errand = useCasedataStore((s) => s.errand);
+  const personalNumber = watch('personalNumber');
+  const personId = watch('personId');
+  const showPersonalNumber = !!personalNumber || !!personId;
 
   return (
     <Modal
@@ -74,33 +77,35 @@ export const ContactModal: FC<ContactModalProps> = ({
         {searchMode === 'person' ? (
           <>
             <div className="flex gap-lg">
-              <FormControl id={`contact-personnumber`} className="w-1/2">
-                <FormLabel>Personnummer</FormLabel>
-                <Input
-                  size="sm"
-                  disabled={disabled}
-                  readOnly
-                  data-cy={`contact-personalNumber`}
-                  className={cx(
-                    formState.errors.personalNumber ? 'border-2 border-error' : null,
-                    'read-only:bg-gray-lighter read-only:cursor-not-allowed'
-                  )}
-                  {...register(`personalNumber`)}
-                />
+              {showPersonalNumber ? (
+                <FormControl id={`contact-personnumber`} className="w-1/2">
+                  <FormLabel>Personnummer</FormLabel>
+                  <Input
+                    size="sm"
+                    disabled={disabled}
+                    readOnly
+                    data-cy={`contact-personalNumber`}
+                    className={cx(
+                      formState.errors.personalNumber ? 'border-2 border-error' : null,
+                      'read-only:bg-gray-lighter read-only:cursor-not-allowed'
+                    )}
+                    {...register(`personalNumber`)}
+                  />
 
-                {errors && formState.errors.personalNumber && (
-                  <div className="my-sm text-error">
-                    <FormErrorMessage>{formState.errors.personalNumber?.message}</FormErrorMessage>
-                  </div>
-                )}
-              </FormControl>
+                  {errors && formState.errors.personalNumber && (
+                    <div className="my-sm text-error">
+                      <FormErrorMessage>{formState.errors.personalNumber?.message}</FormErrorMessage>
+                    </div>
+                  )}
+                </FormControl>
+              ) : null}
 
               <ContactRelationSelect
                 contact={contact}
                 register={register}
                 errors={errors}
                 disabled={disabled}
-                className={cx(manual || editing ? 'w-1/2' : 'w-full')}
+                className={cx(showPersonalNumber && (manual || editing) ? 'w-1/2' : 'w-full')}
               />
             </div>
             <div className="flex gap-lg">

--- a/frontend/src/casedata/components/errand/forms/contact-modal.component.tsx
+++ b/frontend/src/casedata/components/errand/forms/contact-modal.component.tsx
@@ -85,10 +85,6 @@ export const ContactModal: FC<ContactModalProps> = ({
                     disabled={disabled}
                     readOnly
                     data-cy={`contact-personalNumber`}
-                    className={cx(
-                      formState.errors.personalNumber ? 'border-2 border-error' : null,
-                      'read-only:bg-gray-lighter read-only:cursor-not-allowed'
-                    )}
                     {...register(`personalNumber`)}
                   />
 

--- a/frontend/src/supportmanagement/components/new-contacts/support-contact-modal.component.tsx
+++ b/frontend/src/supportmanagement/components/new-contacts/support-contact-modal.component.tsx
@@ -53,6 +53,8 @@ export const SupportContactModal: FC<SupportContactModalProps> = ({
   const username = form.watch('username');
   const personNumber = form.watch('personNumber');
   const showPersonNumberField = searchMode === 'employee' || !!personNumber || !!username;
+  const showUsername = !!username && !personNumber;
+  const personNumberFieldName = showUsername ? 'username' : 'personNumber';
 
   return (
     <Modal
@@ -84,33 +86,14 @@ export const SupportContactModal: FC<SupportContactModalProps> = ({
               <div className="flex gap-lg">
                 {showPersonNumberField ? (
                   <FormControl id={`contact-personnumber`} className="w-1/2">
-                    <FormLabel>{username && !personNumber ? 'Användarnamn' : 'Personnummer'}</FormLabel>
-                    {username && !personNumber ? (
-                      <Input
-                        size="sm"
-                        disabled={disabled}
-                        readOnly
-                        data-cy={`contact-username`}
-                        className={cx(
-                          form.formState.errors.personNumber ? 'border-2 border-error' : null,
-                          'read-only:bg-gray-lighter read-only:cursor-not-allowed'
-                        )}
-                        {...form.register(`username`)}
-                      />
-                    ) : (
-                      <Input
-                        size="sm"
-                        disabled={disabled}
-                        readOnly
-                        data-cy={`contact-personNumber`}
-                        className={cx(
-                          form.formState.errors.personNumber ? 'border-2 border-error' : null,
-                          'read-only:bg-gray-lighter read-only:cursor-not-allowed'
-                        )}
-                        {...form.register(`personNumber`)}
-                      />
-                    )}
-
+                    <FormLabel>{showUsername ? 'Användarnamn' : 'Personnummer'}</FormLabel>
+                    <Input
+                      size="sm"
+                      disabled={disabled}
+                      readOnly
+                      data-cy={`contact-${personNumberFieldName}`}
+                      {...form.register(personNumberFieldName)}
+                    />
                     {form.formState.errors.personNumber && (
                       <div className="my-sm text-error">
                         <FormErrorMessage>{form.formState.errors.personNumber?.message}</FormErrorMessage>

--- a/frontend/src/supportmanagement/components/new-contacts/support-contact-modal.component.tsx
+++ b/frontend/src/supportmanagement/components/new-contacts/support-contact-modal.component.tsx
@@ -2,8 +2,8 @@ import CommonNestedEmailArrayV2 from '@common/components/commonNestedEmailArrayV
 import CommonNestedPhoneArrayV2 from '@common/components/commonNestedPhoneArrayV2';
 import { AddressResult } from '@common/services/adress-service';
 import { appConfig } from '@config/appconfig';
-import { useMetadataStore, useSupportStore } from '@stores/index';
 import { Button, cx, FormControl, FormErrorMessage, FormLabel, Input, Modal, Select } from '@sk-web-gui/react';
+import { useMetadataStore, useSupportStore } from '@stores/index';
 import { ExternalIdType, SupportStakeholderFormModel } from '@supportmanagement/services/support-errand-service';
 import { Dispatch, FC, SetStateAction } from 'react';
 import { UseFieldArrayReplace, UseFormReturn } from 'react-hook-form';
@@ -52,6 +52,7 @@ export const SupportContactModal: FC<SupportContactModalProps> = ({
 
   const username = form.watch('username');
   const personNumber = form.watch('personNumber');
+  const showPersonNumberField = searchMode === 'employee' || !!personNumber || !!username;
 
   return (
     <Modal
@@ -81,42 +82,44 @@ export const SupportContactModal: FC<SupportContactModalProps> = ({
           {searchMode === 'person' || searchMode === 'employee' ? (
             <>
               <div className="flex gap-lg">
-                <FormControl id={`contact-personnumber`} className="w-1/2">
-                  <FormLabel>{username && !personNumber ? 'Användarnamn' : 'Personnummer'}</FormLabel>
-                  {username && !personNumber ? (
-                    <Input
-                      size="sm"
-                      disabled={disabled}
-                      readOnly
-                      data-cy={`contact-username`}
-                      className={cx(
-                        form.formState.errors.personNumber ? 'border-2 border-error' : null,
-                        'read-only:bg-gray-lighter read-only:cursor-not-allowed'
-                      )}
-                      {...form.register(`username`)}
-                    />
-                  ) : (
-                    <Input
-                      size="sm"
-                      disabled={disabled}
-                      readOnly
-                      data-cy={`contact-personNumber`}
-                      className={cx(
-                        form.formState.errors.personNumber ? 'border-2 border-error' : null,
-                        'read-only:bg-gray-lighter read-only:cursor-not-allowed'
-                      )}
-                      {...form.register(`personNumber`)}
-                    />
-                  )}
+                {showPersonNumberField ? (
+                  <FormControl id={`contact-personnumber`} className="w-1/2">
+                    <FormLabel>{username && !personNumber ? 'Användarnamn' : 'Personnummer'}</FormLabel>
+                    {username && !personNumber ? (
+                      <Input
+                        size="sm"
+                        disabled={disabled}
+                        readOnly
+                        data-cy={`contact-username`}
+                        className={cx(
+                          form.formState.errors.personNumber ? 'border-2 border-error' : null,
+                          'read-only:bg-gray-lighter read-only:cursor-not-allowed'
+                        )}
+                        {...form.register(`username`)}
+                      />
+                    ) : (
+                      <Input
+                        size="sm"
+                        disabled={disabled}
+                        readOnly
+                        data-cy={`contact-personNumber`}
+                        className={cx(
+                          form.formState.errors.personNumber ? 'border-2 border-error' : null,
+                          'read-only:bg-gray-lighter read-only:cursor-not-allowed'
+                        )}
+                        {...form.register(`personNumber`)}
+                      />
+                    )}
 
-                  {form.formState.errors.personNumber && (
-                    <div className="my-sm text-error">
-                      <FormErrorMessage>{form.formState.errors.personNumber?.message}</FormErrorMessage>
-                    </div>
-                  )}
-                </FormControl>
+                    {form.formState.errors.personNumber && (
+                      <div className="my-sm text-error">
+                        <FormErrorMessage>{form.formState.errors.personNumber?.message}</FormErrorMessage>
+                      </div>
+                    )}
+                  </FormControl>
+                ) : null}
                 {appConfig.features.useRolesForStakeholders ? (
-                  <FormControl id={`contact-relation`} size="sm" className="w-1/2">
+                  <FormControl id={`contact-relation`} size="sm" className={showPersonNumberField ? 'w-1/2' : 'w-full'}>
                     <FormLabel>Roll</FormLabel>
                     <Select
                       data-cy={`role-select`}
@@ -146,9 +149,9 @@ export const SupportContactModal: FC<SupportContactModalProps> = ({
                       </div>
                     )}
                   </FormControl>
-                ) : (
+                ) : showPersonNumberField ? (
                   <div className="w-1/2"></div>
-                )}
+                ) : null}
               </div>
               <div className="flex gap-lg">
                 <FormControl id={`firstName`} className="w-1/2">


### PR DESCRIPTION
## Summary
- Personnummer-fältet är hårdkodat `readOnly` och kunde inte fyllas i vid manuell registrering av privatperson — det visades tomt och förvirrande.
- Fältet renderas nu endast när det finns ett faktiskt värde (`personalNumber`/`personId`) att visa, dvs. när intressenten kommer från en sökning eller redigeras.
- Gäller både casedata-modalen (MEX, PT, KS m.fl.) och support-modalen (KC, LOP m.fl.). I supportflödet behålls fältet i "Anställd"-läget eftersom det dubblerar som användarnamn-display.
- Cypress-tester uppdaterade för att asserta `not.exist` istället för `readonly` + tomt värde i berörda manuellt-tillägg-flöden.


https://jira.sundsvall.se/browse/DRAKEN-3803