### PR TITLE
fix: intercept bare schema endpoint in PT assets tab cypress tests

### DIFF
--- a/frontend/cypress/e2e/case-data/pt/errandPage-assets-tab-pt.cy.ts
+++ b/frontend/cypress/e2e/case-data/pt/errandPage-assets-tab-pt.cy.ts
@@ -39,7 +39,7 @@ const mockFTErrandLocked = {
 };
 
 const setupCommonIntercepts = () => {
-  cy.intercept('GET', '**/schemas/*/latest', {
+  cy.intercept('GET', /\/schemas\/[^/]+(\/latest)?$/, {
     data: {
       created: '2026-01-28T09:31:47.183+01:00',
       description: 'A JSON-schema that defines services for paratransit errands (FT)',


### PR DESCRIPTION
## Summary
- `startEdit` in `casedata-service-tab.tsx` now calls `getRjsfSchema(municipalityId, storedSchemaId)` (introduced in #908), which hits `{municipalityId}/schemas/{schemaId}`.
- The cypress test in `errandPage-assets-tab-pt.cy.ts` only intercepted `**/schemas/*/latest` and `**/schemas/*/ui-schema`, leaving the bare schema URL unmocked. `getRjsfSchema` threw, the modal never opened, and two tests failed:
  - `opens edit modal when clicking edit button` — `.sk-modal-dialog-header-title` never appeared.
  - `calls the draft asset endpoint when editing a service` — `Spara` button never appeared.
- Replaced the glob `**/schemas/*/latest` with the regex `/\/schemas\/[^/]+(\/latest)?$/` so the same mock covers both `/latest` and the bare endpoint, while still excluding `/ui-schema`.

## Test plan
- [ ] CI run of `errandPage-assets-tab-pt.cy.ts` shows all 11 tests passing.