### PR TITLE
feat(DRAKEN-3617): live PDF-preview i utredningstabben

### DIFF
--- a/frontend/src/casedata/components/errand/sidebar/sidebar-utredning.component.tsx
+++ b/frontend/src/casedata/components/errand/sidebar/sidebar-utredning.component.tsx
@@ -3,7 +3,7 @@
 import { DecisionOutcomeKey } from '@casedata/interfaces/decision';
 import { GenericExtraParameters } from '@casedata/interfaces/extra-parameters';
 import { CreateStakeholderDto } from '@casedata/interfaces/stakeholder';
-import { renderUtredningPdf, saveDecision } from '@casedata/services/casedata-decision-service';
+import { renderPdf, saveDecision } from '@casedata/services/casedata-decision-service';
 import { getErrand, isErrandAdmin, isErrandLocked, validateAction } from '@casedata/services/casedata-errand-service';
 import { getOwnerStakeholder } from '@casedata/services/casedata-stakeholder-service';
 import TextEditor from '@common/components/dynamic-text-editor';
@@ -77,7 +77,7 @@ export const SidebarUtredning: React.FC = () => {
   const save = async (data: UtredningFormModel) => {
     try {
       setIsLoading(true);
-      const rendered = await renderUtredningPdf(errand!, data);
+      const rendered = await renderPdf(errand!, data, 'investigation');
       await saveDecision(municipalityId, errand!, data, 'PROPOSED', rendered.pdfBase64);
       await getErrand(municipalityId, errand!.id.toString()).then((res) => setErrand(res.errand));
       setIsLoading(false);

--- a/frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx
@@ -7,14 +7,15 @@ import { ErrandStatus } from '@casedata/interfaces/errand-status';
 import { GenericExtraParameters } from '@casedata/interfaces/extra-parameters';
 import { Role } from '@casedata/interfaces/role';
 import { CreateStakeholderDto } from '@casedata/interfaces/stakeholder';
+import { getDraftAssets, updateAsset } from '@casedata/services/asset-service';
 import { validateAttachmentsForDecision } from '@casedata/services/casedata-attachment-service';
 import {
   fetchDecisionTemplates,
   getFinalDecisonWithHighestId,
   getLawMapping,
   mapServicesToTemplateParams,
-  renderBeslutPdf,
   renderHtml,
+  renderPdf,
   saveDecision,
 } from '@casedata/services/casedata-decision-service';
 import {
@@ -27,7 +28,6 @@ import {
   validateErrandForDecision,
   validateStatusForDecision,
 } from '@casedata/services/casedata-errand-service';
-import { getDraftAssets, updateAsset } from '@casedata/services/asset-service';
 import { sendDecisionMessage, sendMessage } from '@casedata/services/casedata-message-service';
 import {
   getOwnerStakeholder,
@@ -284,7 +284,7 @@ export const CasedataDecisionTab: FC<{
   const save = async (data: DecisionFormModel) => {
     if (!errand) return;
     try {
-      const rendered = await renderBeslutPdf(errand, data, services);
+      const rendered = await renderPdf(errand, data, 'decision', services);
       await saveDecision(municipalityId, errand, data, 'FINAL', rendered.pdfBase64);
       setIsLoading(false);
       setError(undefined);
@@ -326,7 +326,7 @@ export const CasedataDecisionTab: FC<{
         adAccount: user.username,
       } as CreateStakeholderDto;
       setIsSaveAndSendLoading(true);
-      const rendered = await renderBeslutPdf(errand, data, services);
+      const rendered = await renderPdf(errand, data, 'decision', services);
       await saveDecision(municipalityId, errand, data, 'FINAL', rendered.pdfBase64);
 
       const renderedHtml = await renderHtml(errand, data, 'decision');
@@ -435,7 +435,7 @@ export const CasedataDecisionTab: FC<{
   const renderAndDownloadPdf = async () => {
     if (!errand) return;
     const data = getValues();
-    const pdfData = await renderBeslutPdf(errand, data, services);
+    const pdfData = await renderPdf(errand, data, 'decision', services);
     downloadPdf(pdfData.pdfBase64);
   };
 

--- a/frontend/src/casedata/components/errand/tabs/investigation/casedata-investigation-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/investigation/casedata-investigation-tab.tsx
@@ -6,6 +6,7 @@ import { IErrand } from '@casedata/interfaces/errand';
 import { GenericExtraParameters } from '@casedata/interfaces/extra-parameters';
 import { CreateStakeholderDto } from '@casedata/interfaces/stakeholder';
 import {
+  buildPdfTemplate,
   fetchInvestigationSkeleton,
   getProposedOrRecommendedDecision,
   getUtredningPhrases,
@@ -14,14 +15,16 @@ import {
   saveDecision,
 } from '@casedata/services/casedata-decision-service';
 import { getErrand, isErrandLocked, isFTErrand, validateAction } from '@casedata/services/casedata-errand-service';
+import TextEditor from '@common/components/dynamic-text-editor';
+import { TemplatePdfPreview } from '@common/components/template-preview/template-pdf-preview.component';
 import { Law } from '@common/data-contracts/case-data/data-contracts';
+import { isMEX } from '@common/services/application-service';
 import { getToastOptions } from '@common/utils/toast-message-settings';
-import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
 import { yupResolver } from '@hookform/resolvers/yup';
 import {
   Button,
   cx,
-  Divider,
+  Disclosure,
   FormControl,
   FormErrorMessage,
   FormLabel,
@@ -30,11 +33,11 @@ import {
   useConfirm,
   useSnackbar,
 } from '@sk-web-gui/react';
-import TextEditor from '@common/components/dynamic-text-editor';
+import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
+import { Check, ClipboardPenLine, Info } from 'lucide-react';
 import { FC, useEffect, useMemo, useRef, useState } from 'react';
 import { Resolver, useForm } from 'react-hook-form';
 import * as yup from 'yup';
-import { Check, ClipboardPenLine, Download, Info } from 'lucide-react';
 
 export interface UtredningFormModel {
   id?: string;
@@ -80,7 +83,6 @@ export const CasedataInvestigationTab: FC<{
   const setErrand = useCasedataStore((s) => s.setErrand);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(false);
-  const [previewError, setPreviewError] = useState(false);
   const [textIsDirty, setTextIsDirty] = useState(false);
   const [firstDescriptionChange, setFirstDescriptionChange] = useState(true);
   const [firstOutcomeChange, setFirstOutcomeChange] = useState(true);
@@ -113,8 +115,15 @@ export const CasedataInvestigationTab: FC<{
     mode: 'onChange', // NOTE: Needed if we want to disable submit until valid
   });
 
-  const { description, outcome } = watch();
+  const { description, outcome, law } = watch();
   const saveCasedataErrand = useSaveCasedataErrand();
+
+  const previewTemplate = useMemo(() => {
+    if (isMEX()) return { identifier: undefined, parameters: {} };
+    if (!outcome && !isFTErrand(props.errand)) return { identifier: undefined, parameters: {} };
+    return buildPdfTemplate(props.errand, getValues(), 'investigation');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.errand, outcome, description, law]);
   const save = async (data: UtredningFormModel) => {
     try {
       setIsLoading(true);
@@ -154,26 +163,6 @@ export const CasedataInvestigationTab: FC<{
       setIsLoading(false);
       setError(false);
     }
-  };
-
-  const getPdfPreview = () => {
-    const data = getValues();
-    renderUtredningPdf(props.errand, data).then(async (d) => {
-      await saveDecision(municipalityId, props.errand, data, 'PROPOSED', d.pdfBase64);
-      await getErrand(municipalityId, props.errand.id.toString()).then((res) => setErrand(res.errand));
-      if (typeof d.error === 'undefined' && typeof d.pdfBase64 !== 'undefined') {
-        const uri = `data:application/pdf;base64,${d.pdfBase64}`;
-        const link = document.createElement('a');
-        link.href = uri;
-        link.setAttribute('download', `Utredning-${props.errand.errandNumber}.pdf`);
-        document.body.appendChild(link);
-        link.click();
-        setPreviewError(false);
-      } else {
-        console.error('Error when fetching preview');
-        setPreviewError(true);
-      }
-    });
   };
 
   const outcomeModalCallback = async (outcome: string) => {
@@ -284,19 +273,6 @@ export const CasedataInvestigationTab: FC<{
         <div className="inline-flex mt-ms gap-lg justify-start items-center flex-wrap">
           <h2 className="text-h4-sm md:text-h4-md">Utredning</h2>
         </div>
-        <Button
-          type="button"
-          disabled={!formState.isValid || isErrandLocked(errand) || !allowed}
-          size="sm"
-          variant="primary"
-          color="vattjom"
-          inverted={!(isErrandLocked(errand) || !allowed)}
-          rightIcon={<Download size={18} />}
-          onClick={getPdfPreview}
-          data-cy="preview-investigation-button"
-        >
-          Förhandsgranska PDF
-        </Button>
       </div>
       <div className="mt-lg">
         {errand?.decisions && errand?.decisions.find((d) => d.decisionType === 'RECOMMENDED') && (
@@ -312,16 +288,6 @@ export const CasedataInvestigationTab: FC<{
           </div>
         )}
 
-        {isFTErrand(props.errand) && (
-          <div className="pb-[1.5rem]">
-            <Divider.Section orientation="horizontal">
-              <div className="flex gap-sm items-center">
-                <ClipboardPenLine />
-                <h3 className="text-h4-sm md:text-h4-md">Utredningsmall</h3>
-              </div>
-            </Divider.Section>
-          </div>
-        )}
         <form onSubmit={handleSubmit(save)} data-cy="utredning-form">
           <Input type="hidden" {...register('decidedBy')} value={user.username} />
           <div className="flex gap-24">
@@ -399,34 +365,51 @@ export const CasedataInvestigationTab: FC<{
               </>
             )}
           </div>
-          <FormControl className="w-full">
-            <FormLabel>Utredningstext</FormLabel>
-            <Input type="hidden" {...register('id')} />
-            <Input data-cy="utredning-description-input" type="hidden" {...register('description')} />
-            <Input type="hidden" {...register('errandNumber')} />
-            <div data-cy="utredning-richtext-wrapper">
-              <TextEditor
-                className={cx(`mb-md h-[80%] text-editor-with-toolbar`)}
-                readOnly={isErrandLocked(errand) || !allowed}
-                onChange={(e) => {
-                  // Skip the first onChange after template load (TextEditor normalizes HTML)
-                  if (skipNextOnChange.current) {
-                    skipNextOnChange.current = false;
-                    setValue('description', e.target.value.markup ?? '', { shouldDirty: false });
-                  } else {
-                    setValue('description', e.target.value.markup ?? '', { shouldDirty: true });
-                  }
-                  trigger('description');
-                }}
-                value={{ markup: description }}
-              />
-            </div>
-            <div className="my-sm">
-              {errors.description && formState.isDirty && (
-                <FormErrorMessage>{errors.description?.message}</FormErrorMessage>
-              )}
-            </div>
-          </FormControl>
+          <TemplatePdfPreview identifier={previewTemplate.identifier} parameters={previewTemplate.parameters} />
+          <Input type="hidden" {...register('id')} />
+          <Input data-cy="utredning-description-input" type="hidden" {...register('description')} />
+          <Input type="hidden" {...register('errandNumber')} />
+          {(() => {
+            const editorBlock = (
+              <FormControl className="w-full">
+                <FormLabel>Utredningstext</FormLabel>
+                <div data-cy="utredning-richtext-wrapper">
+                  <TextEditor
+                    className={cx(`mb-md h-[80%] text-editor-with-toolbar`)}
+                    readOnly={isErrandLocked(errand) || !allowed}
+                    onChange={(e) => {
+                      // Skip the first onChange after template load (TextEditor normalizes HTML)
+                      if (skipNextOnChange.current) {
+                        skipNextOnChange.current = false;
+                        setValue('description', e.target.value.markup ?? '', { shouldDirty: false });
+                      } else {
+                        setValue('description', e.target.value.markup ?? '', { shouldDirty: true });
+                      }
+                      trigger('description');
+                    }}
+                    value={{ markup: description }}
+                  />
+                </div>
+                <div className="my-sm">
+                  {errors.description && formState.isDirty && (
+                    <FormErrorMessage>{errors.description?.message}</FormErrorMessage>
+                  )}
+                </div>
+              </FormControl>
+            );
+            return isFTErrand(props.errand) ? (
+              <Disclosure variant="alt" initalOpen className="mb-24" data-cy="investigation-template-disclosure">
+                <Disclosure.Header>
+                  <Disclosure.Icon icon={<ClipboardPenLine size={18} />} />
+                  <Disclosure.Title>Utredningsmall</Disclosure.Title>
+                  <Disclosure.Button />
+                </Disclosure.Header>
+                <Disclosure.Content>{editorBlock}</Disclosure.Content>
+              </Disclosure>
+            ) : (
+              editorBlock
+            );
+          })()}
           <div className="flex justify-left gap-10">
             <Button
               data-cy="save-utredning-button"
@@ -474,9 +457,6 @@ export const CasedataInvestigationTab: FC<{
           </div>
           <div className="mt-lg">
             {error && <FormErrorMessage>Något gick fel när utredningen sparades.</FormErrorMessage>}
-          </div>
-          <div className="mt-lg">
-            {previewError && <FormErrorMessage>Något gick fel när förhandsgranskningen skapades.</FormErrorMessage>}
           </div>
         </form>
       </div>

--- a/frontend/src/casedata/components/errand/tabs/investigation/casedata-investigation-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/investigation/casedata-investigation-tab.tsx
@@ -11,7 +11,7 @@ import {
   getProposedOrRecommendedDecision,
   getUtredningPhrases,
   lawMapping,
-  renderUtredningPdf,
+  renderPdf,
   saveDecision,
 } from '@casedata/services/casedata-decision-service';
 import { getErrand, isErrandLocked, isFTErrand, validateAction } from '@casedata/services/casedata-errand-service';
@@ -138,7 +138,7 @@ export const CasedataInvestigationTab: FC<{
         data.outcome = 'APPROVAL';
         await saveDecision(municipalityId, props.errand, data, 'PROPOSED');
       } else {
-        const rendered = await renderUtredningPdf(errand!, data);
+        const rendered = await renderPdf(errand!, data, 'investigation');
         await saveDecision(municipalityId, props.errand, data, 'PROPOSED', rendered.pdfBase64);
       }
 

--- a/frontend/src/casedata/services/casedata-decision-service.ts
+++ b/frontend/src/casedata/services/casedata-decision-service.ts
@@ -76,7 +76,10 @@ export const getLawMapping = (errand: IErrand): Law[] => {
 export const LOST_PERMIT_STANDARD_DECISION_TEXT =
   '<p>Inget formellt beslut fattas för borttappade kort, beslutet om att bevilja parkeringstillstånd har tagits i ärendet för den ursprungliga ansökan.</p>';
 
-export const fetchDecisionTemplates: (prefix: string, decision?: string) => Promise<Template[]> = (prefix, decision) => {
+export const fetchDecisionTemplates: (prefix: string, decision?: string) => Promise<Template[]> = (
+  prefix,
+  decision
+) => {
   const params = new URLSearchParams({ templateType: 'Decision', prefix });
   if (decision) {
     params.append('decision', decision);
@@ -303,20 +306,17 @@ export const renderBeslutPdf: (
   return renderPdf(errand, d, 'decision', services);
 };
 
-export const renderPdf: (
+export const buildPdfTemplate: (
   errand: IErrand,
   formData: UtredningFormModel | DecisionFormModel,
   templateType: 'investigation' | 'decision',
   services?: Service[]
-) => Promise<{ pdfBase64: string; error?: string }> = async (errand, formData, templateType, services) => {
+) => { identifier: string; parameters: { [key: string]: any } } = (errand, formData, templateType, services) => {
   const decision = errand.decisions.find(
     (d) =>
       (templateType === 'decision' && d.decisionType === 'FINAL') ||
       (templateType === 'investigation' && d.decisionType === 'PROPOSED')
   );
-  if (!decision) {
-    console.error('No saved decision found. Rendering preview for current form values.');
-  }
   const outcome =
     formData.outcome === 'APPROVAL'
       ? 'approval'
@@ -354,7 +354,7 @@ export const renderPdf: (
 
   const owner = getOwnerStakeholder(errand);
   const wrapWithWordBreak = (html: string) =>
-    `<div style="overflow-wrap: break-word; word-break: break-word;">${html}</div>`;
+    `<div style="overflow-wrap: break-word; word-break: break-word;">${html ?? ''}</div>`;
 
   const parameters: { [key: string]: any } = {
     caseNumber: formData.errandNumber ?? '',
@@ -377,7 +377,8 @@ export const renderPdf: (
     parameters['permitFirstname'] = owner?.firstName;
     parameters['permitLastname'] = owner?.lastName;
     parameters['creationDate'] = dayjs(decision?.created).format('YYYY-MM-DD');
-    parameters['disabilityReason'] = errand.extraParameters.find((p) => p.key === 'application.reason')?.values?.[0] ?? '';
+    parameters['disabilityReason'] =
+      errand.extraParameters.find((p) => p.key === 'application.reason')?.values?.[0] ?? '';
   } else if (templateType === 'decision') {
     parameters['decisionText'] = wrapWithWordBreak(formData.description);
     parameters['decisionDate'] = dayjs(decision?.decidedAt).format('YYYY-MM-DD');
@@ -411,12 +412,19 @@ export const renderPdf: (
       : '';
 
     parameters['lawReferences'] = lawReferences;
-    parameters['services'] = services && services.length > 0
-      ? mapServicesToTemplateParams(services)
-      : [];
+    parameters['services'] = services && services.length > 0 ? mapServicesToTemplateParams(services) : [];
   }
 
-  const renderBody: TemplateSelector = { identifier, parameters };
+  return { identifier, parameters };
+};
+
+export const renderPdf: (
+  errand: IErrand,
+  formData: UtredningFormModel | DecisionFormModel,
+  templateType: 'investigation' | 'decision',
+  services?: Service[]
+) => Promise<{ pdfBase64: string; error?: string }> = async (errand, formData, templateType, services) => {
+  const renderBody: TemplateSelector = buildPdfTemplate(errand, formData, templateType, services);
 
   return apiService
     .post<ApiResponse<Render>, TemplateSelector>('render/pdf', renderBody)
@@ -450,7 +458,10 @@ export const renderHtml: (
       administratorName: errand.administrator
         ? `${errand.administrator?.firstName} ${errand.administrator?.lastName}`
         : '',
-      description: `<div style="overflow-wrap: break-word; word-break: break-word;">${formData.description.replace(/<p>/g, '<p style="margin: 0;">')}</div>`,
+      description: `<div style="overflow-wrap: break-word; word-break: break-word;">${formData.description.replace(
+        /<p>/g,
+        '<p style="margin: 0;">'
+      )}</div>`,
       decisionDate: dayjs(decision?.updated).format('YYYY-MM-DD'),
     },
   };

--- a/frontend/src/casedata/services/casedata-decision-service.ts
+++ b/frontend/src/casedata/services/casedata-decision-service.ts
@@ -290,22 +290,6 @@ export const mapServicesToTemplateParams = (services: Service[]): Record<string,
   });
 };
 
-export const renderUtredningPdf: (
-  errand: IErrand,
-  d: UtredningFormModel | DecisionFormModel,
-  services?: Service[]
-) => Promise<{ pdfBase64: string; error?: string }> = async (errand, d, services) => {
-  return renderPdf(errand, d, 'investigation', services);
-};
-
-export const renderBeslutPdf: (
-  errand: IErrand,
-  d: UtredningFormModel | DecisionFormModel,
-  services?: Service[]
-) => Promise<{ pdfBase64: string; error?: string }> = async (errand, d, services) => {
-  return renderPdf(errand, d, 'decision', services);
-};
-
 export const buildPdfTemplate: (
   errand: IErrand,
   formData: UtredningFormModel | DecisionFormModel,


### PR DESCRIPTION
## Summary
- Ersätter "Förhandsgranska PDF"-knappen i utredningstabben med en inline `TemplatePdfPreview` som uppdateras live (debouncad 800ms) när utfall, lagrum eller utredningstext ändras.
- Bryter ut `buildPdfTemplate` från `renderPdf` så live-preview och sparad PDF bygger identifier + parameters genom samma kodväg (kan inte divergera).
- "Utredningsmall"-rubriken (FT/RFT) är nu en `Disclosure`-accordion som wrappar textrutan i stället för att vara en divider ovanför hela formuläret.

## Bug fix
Förhandsgranska-knappen i utredningstabben anropade `saveDecision(..., 'PROPOSED', pdf)` innan något beslut fanns sparat, vilket gav `400 Bad Request` på `PATCH /pt/{municipalityId}/errands/{id}/decisions` när användaren klickade. Den live-preview-baserade lösningen går via `renderTemplatePdf` direkt och sparar inte — buggen försvinner automatiskt.

## Konsistens med decision-tabben
Decision-tabben fick samma refactor i DRAKEN-3085 (preview slutar spara, använder `TemplatePdfPreview`). Utredningstabben missades då. Den här ändringen tar utredningstabben till samma mönster.

## Test plan
- [ ] PT (RPH, non-FT): välj utfall + lagrum, börja skriva utredningstext → PDF-preview uppdateras live ovanför textrutan
- [ ] PT FT/RFT: skelettmall laddas in i editorn som tidigare, "Utredningsmall"-accordion innehåller textrutan, preview visas ovan accordion
- [ ] MEX: ingen live-preview (samma som decision-tabben)
- [ ] Spara fungerar fortfarande och bifogar PDF till PROPOSED-beslutet
- [ ] Ingen 400 längre vid första interaktion med utredningstabben

https://jira.sundsvall.se/browse/DRAKEN-3617