### PR TITLE
fix: message template dropdown empty in Draken new message dialog

### DIFF
--- a/backend/src/controllers/template.controller.ts
+++ b/backend/src/controllers/template.controller.ts
@@ -149,7 +149,7 @@ export class TemplateController {
     // Templates live in SUPPORTMANAGEMENT_NAMESPACE (e.g. CONTACTSUNDSVALL).
     // CASEDATA_NAMESPACE (e.g. SBK_MEX) is for errands only — used as fallback
     // for envs that don't have a supportmanagement namespace configured.
-    const namespace = prefix === 'internal.' ? 'CONTACTSUNDSVALL' : SUPPORTMANAGEMENT_NAMESPACE || CASEDATA_NAMESPACE;
+    const namespace = SUPPORTMANAGEMENT_NAMESPACE || CASEDATA_NAMESPACE;
     const baseUrl = `${this.SERVICE}/${MUNICIPALITY_ID}/templates`;
     const searchUrl = namespace ? `${baseUrl}?namespace=${namespace}` : baseUrl;
 

--- a/backend/src/controllers/template.controller.ts
+++ b/backend/src/controllers/template.controller.ts
@@ -146,7 +146,10 @@ export class TemplateController {
     @QueryParam('excludeRoles') excludeRoles: string = '',
     @QueryParam('decision') decision: string = '',
   ): Promise<ResponseData> {
-    const namespace = prefix === 'internal.' ? 'CONTACTSUNDSVALL' : CASEDATA_NAMESPACE || SUPPORTMANAGEMENT_NAMESPACE;
+    // Templates live in SUPPORTMANAGEMENT_NAMESPACE (e.g. CONTACTSUNDSVALL).
+    // CASEDATA_NAMESPACE (e.g. SBK_MEX) is for errands only — used as fallback
+    // for envs that don't have a supportmanagement namespace configured.
+    const namespace = prefix === 'internal.' ? 'CONTACTSUNDSVALL' : SUPPORTMANAGEMENT_NAMESPACE || CASEDATA_NAMESPACE;
     const baseUrl = `${this.SERVICE}/${MUNICIPALITY_ID}/templates`;
     const searchUrl = namespace ? `${baseUrl}?namespace=${namespace}` : baseUrl;
 

--- a/frontend/src/casedata/hooks/useMessageTemplates.ts
+++ b/frontend/src/casedata/hooks/useMessageTemplates.ts
@@ -73,7 +73,7 @@ export function useMessageTemplates(user: User, shouldLoad: boolean): UseMessage
         });
 
         const emailTemplates = appResult.templates.filter((t) => {
-          return getTemplateType(t) === 'Email' && !['signature', 'publicdocuments'].includes(getTemplateRole(t) || '');
+          return getTemplateType(t) === 'email' && !['signature', 'publicdocuments'].includes(getTemplateRole(t) || '');
         });
 
         // If no app-specific email templates, use default ones
@@ -81,21 +81,21 @@ export function useMessageTemplates(user: User, shouldLoad: boolean): UseMessage
           emailTemplates.length === 0
             ? defaultResult.templates.filter((t) => {
                 return (
-                  getTemplateType(t) === 'Email' &&
+                  getTemplateType(t) === 'email' &&
                   !['signature', 'publicdocuments', 'closing'].includes(getTemplateRole(t) || '')
                 );
               })
             : [];
 
         const smsTemplates = appResult.templates.filter((t) => {
-          return getTemplateType(t) === 'Sms' && getTemplateRole(t) !== 'signature';
+          return getTemplateType(t) === 'sms' && getTemplateRole(t) !== 'signature';
         });
 
         // If no app-specific sms templates, use default ones
         const fallbackSmsTemplates =
           smsTemplates.length === 0
             ? defaultResult.templates.filter((t) => {
-                return getTemplateType(t) === 'Sms' && getTemplateRole(t) !== 'signature';
+                return getTemplateType(t) === 'sms' && getTemplateRole(t) !== 'signature';
               })
             : [];
 

--- a/frontend/src/common/utils/template-metadata.ts
+++ b/frontend/src/common/utils/template-metadata.ts
@@ -9,24 +9,24 @@ export function getTemplateMetadata(template: TemplateWithMetadata, key: string)
 
 /**
  * Get template type from metadata (templateType), falling back to identifier parts[1].
- * E.g. "mex.email.default" → "email"
+ * E.g. "mex.email.default" → "email". Always lowercased.
  */
 export function getTemplateType(template: TemplateWithMetadata): string | undefined {
   const fromMetadata = getTemplateMetadata(template, 'templateType');
-  if (fromMetadata) return fromMetadata;
+  if (fromMetadata) return fromMetadata.toLowerCase();
 
   const parts = template.identifier?.split('.') || [];
-  return parts.length >= 2 ? parts[1] : undefined;
+  return parts.length >= 2 ? parts[1].toLowerCase() : undefined;
 }
 
 /**
  * Get template role from metadata (templateRole), falling back to identifier parts[2].
- * E.g. "mex.email.signature" → "signature"
+ * E.g. "mex.email.signature" → "signature". Always lowercased.
  */
 export function getTemplateRole(template: TemplateWithMetadata): string | undefined {
   const fromMetadata = getTemplateMetadata(template, 'templateRole');
-  if (fromMetadata) return fromMetadata;
+  if (fromMetadata) return fromMetadata.toLowerCase();
 
   const parts = template.identifier?.split('.') || [];
-  return parts.length >= 3 ? parts[2] : undefined;
+  return parts.length >= 3 ? parts[2].toLowerCase() : undefined;
 }


### PR DESCRIPTION
## Summary
- Backend: query `SUPPORTMANAGEMENT_NAMESPACE` first, fall back to `CASEDATA_NAMESPACE`. Templates live in `CONTACTSUNDSVALL` (supportmanagement namespace), not in `SBK_MEX` which is errand-only.
- Backend: `internal.signature` lookup is no longer hardcoded to `CONTACTSUNDSVALL` — follows the same fallback chain so non-Sundsvall environments (e.g. Ånge / CONTACTANGE) can have their own internal signatures.
- Frontend: normalize `templateType` / `templateRole` to lowercase so filters work regardless of metadata casing (`Email` vs `email`, `Sms` vs `sms`).

## Bakgrund
"Välj meddelandemall"-dropdownen i Drakens Nytt meddelande-dialog var tom. Två orsaker:

1. Backend frågade `CASEDATA_NAMESPACE` (`SBK_MEX`) för `default.*` och `mex.*`-prefixade mallar, men mallarna lever i `CONTACTSUNDSVALL`. Endast `internal.*` fungerade (hårdkodad).
2. Frontend-filtret jämförde mot `'Email'` / `'Sms'` (versal), men identifier-fallback gav lowercase. Filter matchade då inte om metadata saknades.

Vidare upptäcktes att `internal.signature` (intern signatur för Draken-kanalen och "Begär intern återkoppling") var hårdkodad till `CONTACTSUNDSVALL`. Det fungerar i Sundsvalls instanser men bryter för andra kommuner (Ånge etc.) som har egen support-management-namespace. Fixat samtidigt för att framtidssäkra.

## Ändringar
- \`backend/src/controllers/template.controller.ts\` — flippad fallback-ordning för namespace; tagit bort hårdkodning av `internal.` så även den följer fallbacken
- \`frontend/src/common/utils/template-metadata.ts\` — case-normalisering i `getTemplateType`/`getTemplateRole`
- \`frontend/src/casedata/hooks/useMessageTemplates.ts\` — filter använder lowercase strings

## Test plan
- [ ] Sätt `SUPPORTMANAGEMENT_NAMESPACE=CONTACTSUNDSVALL` i lokal env för MEX/PT
- [ ] Öppna ett ärende i Draken (MEX) → Meddelanden → Nytt meddelande
- [ ] Verifiera att `default.email.default` syns i "Välj meddelandemall"-dropdownen
- [ ] Verifiera att val av mall populerar meddelandekroppen
- [ ] Verifiera att Draken-kanalens interna signatur fortfarande sätts korrekt
- [ ] Verifiera att KC-flödet inte påverkas