### PR TITLE
fix: template fix to main branch

### DIFF
--- a/backend/src/controllers/template.controller.ts
+++ b/backend/src/controllers/template.controller.ts
@@ -146,7 +146,10 @@ export class TemplateController {
     @QueryParam('excludeRoles') excludeRoles: string = '',
     @QueryParam('decision') decision: string = '',
   ): Promise<ResponseData> {
-    const namespace = prefix === 'internal.' ? 'CONTACTSUNDSVALL' : CASEDATA_NAMESPACE || SUPPORTMANAGEMENT_NAMESPACE;
+    // Templates live in SUPPORTMANAGEMENT_NAMESPACE (e.g. CONTACTSUNDSVALL).
+    // CASEDATA_NAMESPACE (e.g. SBK_MEX) is for errands only — used as fallback
+    // for envs that don't have a supportmanagement namespace configured.
+    const namespace = SUPPORTMANAGEMENT_NAMESPACE || CASEDATA_NAMESPACE;
     const baseUrl = `${this.SERVICE}/${MUNICIPALITY_ID}/templates`;
     const searchUrl = namespace ? `${baseUrl}?namespace=${namespace}` : baseUrl;
 

--- a/frontend/src/casedata/hooks/useMessageTemplates.ts
+++ b/frontend/src/casedata/hooks/useMessageTemplates.ts
@@ -73,7 +73,7 @@ export function useMessageTemplates(user: User, shouldLoad: boolean): UseMessage
         });
 
         const emailTemplates = appResult.templates.filter((t) => {
-          return getTemplateType(t) === 'Email' && !['signature', 'publicdocuments'].includes(getTemplateRole(t) || '');
+          return getTemplateType(t) === 'email' && !['signature', 'publicdocuments'].includes(getTemplateRole(t) || '');
         });
 
         // If no app-specific email templates, use default ones
@@ -81,21 +81,21 @@ export function useMessageTemplates(user: User, shouldLoad: boolean): UseMessage
           emailTemplates.length === 0
             ? defaultResult.templates.filter((t) => {
                 return (
-                  getTemplateType(t) === 'Email' &&
+                  getTemplateType(t) === 'email' &&
                   !['signature', 'publicdocuments', 'closing'].includes(getTemplateRole(t) || '')
                 );
               })
             : [];
 
         const smsTemplates = appResult.templates.filter((t) => {
-          return getTemplateType(t) === 'Sms' && getTemplateRole(t) !== 'signature';
+          return getTemplateType(t) === 'sms' && getTemplateRole(t) !== 'signature';
         });
 
         // If no app-specific sms templates, use default ones
         const fallbackSmsTemplates =
           smsTemplates.length === 0
             ? defaultResult.templates.filter((t) => {
-                return getTemplateType(t) === 'Sms' && getTemplateRole(t) !== 'signature';
+                return getTemplateType(t) === 'sms' && getTemplateRole(t) !== 'signature';
               })
             : [];
 

--- a/frontend/src/common/utils/template-metadata.ts
+++ b/frontend/src/common/utils/template-metadata.ts
@@ -9,24 +9,24 @@ export function getTemplateMetadata(template: TemplateWithMetadata, key: string)
 
 /**
  * Get template type from metadata (templateType), falling back to identifier parts[1].
- * E.g. "mex.email.default" → "email"
+ * E.g. "mex.email.default" → "email". Always lowercased.
  */
 export function getTemplateType(template: TemplateWithMetadata): string | undefined {
   const fromMetadata = getTemplateMetadata(template, 'templateType');
-  if (fromMetadata) return fromMetadata;
+  if (fromMetadata) return fromMetadata.toLowerCase();
 
   const parts = template.identifier?.split('.') || [];
-  return parts.length >= 2 ? parts[1] : undefined;
+  return parts.length >= 2 ? parts[1].toLowerCase() : undefined;
 }
 
 /**
  * Get template role from metadata (templateRole), falling back to identifier parts[2].
- * E.g. "mex.email.signature" → "signature"
+ * E.g. "mex.email.signature" → "signature". Always lowercased.
  */
 export function getTemplateRole(template: TemplateWithMetadata): string | undefined {
   const fromMetadata = getTemplateMetadata(template, 'templateRole');
-  if (fromMetadata) return fromMetadata;
+  if (fromMetadata) return fromMetadata.toLowerCase();
 
   const parts = template.identifier?.split('.') || [];
-  return parts.length >= 3 ? parts[2] : undefined;
+  return parts.length >= 3 ? parts[2].toLowerCase() : undefined;
 }


### PR DESCRIPTION
Applicera på mainbranchen fixen för mallar som redan gjorts i develop, så att prodsättning kan göras igen.

* fix: message template dropdown empty in Draken new message dialog

- Backend: query SUPPORTMANAGEMENT_NAMESPACE first, fall back to CASEDATA_NAMESPACE. Templates live in CONTACTSUNDSVALL (supportmanagement), not in SBK_MEX which is errand-only.
- Frontend: normalize templateType/templateRole to lowercase so filters work regardless of metadata casing (Email vs email, Sms vs sms).

* fix: also resolve internal.signature dynamically per namespace

Previously hardcoded to CONTACTSUNDSVALL, which broke for non-Sundsvall environments (e.g. Ånge / CONTACTANGE) that have their own internal signature. Now follows the same SUPPORTMANAGEMENT_NAMESPACE || CASEDATA_NAMESPACE fallback as other prefixes.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).
