### PR TITLE
fix: isolate message form instances and group message-type radios

### DIFF
--- a/frontend/cypress/e2e/case-data/mex/errandPage-message-tab-mex.cy.ts
+++ b/frontend/cypress/e2e/case-data/mex/errandPage-message-tab-mex.cy.ts
@@ -185,17 +185,17 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
 
       cy.get('[data-cy="send-message-button"]').should('be.disabled');
 
-      cy.get('[data-cy="messageTemplate"]').should('exist').eq(1).select(1);
+      cy.get('[data-cy="messageTemplate"]').should('exist').first().select(1);
       cy.get('[data-cy="decision-richtext-wrapper"]').should('exist');
 
-      cy.get('[data-cy="newPhoneNumber"]').should('exist').eq(1).clear().type('1234abc890');
+      cy.get('[data-cy="newPhoneNumber"]').should('exist').first().clear().type('1234abc890');
       cy.get('[data-cy="messagePhone-error"]').should('exist').contains('Ej giltigt telefonnummer');
 
-      cy.get('[data-cy="newPhoneNumber"]').should('exist').eq(1).clear().type('+46701740635');
+      cy.get('[data-cy="newPhoneNumber"]').should('exist').first().clear().type('+46701740635');
       cy.get('[data-cy="messagePhone-error"]').should('not.exist');
 
-      cy.get('[data-cy="newPhoneNumber-button"]').should('be.enabled').eq(1).click({ force: true });
-      cy.get('[data-cy="send-message-button"]').should('be.enabled').eq(1).click({ force: true });
+      cy.get('[data-cy="newPhoneNumber-button"]').should('be.enabled').first().click({ force: true });
+      cy.get('[data-cy="send-message-button"]').should('be.enabled').first().click({ force: true });
 
       cy.wait('@sendSms').should(({ request }) => {
         expect(request.body.phonenumber).to.equal('+46701740635');
@@ -209,8 +209,6 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
 
       goToMessageTab();
       cy.get('[data-cy="new-message-button"]').should('exist').click();
-      // FIXME Need to use first since two message composer components are rendered,
-      // on for the sidebar and one for the message tab. Not good.
       cy.get('[data-cy="send-message-button"]').should('be.disabled');
       cy.get('[data-cy="useEmail-radiobutton-true"]').first().click({ force: true });
       cy.get('[data-cy="send-message-button"]').should('be.disabled');

--- a/frontend/src/casedata/components/errand/tabs/messages/message-composer.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/messages/message-composer.component.tsx
@@ -565,7 +565,7 @@ export const MessageComposer: FC<{
             <RadioButton.Group data-cy="message-type-radio-button-group" className="mt-sm !gap-4">
               <RadioButton
                 disabled={isLoading || !allowed}
-                name="useNewMessage"
+                name="typeOfMessage"
                 id="useNewMessage"
                 value="newMessage"
                 checked={typeOfMessage === 'newMessage'}
@@ -575,7 +575,7 @@ export const MessageComposer: FC<{
               </RadioButton>
               <RadioButton
                 disabled={isLoading || !allowed}
-                name="useInfoCompletion"
+                name="typeOfMessage"
                 id="useInfoCompletion"
                 value="infoCompletion"
                 checked={typeOfMessage === 'infoCompletion'}
@@ -585,7 +585,7 @@ export const MessageComposer: FC<{
               </RadioButton>
               <RadioButton
                 disabled={isLoading || !allowed}
-                name="useInternalCompletion"
+                name="typeOfMessage"
                 id="useInternalCompletion"
                 value="internalCompletion"
                 checked={typeOfMessage === 'internalCompletion'}

--- a/frontend/src/common/components/message/message-wrapper.component.tsx
+++ b/frontend/src/common/components/message/message-wrapper.component.tsx
@@ -33,7 +33,7 @@ export const MessageWrapper: FC<{
           <X data-cy="close-message-wrapper-icon" />
         </Button>
       </Header>
-      {children}
+      {show && children}
     </section>
   </>
 );

--- a/frontend/src/supportmanagement/components/support-message-form/support-message-form.component.tsx
+++ b/frontend/src/supportmanagement/components/support-message-form/support-message-form.component.tsx
@@ -546,7 +546,7 @@ export const SupportMessageForm: FC<{
         <RadioButton.Group data-cy="message-type-radio-button-group" className="mt-sm !gap-4">
           <RadioButton
             disabled={props.locked}
-            name="useNewMessage"
+            name="typeOfMessage"
             id="useNewMessage"
             value="newMessage"
             checked={typeOfMessage === 'newMessage'}
@@ -556,7 +556,7 @@ export const SupportMessageForm: FC<{
           </RadioButton>
           <RadioButton
             disabled={props.locked}
-            name="useInfoCompletion"
+            name="typeOfMessage"
             id="useInfoCompletion"
             value="infoCompletion"
             checked={typeOfMessage === 'infoCompletion'}
@@ -566,7 +566,7 @@ export const SupportMessageForm: FC<{
           </RadioButton>
           <RadioButton
             disabled={props.locked}
-            name="useInternalCompletion"
+            name="typeOfMessage"
             id="useInternalCompletion"
             value="internalCompletion"
             checked={typeOfMessage === 'internalCompletion'}


### PR DESCRIPTION
## Beskrivning

Meddelandeknappen "Typ av meddelande" gick i vissa lägen inte att klicka på, och val i "Välj meddelandemall" kunde råka markera en radioknapp. Båda problemen visade sig vara symptom av att hela formuläret renderades två gånger samtidigt i DOM:en.

## Rotorsak

`MessageWrapper` unmountar inte sina barn — den döljer dem med `w-0 px-0`. Eftersom både `MessageComposer` (casedata) och `SupportMessageForm` (support) renderas på två platser samtidigt (tab + sidebar) fanns dubbletter av samma formulär i DOM:en hela tiden. Resultatet:

- Dubbla `id`-attribut → label-klick i en instans kunde träffa den dolda instansen
- Dubbla radioknappar med samma `name` (efter min första fix) → native browser-radiogruppering omfattade alla 6 inputs som en grupp
- Mallar och errand-relationer hämtades dubbelt
- Form state, refs och effekter levde i båda instanser parallellt

## Fix

1. `MessageWrapper` renderar nu barnen villkorligt (`{show && children}`). När panelen är stängd unmountas formuläret helt.
2. De tre radios för "Typ av meddelande" delar nu `name="typeOfMessage"` (var olika tidigare, vilket bröt korrekt HTML-radiosemantik).

Övergångsanimationen i `<section>`-wrappern är intakt eftersom den ligger på wrappern, inte på barnen.

## Sidoeffekter (positiva)

- Templates och errand-relationer hämtas inte längre dubbelt
- Validering, watch-handlers och refs körs bara i synligt formulär
- DOM:en är mindre — bättre devtools-läsbarhet och accessibility
- Form state återställs naturligt vid stängning via unmount

## Testplan

- [ ] Öppna meddelandekompositören från meddelandefliken — välj olika mallar, byt radio "Typ av meddelande" fram och tillbaka
- [ ] Öppna meddelandekompositören från sidofältet — samma test
- [ ] Verifiera att stängningsanimationen ser OK ut
- [ ] Skicka meddelande med "Begär komplettering" → ärendestatus ska sättas till `VantarPaKomplettering`
- [ ] Skicka meddelande med "Begär intern återkoppling" → ärendestatus ska sättas till `InterntAterkoppling`
- [ ] Testa både casedata och support-management

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).