### PR TITLE
fix: fall back to default closing template when app-specific is missing

### DIFF
--- a/frontend/src/supportmanagement/components/support-errand/sidebar/buttons/support-close-errand-button.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/buttons/support-close-errand-button.component.tsx
@@ -59,43 +59,49 @@ export const SupportCloseErrandButtonComponent: React.FC<{ disabled: boolean }> 
 
   const formControls: UseFormReturn<SupportErrand, any, undefined> = useFormContext();
 
-  const showCloseErrorToast = () => {
+  const showCloseErrorToast = (message = 'Något gick fel när ärendet skulle avslutas') => {
     toastMessage({
       position: 'bottom',
       closeable: false,
-      message: 'Något gick fel när ärendet skulle avslutas',
+      message,
       status: 'error',
     });
   };
 
-  const handleCloseErrand = (resolution: Resolution, msg: boolean) => {
+  const handleCloseErrand = async (resolution: Resolution, msg: boolean) => {
     setIsLoading(true);
-    return closeSupportErrand(supportErrand!.id!, municipalityId, resolution)
-      .then(() => {
-        if (msg) {
-          const admin = administrators.find((a) => a.adAccount === supportErrand!.assignedUserId);
-          const adminName = getAdminName(admin!);
-          return sendClosingMessage(adminName, supportErrand!, municipalityId);
-        }
-      })
-      .then(() => {
-        toastMessage(
-          getToastOptions({
-            message: 'Ärendet avslutades',
-            status: 'success',
-          })
-        );
-        setTimeout(() => {
-          window.close();
-        }, 2000);
+    try {
+      await closeSupportErrand(supportErrand!.id!, municipalityId, resolution);
+    } catch (e) {
+      showCloseErrorToast();
+      setIsLoading(false);
+      return;
+    }
+
+    if (msg) {
+      try {
+        const admin = administrators.find((a) => a.adAccount === supportErrand!.assignedUserId);
+        const adminName = getAdminName(admin!);
+        await sendClosingMessage(adminName, supportErrand!, municipalityId);
+      } catch (e) {
+        showCloseErrorToast('Ärendet avslutades men avslutningsmeddelandet kunde inte skickas');
         setIsLoading(false);
         getSupportErrandById(supportErrand!.id!, municipalityId).then((res) => setSupportErrand(res.errand));
-      })
-      .catch((e) => {
-        showCloseErrorToast();
-        setIsLoading(false);
         return;
-      });
+      }
+    }
+
+    toastMessage(
+      getToastOptions({
+        message: 'Ärendet avslutades',
+        status: 'success',
+      })
+    );
+    setTimeout(() => {
+      window.close();
+    }, 2000);
+    setIsLoading(false);
+    getSupportErrandById(supportErrand!.id!, municipalityId).then((res) => setSupportErrand(res.errand));
   };
 
   return (

--- a/frontend/src/supportmanagement/components/support-errand/sidebar/buttons/support-close-errand-button.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/buttons/support-close-errand-button.component.tsx
@@ -69,10 +69,13 @@ export const SupportCloseErrandButtonComponent: React.FC<{ disabled: boolean }> 
   };
 
   const handleCloseErrand = async (resolution: Resolution, msg: boolean) => {
+    if (!supportErrand?.id) return;
+    const errandId = supportErrand.id;
     setIsLoading(true);
     try {
-      await closeSupportErrand(supportErrand!.id!, municipalityId, resolution);
+      await closeSupportErrand(errandId, municipalityId, resolution);
     } catch (e) {
+      console.error('Failed to close support errand', e);
       showCloseErrorToast();
       setIsLoading(false);
       return;
@@ -80,13 +83,14 @@ export const SupportCloseErrandButtonComponent: React.FC<{ disabled: boolean }> 
 
     if (msg) {
       try {
-        const admin = administrators.find((a) => a.adAccount === supportErrand!.assignedUserId);
+        const admin = administrators.find((a) => a.adAccount === supportErrand.assignedUserId);
         const adminName = getAdminName(admin!);
-        await sendClosingMessage(adminName, supportErrand!, municipalityId);
+        await sendClosingMessage(adminName, supportErrand, municipalityId);
       } catch (e) {
+        console.error('Failed to send closing message', e);
         showCloseErrorToast('Ärendet avslutades men avslutningsmeddelandet kunde inte skickas');
         setIsLoading(false);
-        getSupportErrandById(supportErrand!.id!, municipalityId).then((res) => setSupportErrand(res.errand));
+        getSupportErrandById(errandId, municipalityId).then((res) => setSupportErrand(res.errand));
         return;
       }
     }
@@ -101,7 +105,7 @@ export const SupportCloseErrandButtonComponent: React.FC<{ disabled: boolean }> 
       window.close();
     }, 2000);
     setIsLoading(false);
-    getSupportErrandById(supportErrand!.id!, municipalityId).then((res) => setSupportErrand(res.errand));
+    getSupportErrandById(errandId, municipalityId).then((res) => setSupportErrand(res.errand));
   };
 
   return (

--- a/frontend/src/supportmanagement/services/message-template-service.ts
+++ b/frontend/src/supportmanagement/services/message-template-service.ts
@@ -161,10 +161,14 @@ export async function getSmsTemplate(
 
 export async function getClosingTemplate(app: string, parameters: Record<string, string> = {}): Promise<string | null> {
   const appLower = app.toLowerCase();
-  const contentId = `${appLower}.email.closing`;
   const signatureId = `${appLower}.email.signature`;
 
-  return fetchContentWithSignature(contentId, signatureId, parameters);
+  const appClosing = await fetchContentWithSignature(`${appLower}.email.closing`, signatureId, parameters);
+  if (appClosing) {
+    return appClosing;
+  }
+
+  return fetchContentWithSignature('default.email.closing', signatureId, parameters);
 }
 
 export async function getInternalSignature(parameters: Record<string, string> = {}): Promise<string | null> {

--- a/frontend/src/supportmanagement/services/support-message-service.ts
+++ b/frontend/src/supportmanagement/services/support-message-service.ts
@@ -4,6 +4,7 @@ import { toBase64 } from '@common/utils/toBase64';
 import dayjs from 'dayjs';
 import { CCommunicationAttachment } from 'src/data-contracts/backend/data-contracts';
 import { v4 as uuidv4 } from 'uuid';
+
 import { getClosingTemplate } from './message-template-service';
 import { SingleSupportAttachment } from './support-attachment-service';
 import { Channels, ContactChannelType, SupportErrand } from './support-errand-service';
@@ -52,7 +53,7 @@ const getClosingMessageBody = async (userName: string): Promise<string> => {
 
   const content = await getClosingTemplate(app, { user: userName });
   if (!content) {
-    console.error(`Could not get closing-template: ${app}.email.closing`);
+    console.error(`Could not get closing-template: neither ${app}.email.closing nor default.email.closing was found`);
     return '';
   }
 
@@ -75,6 +76,9 @@ const getPlaintextMessageBody = (htmlMessage: string): string => {
 export const sendClosingMessage = async (adminName: string, supportErrand: SupportErrand, municipalityId: string) => {
   const contactChannels = applicantContactChannel(supportErrand);
   const messageBody = await getClosingMessageBody(adminName);
+  if (!messageBody) {
+    return Promise.reject('No closing-message template available');
+  }
   const plaintextMessageBody = getPlaintextMessageBody(messageBody);
 
   return sendMessage({

--- a/frontend/src/supportmanagement/services/support-message-service.ts
+++ b/frontend/src/supportmanagement/services/support-message-service.ts
@@ -77,7 +77,7 @@ export const sendClosingMessage = async (adminName: string, supportErrand: Suppo
   const contactChannels = applicantContactChannel(supportErrand);
   const messageBody = await getClosingMessageBody(adminName);
   if (!messageBody) {
-    return Promise.reject('No closing-message template available');
+    throw new Error('No closing-message template available');
   }
   const plaintextMessageBody = getPlaintextMessageBody(messageBody);
 


### PR DESCRIPTION
## Beskrivning

Apps utan en `{app}.email.closing`-mall (KC, KA, MEX, PT) skickade tysta tomma mejl när handläggare avslutade ett ärende med "Skicka meddelande till ärendeägare"-kryssrutan.

## Problem

- `getClosingTemplate` slog bara upp `{app}.email.closing`. Saknades den returnerades en tom sträng utan att flödet stoppades.
- `sendClosingMessage` skickade vidare det tomma innehållet till `sendMessage`, vilket resulterade i ett tomt mejl till ärendeägaren.
- `handleCloseErrand` skiljde inte på "ärendet kunde inte avslutas" och "ärendet avslutades men avslutningsmeddelandet kunde inte skickas". Vid fel i meddelandeskicket visades fel toast och UI:t uppdaterades inte med den faktiska avslutade statusen.

## Fix

- **`getClosingTemplate`** försöker först `{app}.email.closing` och faller sedan tillbaka till `default.email.closing` (konsekvent med `useMessageTemplates`-mönstret för andra varianter).
- **`sendClosingMessage`** avbryter (Promise.reject) när ingen mall finns istället för att skicka tomt mejl.
- **`handleCloseErrand`** delas upp i två steg med separata try/catch:
  - Misslyckas själva stängningen → fel-toast, ingen ändring av status
  - Stängning lyckas men meddelandeskicket misslyckas → särskild toast ("Ärendet avslutades men avslutningsmeddelandet kunde inte skickas") och refetch av ärendet så att UI:t visar den faktiska avslutade statusen.

## Testplan

- [x] App utan egen closing-mall (t.ex. KC): avsluta ärende med checkboxen ikryssad → defaultmall används, mejl skickas korrekt
- [x] App med egen closing-mall (t.ex. IK/LOP): avsluta ärende med checkboxen ikryssad → app-specifik mall används som tidigare
- [x] Saknad både app- och defaultmall: avsluta ärende → ärendet stängs ändå, men en tydlig toast informerar om att meddelandet inte gick iväg, och UI:t reflekterar det avslutade ärendet
- [x] Fel vid själva stängningen (mocka 500 från backend): fel-toast visas, status oförändrad

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).