### PR TITLE
fix: wrap PT investigation editor in same Disclosure as FT

### DIFF
--- a/frontend/src/casedata/components/errand/tabs/investigation/casedata-investigation-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/investigation/casedata-investigation-tab.tsx
@@ -397,7 +397,9 @@ export const CasedataInvestigationTab: FC<{
                 </div>
               </FormControl>
             );
-            return isFTErrand(props.errand) ? (
+            return isMEX() ? (
+              editorBlock
+            ) : (
               <Disclosure variant="alt" initalOpen className="mb-24" data-cy="investigation-template-disclosure">
                 <Disclosure.Header>
                   <Disclosure.Icon icon={<ClipboardPenLine size={18} />} />
@@ -406,8 +408,6 @@ export const CasedataInvestigationTab: FC<{
                 </Disclosure.Header>
                 <Disclosure.Content>{editorBlock}</Disclosure.Content>
               </Disclosure>
-            ) : (
-              editorBlock
             );
           })()}
           <div className="flex justify-left gap-10">

--- a/frontend/src/casedata/services/casedata-decision-service.ts
+++ b/frontend/src/casedata/services/casedata-decision-service.ts
@@ -343,7 +343,7 @@ export const buildPdfTemplate: (
   const parameters: { [key: string]: any } = {
     caseNumber: formData.errandNumber ?? '',
     caseType: getLabelFromCaseType(formData.errandCaseType),
-    personalNumber: formData.personalNumber ?? '',
+    personalNumber: owner?.personalNumber ?? '',
     addressLastname: owner?.lastName,
     addressFirstname: owner?.firstName,
     addressCo: owner?.careof,


### PR DESCRIPTION
## Summary
- Wrappa PT/RPH-editorn i samma `Utredningsmall`-Disclosure som FT/RFT redan har.
- Endast MEX behåller den rena `editorBlock`-renderingen.
- Tidigare gav PT/RPH bara en bar textruta medan FT fick en Disclosure runt sin — visuellt inkonsekvent efter PR #1008.
- Läs `personalNumber` från owner-stakeholder direkt i `buildPdfTemplate` (`casedata-decision-service.ts`). `UtredningFormModel` saknar fältet så investigation-tabbens preview/save skickade alltid `personalNumber=""` till templating-tjänsten — vilket gjorde att personnummer aldrig dök upp i utrednings-PDF:en. Decision-tabben satte fältet via formData från samma `owner`, så att läsa det direkt i `buildPdfTemplate` är beteendeneutralt där.

## Test plan
- [ ] Öppna ett PT/RPH-ärende → Utredning-tabben → bekräfta att textrutan nu ligger inuti en `Utredningsmall`-Disclosure (öppen som standard).
- [ ] Öppna ett FT/RFT-ärende → Utredning-tabben → bekräfta att Disclosure fortfarande fungerar oförändrad.
- [ ] Öppna ett MEX-ärende → Utredning-tabben → bekräfta att textrutan renderas utan Disclosure.
- [ ] Öppna ett PT/RPH-ärende med en stakeholder som ägare → Utredning-tabben → bekräfta att personnummer visas i mall-preview/sparad PDF.
- [ ] Öppna ett ärende i Beslut-tabben → bekräfta att personnummer fortfarande visas i preview (regressionscheck).