### PR TITLE
Pre-select default message template, warn on overwrite, exclude closing role

### DIFF
--- a/frontend/cypress/e2e/case-data/mex/errandPage-message-tab-mex.cy.ts
+++ b/frontend/cypress/e2e/case-data/mex/errandPage-message-tab-mex.cy.ts
@@ -185,7 +185,7 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
 
       cy.get('[data-cy="send-message-button"]').should('be.disabled');
 
-      cy.get('[data-cy="messageTemplate"]').should('exist').first().select(1);
+      cy.get('[data-cy="messageTemplate"]').should('exist').first().select(0);
       cy.get('[data-cy="decision-richtext-wrapper"]').should('exist');
 
       cy.get('[data-cy="newPhoneNumber"]').should('exist').first().clear().type('1234abc890');
@@ -298,7 +298,7 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
           cy.get(`[data-cy="expand-message-button-${message.emailHeaders[0].values}"]`).should('exist').click();
           messageNode.find(`[data-cy="respond-button"]`).should('exist').click({ force: true });
 
-          cy.get('[data-cy="messageTemplate"]').should('exist').first().select(1);
+          cy.get('[data-cy="messageTemplate"]').should('exist').first().select(0);
           cy.get('[data-cy="email-tag-0"]').should('exist').contains(message.email);
           cy.get('[data-cy="send-message-button"]').should('exist').first().click({ force: true });
 

--- a/frontend/src/casedata/components/errand/tabs/messages/casedata-messages-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/messages/casedata-messages-tab.tsx
@@ -6,10 +6,11 @@ import {
   MessageNode,
   setMessageViewStatus,
 } from '@casedata/services/casedata-message-service';
+import { CasedataMessageType, isCasedataWebMessageType } from '@casedata/services/casedata-message-types';
 import { Button, Divider, FormLabel, Select, useSnackbar } from '@sk-web-gui/react';
 import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
 import { Mail } from 'lucide-react';
-import { FC, useMemo, useState } from 'react';
+import { FC, useCallback, useMemo, useState } from 'react';
 import { MessageResponse } from 'src/data-contracts/backend/data-contracts';
 
 import { MessageComposer } from './message-composer.component';
@@ -87,24 +88,27 @@ export const CasedataMessagesTab: FC<{
     }
   };
 
-  const filterBySource = (message: MessageResponse) => {
-    switch (filterSource) {
-      case 1:
-        return message.messageType === 'DRAKEN';
-      case 2:
-        return message.messageType === 'DIGITAL_MAIL';
-      case 3:
-        return message.messageType === 'EMAIL';
-      case 4:
-        return message.messageType === 'MINASIDOR';
-      case 5:
-        return message.messageType === 'SMS';
-      case 6:
-        return message.messageType === 'WEBMESSAGE' || !!message.externalCaseId;
-      default:
-        return true;
-    }
-  };
+  const filterBySource = useCallback(
+    (message: MessageResponse) => {
+      switch (filterSource) {
+        case 1:
+          return message.messageType === CasedataMessageType.Draken;
+        case 2:
+          return message.messageType === CasedataMessageType.DigitalMail;
+        case 3:
+          return message.messageType === CasedataMessageType.Email;
+        case 4:
+          return message.messageType === CasedataMessageType.MinaSidor;
+        case 5:
+          return message.messageType === CasedataMessageType.Sms;
+        case 6:
+          return isCasedataWebMessageType(message.messageType) || !!message.externalCaseId;
+        default:
+          return true;
+      }
+    },
+    [filterSource]
+  );
 
   const sortedMessages = useMemo(() => {
     if (!combinedMessages || !combinedMessageTree) return [];
@@ -125,7 +129,7 @@ export const CasedataMessagesTab: FC<{
       }
       return combinedMessageTree;
     }
-  }, [combinedMessages, combinedMessageTree, sortMessages, filterSource]);
+  }, [combinedMessages, combinedMessageTree, sortMessages, filterSource, filterBySource]);
 
   return (
     <>

--- a/frontend/src/casedata/components/errand/tabs/messages/message-composer.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/messages/message-composer.component.tsx
@@ -371,7 +371,15 @@ export const MessageComposer: FC<{
     }
   };
 
-  const { contactMeans, addExisting, existingAttachments, newAttachments, messageBody, messageBodyPlaintext } = watch();
+  const {
+    contactMeans,
+    addExisting,
+    existingAttachments,
+    newAttachments,
+    messageBody,
+    messageBodyPlaintext,
+    messageTemplate,
+  } = watch();
 
   useEffect(() => {
     if (errand && props.show) {
@@ -601,6 +609,7 @@ export const MessageComposer: FC<{
                 {...register('messageTemplate')}
                 className="w-full text-dark-primary"
                 size="sm"
+                value={messageTemplate ?? ''}
                 onChange={(e) => {
                   const newId = e.currentTarget.value;
                   if (bodyEdited) {

--- a/frontend/src/casedata/components/errand/tabs/messages/message-composer.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/messages/message-composer.component.tsx
@@ -48,7 +48,7 @@ import {
 import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
 import { EMAIL_INFORMATION_TEXT } from '@supportmanagement/services/message-template-service';
 import { File, Paperclip, X } from 'lucide-react';
-import { FC, useEffect, useMemo, useState } from 'react';
+import { FC, useEffect, useMemo, useRef, useState } from 'react';
 import { Resolver, useFieldArray, useForm } from 'react-hook-form';
 import * as yup from 'yup';
 
@@ -172,6 +172,8 @@ export const MessageComposer: FC<{
   const [typeOfMessage, setTypeOfMessage] = useState<string>('newMessage');
   const [selectedRelationId, setSelectedRelationId] = useState<string>('');
   const [relationErrands, setRelationErrands] = useState<RelationWithErrandNumber[]>([]);
+  const [bodyEdited, setBodyEdited] = useState(false);
+  const lastAppliedTemplateRef = useRef<string>('');
 
   const closeConfirm = useConfirm();
   const toastMessage = useSnackbar();
@@ -374,13 +376,13 @@ export const MessageComposer: FC<{
     if (contactMeans === 'sms' && errand) {
       setValue('newPhoneNumber', getOwnerStakeholder(errand)?.phoneNumbers?.[0]?.value || '');
     }
-    setValue('messageTemplate', '');
-    setValue('messageBody', defaultSignature());
+    const defaultId = !props.message ? getDefaultTemplateId(contactMeans) : '';
+    applyTemplate(defaultId);
     setTimeout(() => {
       props.setUnsaved(false);
     }, 0);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [contactMeans]);
+  }, [contactMeans, templates]);
 
   const defaultSignature = () => {
     if (!templates) return '';
@@ -398,9 +400,14 @@ export const MessageComposer: FC<{
     }
   };
 
+  const getDefaultTemplateId = (means: string): string => {
+    if (!templates) return '';
+    const list = means === 'sms' ? templates.smsTemplates : templates.emailTemplates;
+    return list?.find((t) => t.identifier?.endsWith('.default'))?.identifier || '';
+  };
+
   useEffect(() => {
     setReplying(!!props.message?.messageId);
-    setValue('messageTemplate', '');
     if (props.message) {
       const replyTo = props.message?.emailHeaders?.find((h) => h.header === 'MESSAGE_ID')?.values[0];
       const references = props.message?.emailHeaders?.find((h) => h.header === 'REFERENCES')?.values || [];
@@ -437,9 +444,13 @@ export const MessageComposer: FC<{
             ? sanitizeHtmlMessageBody(props.message.htmlMessage)
             : formatMessage(sanitized(props.message.message ?? '')))
       );
+      setValue('messageTemplate', '');
+      lastAppliedTemplateRef.current = '';
+      setBodyEdited(true);
       trigger();
     } else {
-      setValue('messageBody', defaultSignature());
+      const defaultId = getDefaultTemplateId(contactMeans);
+      applyTemplate(defaultId);
       setValue('headerReplyTo', '');
       setValue('headerReferences', '');
       setValue('contactMeans', 'email');
@@ -466,6 +477,13 @@ export const MessageComposer: FC<{
       const footer = needsFooter ? templates.byId[footerId] || '' : '';
       setValue('messageBody', content + templates.emailSignature + footer);
     }
+  };
+
+  const applyTemplate = (id: string) => {
+    setValue('messageTemplate', id);
+    changeTemplate(id);
+    lastAppliedTemplateRef.current = id;
+    setBodyEdited(false);
   };
 
   return (
@@ -605,11 +623,30 @@ export const MessageComposer: FC<{
               className="w-full text-dark-primary"
               size="sm"
               onChange={(e) => {
-                changeTemplate(e.currentTarget.value);
+                const newId = e.currentTarget.value;
+                if (bodyEdited) {
+                  closeConfirm
+                    .showConfirmation(
+                      'Skriv över texten?',
+                      'Att byta mall ersätter den text du har skrivit. Vill du fortsätta?',
+                      'Ja, skriv över',
+                      'Avbryt',
+                      'info',
+                      'info'
+                    )
+                    .then((confirmed) => {
+                      if (confirmed) {
+                        applyTemplate(newId);
+                      } else {
+                        setValue('messageTemplate', lastAppliedTemplateRef.current);
+                      }
+                    });
+                } else {
+                  applyTemplate(newId);
+                }
               }}
               data-cy="messageTemplate"
             >
-              <Select.Option value="">Välj mall</Select.Option>
               {(contactMeans === 'sms' ? templates?.smsTemplates : templates?.emailTemplates)?.map((t) => (
                 <Select.Option key={t.identifier} value={t.identifier}>
                   {t.name}
@@ -632,6 +669,7 @@ export const MessageComposer: FC<{
                     });
                     setValue('messageBodyPlaintext', e.target.value.plainText ?? '', { shouldDirty: true });
                     trigger('messageBody');
+                    setBodyEdited(true);
                   }}
                   value={{ markup: messageBody, plainText: messageBodyPlaintext }}
                 />

--- a/frontend/src/casedata/components/errand/tabs/messages/message-composer.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/messages/message-composer.component.tsx
@@ -173,12 +173,21 @@ export const MessageComposer: FC<{
   const [selectedRelationId, setSelectedRelationId] = useState<string>('');
   const [relationErrands, setRelationErrands] = useState<RelationWithErrandNumber[]>([]);
   const [bodyEdited, setBodyEdited] = useState(false);
+  const bodyEditedRef = useRef(false);
   const lastAppliedTemplateRef = useRef<string>('');
+  const replyHistoryRef = useRef<string>('');
+  const lastNewMessageSetupKeyRef = useRef<string>('');
+  const lastReplySetupKeyRef = useRef<string>('');
 
   const closeConfirm = useConfirm();
   const toastMessage = useSnackbar();
 
   const { templates } = useMessageTemplates(user, props.show);
+
+  const setBodyEditedState = (edited: boolean) => {
+    bodyEditedRef.current = edited;
+    setBodyEdited(edited);
+  };
 
   const allowed = useMemo(() => {
     if (!errand) return false;
@@ -372,47 +381,82 @@ export const MessageComposer: FC<{
     }
   }, [relationErrands, contactMeans, selectedRelationId]);
 
-  useEffect(() => {
-    if (contactMeans === 'sms' && errand) {
-      setValue('newPhoneNumber', getOwnerStakeholder(errand)?.phoneNumbers?.[0]?.value || '');
-    }
-    // Skip template/body management while replying — the [props.message, errand] effect
-    // owns the reply body (signature + quoted history) and must not be overwritten when
-    // templates load asynchronously.
-    if (!props.message) {
-      applyTemplate(getDefaultTemplateId(contactMeans));
-    }
-    setTimeout(() => {
-      props.setUnsaved(false);
-    }, 0);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [contactMeans, templates]);
-
-  const defaultSignature = () => {
+  const defaultSignature = (means: string = contactMeans): string => {
     if (!templates) return '';
-    switch (contactMeans) {
+    switch (means) {
       case 'draken':
         return templates.internalSignature;
       case 'sms':
         return templates.smsTemplate;
       default:
-        // For non-email contact means, remove email_information from signature
-        if (contactMeans !== 'email') {
-          return templates.emailSignature.replace(EMAIL_INFORMATION_TEXT, '');
-        }
-        return templates.emailSignature;
+        return means !== 'email'
+          ? templates.emailSignature.replace(EMAIL_INFORMATION_TEXT, '')
+          : templates.emailSignature;
     }
   };
 
   const getDefaultTemplateId = (means: string): string => {
     if (!templates) return '';
-    const list = means === 'sms' ? templates.smsTemplates : templates.emailTemplates;
+    const list = means === 'sms' ? templates.smsTemplates : means === 'email' ? templates.emailTemplates : [];
     return list?.find((t) => t.identifier?.endsWith('.default'))?.identifier || '';
   };
 
+  const buildTemplateBody = (id: string, means: string, history: string): string => {
+    if (!templates) return history;
+    if (!id) return defaultSignature(means) + history;
+
+    const content = templates.byId[id] || '';
+    if (means === 'sms') {
+      return content + templates.smsSignature + history;
+    }
+    const footerId = `${templates.app}.email.publicdocuments`;
+    const needsFooter = id.endsWith('.priority') || id.endsWith('.default');
+    const footer = needsFooter ? templates.byId[footerId] || '' : '';
+    return content + templates.emailSignature + footer + history;
+  };
+
+  const applyTemplate = (id: string, means: string = contactMeans, history: string = replyHistoryRef.current) => {
+    setValue('messageTemplate', id);
+    setValue('messageBody', buildTemplateBody(id, means, history));
+    lastAppliedTemplateRef.current = id;
+    setBodyEditedState(false);
+  };
+
+  // Effect 1: user-initiated channel changes for new messages (also fires on templates load).
+  // Skips body work when replying — Effect 2 owns the reply body.
+  useEffect(() => {
+    const setupKey = `new:${contactMeans}`;
+    if (contactMeans === 'sms' && errand) {
+      setValue('newPhoneNumber', getOwnerStakeholder(errand)?.phoneNumbers?.[0]?.value || '');
+    }
+    setTimeout(() => {
+      props.setUnsaved(false);
+    }, 0);
+    if (props.message) return;
+    if (bodyEditedRef.current && lastNewMessageSetupKeyRef.current === setupKey) return;
+    applyTemplate(getDefaultTemplateId(contactMeans), contactMeans, '');
+    lastNewMessageSetupKeyRef.current = setupKey;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [contactMeans, templates]);
+
+  // Effect 2: message state — reply setup or new-message cleanup.
+  // Uses messageMeans locally to avoid stale `contactMeans` from `watch()` after setValue.
   useEffect(() => {
     setReplying(!!props.message?.messageId);
     if (props.message) {
+      const messageMeans: CasedataMessageTabFormModel['contactMeans'] =
+        props.message.messageType === 'WEBMESSAGE'
+          ? 'webmessage'
+          : props.message.messageType === 'DRAKEN'
+          ? 'draken'
+          : props.message.messageType === 'MINASIDOR'
+          ? 'minasidor'
+          : 'email';
+      const setupKey = `reply:${props.message.messageId || ''}:${messageMeans}:${errand?.id || ''}`;
+      if (messageMeans !== contactMeans) {
+        setValue('contactMeans', messageMeans);
+      }
+
       const replyTo = props.message?.emailHeaders?.find((h) => h.header === 'MESSAGE_ID')?.values[0];
       const references = props.message?.emailHeaders?.find((h) => h.header === 'REFERENCES')?.values || [];
       references.push(replyTo);
@@ -421,74 +465,37 @@ export const MessageComposer: FC<{
       setValue(
         'emails',
         props.message.direction === 'OUTBOUND'
-          ? props.message?.recipients?.map((email) => ({
-              value: email,
-            })) ?? []
+          ? props.message?.recipients?.map((email) => ({ value: email })) ?? []
           : [{ value: props.message.email ?? '' }]
       );
-      setValue(
-        'contactMeans',
-        props.message.messageType === 'WEBMESSAGE'
-          ? 'webmessage'
-          : props.message.messageType === 'DRAKEN'
-          ? 'draken'
-          : props.message.messageType === 'MINASIDOR'
-          ? 'minasidor'
-          : 'email'
-      );
+
       const historyHeader = `<br><br>-----Ursprungligt meddelande-----<br>Från: ${
         !!props.message?.conversationId ? props.message?.firstName + ' ' + props.message?.lastName : props.message.email
       }<br>Skickat: ${props.message.sent}<br>Till: Sundsvalls kommun<br>Ämne: ${props.message.subject}<br><br>`;
+      const historyBlock =
+        historyHeader +
+        (props.message.htmlMessage
+          ? sanitizeHtmlMessageBody(props.message.htmlMessage)
+          : formatMessage(sanitized(props.message.message ?? '')));
 
-      setValue(
-        'messageBody',
-        defaultSignature() +
-          historyHeader +
-          (props.message.htmlMessage
-            ? sanitizeHtmlMessageBody(props.message.htmlMessage)
-            : formatMessage(sanitized(props.message.message ?? '')))
-      );
-      setValue('messageTemplate', '');
-      lastAppliedTemplateRef.current = '';
-      setBodyEdited(true);
+      replyHistoryRef.current = historyBlock;
+      if (!(bodyEditedRef.current && lastReplySetupKeyRef.current === setupKey)) {
+        applyTemplate(getDefaultTemplateId(messageMeans), messageMeans, historyBlock);
+      }
+      lastReplySetupKeyRef.current = setupKey;
       trigger();
     } else {
-      const defaultId = getDefaultTemplateId(contactMeans);
-      applyTemplate(defaultId);
+      const defaultMeans = 'email';
+      replyHistoryRef.current = '';
+      lastReplySetupKeyRef.current = '';
       setValue('headerReplyTo', '');
       setValue('headerReferences', '');
-      setValue('contactMeans', 'email');
+      setValue('contactMeans', defaultMeans);
+      applyTemplate(getDefaultTemplateId(defaultMeans), defaultMeans, '');
+      lastNewMessageSetupKeyRef.current = `new:${defaultMeans}`;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.message, errand]);
-
-  const changeTemplate = (templateId: string) => {
-    if (!templates) return;
-
-    if (!templateId) {
-      setValue('messageBody', defaultSignature());
-      return;
-    }
-
-    const content = templates.byId[templateId] || '';
-
-    if (contactMeans === 'sms') {
-      // For SMS: use only the signature, not the full smsTemplate (which includes default content)
-      setValue('messageBody', content + templates.smsSignature);
-    } else {
-      const footerId = `${templates.app}.email.publicdocuments`;
-      const needsFooter = templateId.endsWith('.priority') || templateId.endsWith('.default');
-      const footer = needsFooter ? templates.byId[footerId] || '' : '';
-      setValue('messageBody', content + templates.emailSignature + footer);
-    }
-  };
-
-  const applyTemplate = (id: string) => {
-    setValue('messageTemplate', id);
-    changeTemplate(id);
-    lastAppliedTemplateRef.current = id;
-    setBodyEdited(false);
-  };
+  }, [props.message, errand, templates]);
 
   return (
     <>
@@ -673,7 +680,7 @@ export const MessageComposer: FC<{
                     });
                     setValue('messageBodyPlaintext', e.target.value.plainText ?? '', { shouldDirty: true });
                     trigger('messageBody');
-                    setBodyEdited(true);
+                    setBodyEditedState(true);
                   }}
                   value={{ markup: messageBody, plainText: messageBodyPlaintext }}
                 />

--- a/frontend/src/casedata/components/errand/tabs/messages/message-composer.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/messages/message-composer.component.tsx
@@ -8,6 +8,7 @@ import { Role } from '@casedata/interfaces/role';
 import { ACCEPTED_UPLOAD_FILETYPES, getAttachmentLabel } from '@casedata/services/casedata-attachment-service';
 import { getOrCreateConversationId, sendConversationMessage } from '@casedata/services/casedata-conversation-service';
 import { isErrandLocked, setErrandStatus, validateAction } from '@casedata/services/casedata-errand-service';
+import { buildCasedataReplyContext } from '@casedata/services/casedata-message-reply-context-service';
 import {
   MessageNode,
   renderMessageWithTemplates,
@@ -20,14 +21,22 @@ import CommonNestedPhoneArrayV2 from '@common/components/commonNestedPhoneArrayV
 import TextEditor from '@common/components/dynamic-text-editor';
 import FileUpload from '@common/components/file-upload/file-upload.component';
 import { MessageWrapper } from '@common/components/message/message-wrapper.component';
+import { useMessageBodyTemplateState } from '@common/hooks/use-message-body-template-state';
 import { isMEX } from '@common/services/application-service';
 import {
   invalidPhoneMessage,
   phonePattern,
   supportManagementPhonePatternOrCountryCode,
 } from '@common/services/helper-service';
+import {
+  buildMessageTemplateBody,
+  getDefaultMessageBody,
+  getDefaultTemplateId,
+  getTemplateOptions,
+  MessageContactMeans,
+  supportsSelectableTemplates,
+} from '@common/services/message-template-body-service';
 import { getAllRelatedErrands, RelationWithErrandNumber } from '@common/services/relations-service';
-import sanitized, { formatMessage, sanitizeHtmlMessageBody } from '@common/services/sanitizer-service';
 import { getToastOptions } from '@common/utils/toast-message-settings';
 import { appConfig } from '@config/appconfig';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -46,14 +55,13 @@ import {
   useSnackbar,
 } from '@sk-web-gui/react';
 import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
-import { EMAIL_INFORMATION_TEXT } from '@supportmanagement/services/message-template-service';
 import { File, Paperclip, X } from 'lucide-react';
-import { FC, useEffect, useMemo, useRef, useState } from 'react';
+import { FC, useEffect, useMemo, useState } from 'react';
 import { Resolver, useFieldArray, useForm } from 'react-hook-form';
 import * as yup from 'yup';
 
 export interface CasedataMessageTabFormModel {
-  contactMeans: 'email' | 'sms' | 'webmessage' | 'digitalmail' | 'paper' | 'draken' | 'minasidor' | 'katla';
+  contactMeans: MessageContactMeans;
   messageClassification: string;
   messageTemplate?: string;
   emails: { value: string }[];
@@ -172,22 +180,19 @@ export const MessageComposer: FC<{
   const [typeOfMessage, setTypeOfMessage] = useState<string>('newMessage');
   const [selectedRelationId, setSelectedRelationId] = useState<string>('');
   const [relationErrands, setRelationErrands] = useState<RelationWithErrandNumber[]>([]);
-  const [bodyEdited, setBodyEdited] = useState(false);
-  const bodyEditedRef = useRef(false);
-  const lastAppliedTemplateRef = useRef<string>('');
-  const replyHistoryRef = useRef<string>('');
-  const lastNewMessageSetupKeyRef = useRef<string>('');
-  const lastReplySetupKeyRef = useRef<string>('');
+  const {
+    bodyEdited,
+    lastAppliedTemplateRef,
+    replyHistoryRef,
+    setBodyEditedState,
+    shouldSkipAutoApply,
+    markAutoApplied,
+  } = useMessageBodyTemplateState();
 
   const closeConfirm = useConfirm();
   const toastMessage = useSnackbar();
 
   const { templates } = useMessageTemplates(user, props.show);
-
-  const setBodyEditedState = (edited: boolean) => {
-    bodyEditedRef.current = edited;
-    setBodyEdited(edited);
-  };
 
   const allowed = useMemo(() => {
     if (!errand) return false;
@@ -243,11 +248,11 @@ export const MessageComposer: FC<{
 
   const clearAndClose = () => {
     setTimeout(() => {
-      setValue('messageBody', defaultSignature(), { shouldDirty: false });
-      setValue('messageBodyPlaintext', defaultSignature(), { shouldDirty: false });
+      const defaultBody = getDefaultMessageBody(templates, contactMeans);
+      setValue('messageBody', defaultBody, { shouldDirty: false });
+      setValue('messageBodyPlaintext', defaultBody, { shouldDirty: false });
       setValue('emails', [], { shouldDirty: false });
       removeNewAttachment();
-      setValue('messageBody', defaultSignature());
       remove();
       props.closeHandler();
     }, 0);
@@ -381,44 +386,25 @@ export const MessageComposer: FC<{
     }
   }, [relationErrands, contactMeans, selectedRelationId]);
 
-  const defaultSignature = (means: string = contactMeans): string => {
-    if (!templates) return '';
-    switch (means) {
-      case 'draken':
-        return templates.internalSignature;
-      case 'sms':
-        return templates.smsTemplate;
-      default:
-        return means !== 'email'
-          ? templates.emailSignature.replace(EMAIL_INFORMATION_TEXT, '')
-          : templates.emailSignature;
-    }
-  };
-
-  const getDefaultTemplateId = (means: string): string => {
-    if (!templates) return '';
-    const list = means === 'sms' ? templates.smsTemplates : means === 'email' ? templates.emailTemplates : [];
-    return list?.find((t) => t.identifier?.endsWith('.default'))?.identifier || '';
-  };
-
-  const buildTemplateBody = (id: string, means: string, history: string): string => {
-    if (!templates) return history;
-    if (!id) return defaultSignature(means) + history;
-
-    const content = templates.byId[id] || '';
-    if (means === 'sms') {
-      return content + templates.smsSignature + history;
-    }
-    const footerId = `${templates.app}.email.publicdocuments`;
-    const needsFooter = id.endsWith('.priority') || id.endsWith('.default');
-    const footer = needsFooter ? templates.byId[footerId] || '' : '';
-    return content + templates.emailSignature + footer + history;
-  };
-
-  const applyTemplate = (id: string, means: string = contactMeans, history: string = replyHistoryRef.current) => {
+  const applyTemplate = (
+    id: string,
+    means: MessageContactMeans = contactMeans,
+    history: string = replyHistoryRef.current,
+    options: { skipBody?: boolean } = {}
+  ) => {
     setValue('messageTemplate', id);
-    setValue('messageBody', buildTemplateBody(id, means, history));
     lastAppliedTemplateRef.current = id;
+    if (options.skipBody) return;
+    setValue(
+      'messageBody',
+      buildMessageTemplateBody({
+        templates,
+        templateId: id,
+        means,
+        history,
+        includePublicDocumentsFooter: true,
+      })
+    );
     setBodyEditedState(false);
   };
 
@@ -433,9 +419,10 @@ export const MessageComposer: FC<{
       props.setUnsaved(false);
     }, 0);
     if (props.message) return;
-    if (bodyEditedRef.current && lastNewMessageSetupKeyRef.current === setupKey) return;
-    applyTemplate(getDefaultTemplateId(contactMeans), contactMeans, '');
-    lastNewMessageSetupKeyRef.current = setupKey;
+    applyTemplate(getDefaultTemplateId(templates, contactMeans), contactMeans, '', {
+      skipBody: shouldSkipAutoApply(setupKey),
+    });
+    markAutoApplied(setupKey);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [contactMeans, templates]);
 
@@ -444,55 +431,35 @@ export const MessageComposer: FC<{
   useEffect(() => {
     setReplying(!!props.message?.messageId);
     if (props.message) {
-      const messageMeans: CasedataMessageTabFormModel['contactMeans'] =
-        props.message.messageType === 'WEBMESSAGE'
-          ? 'webmessage'
-          : props.message.messageType === 'DRAKEN'
-          ? 'draken'
-          : props.message.messageType === 'MINASIDOR'
-          ? 'minasidor'
-          : 'email';
-      const setupKey = `reply:${props.message.messageId || ''}:${messageMeans}:${errand?.id || ''}`;
-      if (messageMeans !== contactMeans) {
-        setValue('contactMeans', messageMeans);
+      const replyContext = buildCasedataReplyContext(props.message, errand?.id);
+      if (replyContext.contactMeans !== contactMeans) {
+        setValue('contactMeans', replyContext.contactMeans);
       }
 
-      const replyTo = props.message?.emailHeaders?.find((h) => h.header === 'MESSAGE_ID')?.values[0];
-      const references = props.message?.emailHeaders?.find((h) => h.header === 'REFERENCES')?.values || [];
-      references.push(replyTo);
-      setValue('headerReplyTo', replyTo ?? '');
-      setValue('headerReferences', references.join(','));
-      setValue(
-        'emails',
-        props.message.direction === 'OUTBOUND'
-          ? props.message?.recipients?.map((email) => ({ value: email })) ?? []
-          : [{ value: props.message.email ?? '' }]
+      setValue('headerReplyTo', replyContext.headerReplyTo);
+      setValue('headerReferences', replyContext.headerReferences);
+      setValue('emails', replyContext.recipients);
+
+      replyHistoryRef.current = replyContext.historyHtml;
+      // Always sync the dropdown to the default template id; only skip body when the user
+      // has typed into the editor for this same reply (templates loading late should not
+      // wipe their text but should still show the right selection).
+      applyTemplate(
+        getDefaultTemplateId(templates, replyContext.contactMeans),
+        replyContext.contactMeans,
+        replyContext.historyHtml,
+        { skipBody: shouldSkipAutoApply(replyContext.setupKey) }
       );
-
-      const historyHeader = `<br><br>-----Ursprungligt meddelande-----<br>Från: ${
-        !!props.message?.conversationId ? props.message?.firstName + ' ' + props.message?.lastName : props.message.email
-      }<br>Skickat: ${props.message.sent}<br>Till: Sundsvalls kommun<br>Ämne: ${props.message.subject}<br><br>`;
-      const historyBlock =
-        historyHeader +
-        (props.message.htmlMessage
-          ? sanitizeHtmlMessageBody(props.message.htmlMessage)
-          : formatMessage(sanitized(props.message.message ?? '')));
-
-      replyHistoryRef.current = historyBlock;
-      if (!(bodyEditedRef.current && lastReplySetupKeyRef.current === setupKey)) {
-        applyTemplate(getDefaultTemplateId(messageMeans), messageMeans, historyBlock);
-      }
-      lastReplySetupKeyRef.current = setupKey;
+      markAutoApplied(replyContext.setupKey);
       trigger();
     } else {
       const defaultMeans = 'email';
       replyHistoryRef.current = '';
-      lastReplySetupKeyRef.current = '';
       setValue('headerReplyTo', '');
       setValue('headerReferences', '');
       setValue('contactMeans', defaultMeans);
-      applyTemplate(getDefaultTemplateId(defaultMeans), defaultMeans, '');
-      lastNewMessageSetupKeyRef.current = `new:${defaultMeans}`;
+      applyTemplate(getDefaultTemplateId(templates, defaultMeans), defaultMeans, '');
+      markAutoApplied(`new:${defaultMeans}`);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.message, errand, templates]);
@@ -626,45 +593,47 @@ export const MessageComposer: FC<{
             </RadioButton.Group>
           </div>
 
-          <FormControl className="w-full my-12" size="sm" id="messageTemplate">
-            <FormLabel>Välj meddelandemall</FormLabel>
-            <Select
-              tabIndex={props.show ? 0 : -1}
-              {...register('messageTemplate')}
-              className="w-full text-dark-primary"
-              size="sm"
-              onChange={(e) => {
-                const newId = e.currentTarget.value;
-                if (bodyEdited) {
-                  closeConfirm
-                    .showConfirmation(
-                      'Skriv över texten?',
-                      'Att byta mall ersätter den text du har skrivit. Vill du fortsätta?',
-                      'Ja, skriv över',
-                      'Avbryt',
-                      'info',
-                      'info'
-                    )
-                    .then((confirmed) => {
-                      if (confirmed) {
-                        applyTemplate(newId);
-                      } else {
-                        setValue('messageTemplate', lastAppliedTemplateRef.current);
-                      }
-                    });
-                } else {
-                  applyTemplate(newId);
-                }
-              }}
-              data-cy="messageTemplate"
-            >
-              {(contactMeans === 'sms' ? templates?.smsTemplates : templates?.emailTemplates)?.map((t) => (
-                <Select.Option key={t.identifier} value={t.identifier}>
-                  {t.name}
-                </Select.Option>
-              ))}
-            </Select>
-          </FormControl>
+          {templates && supportsSelectableTemplates(contactMeans) && (
+            <FormControl className="w-full my-12" size="sm" id="messageTemplate">
+              <FormLabel>Välj meddelandemall</FormLabel>
+              <Select
+                tabIndex={props.show ? 0 : -1}
+                {...register('messageTemplate')}
+                className="w-full text-dark-primary"
+                size="sm"
+                onChange={(e) => {
+                  const newId = e.currentTarget.value;
+                  if (bodyEdited) {
+                    closeConfirm
+                      .showConfirmation(
+                        'Skriv över texten?',
+                        'Att byta mall ersätter den text du har skrivit. Vill du fortsätta?',
+                        'Ja, skriv över',
+                        'Avbryt',
+                        'info',
+                        'info'
+                      )
+                      .then((confirmed) => {
+                        if (confirmed) {
+                          applyTemplate(newId);
+                        } else {
+                          setValue('messageTemplate', lastAppliedTemplateRef.current);
+                        }
+                      });
+                  } else {
+                    applyTemplate(newId);
+                  }
+                }}
+                data-cy="messageTemplate"
+              >
+                {getTemplateOptions(templates, contactMeans).map((t) => (
+                  <Select.Option key={t.identifier} value={t.identifier}>
+                    {t.name}
+                  </Select.Option>
+                ))}
+              </Select>
+            </FormControl>
+          )}
 
           {props.show ? (
             <FormControl id="message-body" className="w-full">

--- a/frontend/src/casedata/components/errand/tabs/messages/message-composer.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/messages/message-composer.component.tsx
@@ -658,7 +658,13 @@ export const MessageComposer: FC<{
                     });
                     setValue('messageBodyPlaintext', e.target.value.plainText ?? '', { shouldDirty: true });
                     trigger('messageBody');
-                    setBodyEditedState(true);
+                  }}
+                  onTextChange={(_delta, _oldDelta, source) => {
+                    // Only treat user input as an edit; ignore programmatic / silent updates
+                    // so setValue() on body does not flag the form as dirty and skip auto-apply.
+                    if (source === 'user') {
+                      setBodyEditedState(true);
+                    }
                   }}
                   value={{ markup: messageBody, plainText: messageBodyPlaintext }}
                 />

--- a/frontend/src/casedata/components/errand/tabs/messages/message-composer.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/messages/message-composer.component.tsx
@@ -376,8 +376,12 @@ export const MessageComposer: FC<{
     if (contactMeans === 'sms' && errand) {
       setValue('newPhoneNumber', getOwnerStakeholder(errand)?.phoneNumbers?.[0]?.value || '');
     }
-    const defaultId = !props.message ? getDefaultTemplateId(contactMeans) : '';
-    applyTemplate(defaultId);
+    // Skip template/body management while replying — the [props.message, errand] effect
+    // owns the reply body (signature + quoted history) and must not be overwritten when
+    // templates load asynchronously.
+    if (!props.message) {
+      applyTemplate(getDefaultTemplateId(contactMeans));
+    }
     setTimeout(() => {
       props.setUnsaved(false);
     }, 0);

--- a/frontend/src/casedata/components/errand/tabs/messages/render-message-reciever.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/messages/render-message-reciever.component.tsx
@@ -1,6 +1,7 @@
 import { Channels } from '@casedata/interfaces/channels';
 import { IErrand } from '@casedata/interfaces/errand';
 import { MessageNode } from '@casedata/services/casedata-message-service';
+import { CasedataMessageType, isCasedataWebMessageType } from '@casedata/services/casedata-message-types';
 import { getOwnerStakeholder } from '@casedata/services/casedata-stakeholder-service';
 import sanitized from '@common/services/sanitizer-service';
 import { Button } from '@sk-web-gui/button';
@@ -10,28 +11,28 @@ const MAX_VISIBLE_RECIPIENTS = 2;
 const getMessageSourceLabel = (message: MessageNode, errand: IErrand | undefined): string | string[] => {
   if (!message) return '';
 
-  if (message.messageType === 'EMAIL') {
+  if (message.messageType === CasedataMessageType.Email) {
     return message.recipients ?? [];
   }
 
-  if (message.messageType === 'SMS') {
+  if (message.messageType === CasedataMessageType.Sms) {
     return message.mobileNumber ?? '';
   }
 
-  if (message.messageType === 'WEBMESSAGE' || message.externalCaseId) {
+  if (isCasedataWebMessageType(message.messageType) || message.externalCaseId) {
     return 'E-tjänst';
   }
 
-  if (message.messageType === 'MINASIDOR' && message.direction === 'OUTBOUND' && errand) {
+  if (message.messageType === CasedataMessageType.MinaSidor && message.direction === 'OUTBOUND' && errand) {
     const owner = getOwnerStakeholder(errand);
     return (owner?.firstName ?? '') + ' ' + (owner?.lastName ?? '');
   }
 
-  if (message.messageType === 'MINASIDOR' && message.direction === 'INBOUND') {
+  if (message.messageType === CasedataMessageType.MinaSidor && message.direction === 'INBOUND') {
     return errand?.channel === Channels.ESERVICE_KATLA ? 'Färdtjänst' : 'Draken';
   }
 
-  if (message.messageType === 'DRAKEN') {
+  if (message.messageType === CasedataMessageType.Draken) {
     return errand?.channel === Channels.ESERVICE_KATLA ? 'Färdtjänst' : 'Draken';
   }
 

--- a/frontend/src/casedata/components/errand/tabs/messages/render-message-reciever.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/messages/render-message-reciever.component.tsx
@@ -3,10 +3,19 @@ import { IErrand } from '@casedata/interfaces/errand';
 import { MessageNode } from '@casedata/services/casedata-message-service';
 import { CasedataMessageType, isCasedataWebMessageType } from '@casedata/services/casedata-message-types';
 import { getOwnerStakeholder } from '@casedata/services/casedata-stakeholder-service';
+import { MessageResponseDirectionEnum } from '@common/data-contracts/case-data/data-contracts';
 import sanitized from '@common/services/sanitizer-service';
 import { Button } from '@sk-web-gui/button';
 import { FC, useState } from 'react';
 const MAX_VISIBLE_RECIPIENTS = 2;
+
+const getDrakenSourceLabel = (errand: IErrand | undefined): string =>
+  errand?.channel === Channels.ESERVICE_KATLA ? 'Färdtjänst' : 'Draken';
+
+const getOwnerSourceLabel = (errand: IErrand): string => {
+  const owner = getOwnerStakeholder(errand);
+  return (owner?.firstName ?? '') + ' ' + (owner?.lastName ?? '');
+};
 
 const getMessageSourceLabel = (message: MessageNode, errand: IErrand | undefined): string | string[] => {
   if (!message) return '';
@@ -23,18 +32,13 @@ const getMessageSourceLabel = (message: MessageNode, errand: IErrand | undefined
     return 'E-tjänst';
   }
 
-  if (message.messageType === CasedataMessageType.MinaSidor && message.direction === 'OUTBOUND' && errand) {
-    const owner = getOwnerStakeholder(errand);
-    return (owner?.firstName ?? '') + ' ' + (owner?.lastName ?? '');
+  if (message.messageType === CasedataMessageType.MinaSidor) {
+    return message.direction === MessageResponseDirectionEnum.OUTBOUND && errand
+      ? getOwnerSourceLabel(errand)
+      : getDrakenSourceLabel(errand);
   }
 
-  if (message.messageType === CasedataMessageType.MinaSidor && message.direction === 'INBOUND') {
-    return errand?.channel === Channels.ESERVICE_KATLA ? 'Färdtjänst' : 'Draken';
-  }
-
-  if (message.messageType === CasedataMessageType.Draken) {
-    return errand?.channel === Channels.ESERVICE_KATLA ? 'Färdtjänst' : 'Draken';
-  }
+  if (message.messageType === CasedataMessageType.Draken) return getDrakenSourceLabel(errand);
 
   return '(okänd mottagare)';
 };

--- a/frontend/src/casedata/components/errand/tabs/messages/rendered-message.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/messages/rendered-message.component.tsx
@@ -4,16 +4,59 @@ import { messageAttachment } from '@casedata/services/casedata-attachment-servic
 import { getConversationAttachment } from '@casedata/services/casedata-conversation-service';
 import { isErrandLocked, validateAction } from '@casedata/services/casedata-errand-service';
 import { MessageNode } from '@casedata/services/casedata-message-service';
+import {
+  CasedataMessageType,
+  isCasedataReplyableMessageType,
+  isCasedataWebMessageType,
+} from '@casedata/services/casedata-message-types';
 import { MessageAvatar } from '@common/components/message/message-avatar.component';
 import { MessageResponseDirectionEnum } from '@common/data-contracts/case-data/data-contracts';
 import sanitized, { formatMessage } from '@common/services/sanitizer-service';
 import { Button, cx, Icon, useSnackbar } from '@sk-web-gui/react';
 import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
 import dayjs from 'dayjs';
-import { CornerDownRight, Image, Mail, Monitor, Paperclip, Smartphone, SquareMinus, SquarePlus } from 'lucide-react';
+import {
+  CornerDownRight,
+  Image,
+  type LucideIcon,
+  Mail,
+  Monitor,
+  Paperclip,
+  Smartphone,
+  SquareMinus,
+  SquarePlus,
+} from 'lucide-react';
 import { Dispatch, FC, SetStateAction, useEffect, useState } from 'react';
 
 import { EmailRecipients, RenderMessageReciever } from './render-message-reciever.component';
+
+type ChannelPresentation = {
+  Icon: LucideIcon;
+  label: string | ((isKatla: boolean) => string);
+};
+
+const messageChannelPresentation: Partial<Record<CasedataMessageType, ChannelPresentation>> = {
+  [CasedataMessageType.Sms]: { Icon: Smartphone, label: 'Via SMS' },
+  [CasedataMessageType.Email]: { Icon: Mail, label: 'Via e-post' },
+  [CasedataMessageType.DigitalMail]: { Icon: Mail, label: 'Via digital brevlåda' },
+  [CasedataMessageType.WebMessage]: { Icon: Monitor, label: 'via e-tjänst' },
+  [CasedataMessageType.WebMessageLegacy]: { Icon: Monitor, label: 'via e-tjänst' },
+  [CasedataMessageType.Draken]: {
+    Icon: Monitor,
+    label: (isKatla: boolean) => `Via ${isKatla ? 'Färdtjänst' : 'Draken'}`,
+  },
+  [CasedataMessageType.MinaSidor]: { Icon: Monitor, label: 'Via Mina sidor' },
+};
+
+const getChannelPresentation = (messageType: string | undefined, isKatla: boolean) => {
+  const presentation = messageChannelPresentation[messageType as CasedataMessageType];
+  if (!presentation) return null;
+
+  return {
+    Icon: presentation.Icon,
+    label: typeof presentation.label === 'function' ? presentation.label(isKatla) : presentation.label,
+  };
+};
 
 export const RenderedMessage: FC<{
   message: MessageNode;
@@ -30,6 +73,8 @@ export const RenderedMessage: FC<{
   // Changed logic for expanded message to see if it solve problem with unread message counter
   // const [expanded, setExpanded] = useState<boolean>(!message?.children?.length ? true : false);
   const [expanded, setExpanded] = useState<boolean>(false);
+  const channelPresentation = getChannelPresentation(message.messageType, errand?.channel === Channels.ESERVICE_KATLA);
+  const ChannelIcon = channelPresentation?.Icon;
 
   useEffect(() => {
     const _a = errand ? validateAction(errand, user) : false;
@@ -62,7 +107,7 @@ export const RenderedMessage: FC<{
       const ownerInfomration = (errand?.stakeholders ?? []).filter((stakeholder) =>
         stakeholder.roles.includes(Role.APPLICANT)
       );
-      const isWebMessageOpenE = msg.messageType === 'WEBMESSAGE' && msg.externalCaseId !== null;
+      const isWebMessageOpenE = isCasedataWebMessageType(msg.messageType) && msg.externalCaseId !== null;
       const isOwnerStakeholderEmail = ownerInfomration.some((stakeholder) =>
         stakeholder.emails.some((email) => email.value === msg.email)
       );
@@ -97,7 +142,7 @@ export const RenderedMessage: FC<{
                   <p className="mr-md break-all font-bold">
                     Till: <RenderMessageReciever selectedMessage={message} errand={errand} />
                   </p>
-                  {message.messageType === 'EMAIL' && (message.ccRecipients?.length ?? 0) > 0 && (
+                  {message.messageType === CasedataMessageType.Email && (message.ccRecipients?.length ?? 0) > 0 && (
                     <p className="mr-md break-all font-bold">
                       Kopia: <EmailRecipients recipients={message.ccRecipients!} />
                     </p>
@@ -121,51 +166,12 @@ export const RenderedMessage: FC<{
                   <span className="text-xs mx-sm">|</span>
                 </>
               ) : null}
-              <span className="flex text-xs whitespace-nowrap items-center">
-                {(() => {
-                  switch (message.messageType) {
-                    case 'SMS':
-                      return (
-                        <>
-                          <Smartphone size="1.5rem" className="align-sub mx-sm" /> Via SMS
-                        </>
-                      );
-                    case 'EMAIL':
-                      return (
-                        <>
-                          <Mail size="1.5rem" className="align-sub mx-sm" /> Via e-post
-                        </>
-                      );
-                    case 'DIGITAL_MAIL':
-                      return (
-                        <>
-                          <Mail size="1.5rem" className="align-sub mx-sm" /> Via digital brevlåda
-                        </>
-                      );
-                    case 'WEB_MESSAGE':
-                      return (
-                        <>
-                          <Monitor size="1.5rem" className="align-sub mx-sm" /> via e-tjänst
-                        </>
-                      );
-                    case 'DRAKEN':
-                      return (
-                        <>
-                          <Monitor size="1.5rem" className="align-sub mx-sm" /> Via{' '}
-                          {errand?.channel === Channels.ESERVICE_KATLA ? 'Färdtjänst' : 'Draken'}
-                        </>
-                      );
-                    case 'MINASIDOR':
-                      return (
-                        <>
-                          <Monitor size="1.5rem" className="align-sub mx-sm" /> Via Mina sidor
-                        </>
-                      );
-                    default:
-                      return '';
-                  }
-                })()}
-              </span>
+              {channelPresentation && ChannelIcon ? (
+                <span className="flex text-xs whitespace-nowrap items-center">
+                  <ChannelIcon size="1.5rem" className="align-sub mx-sm" />
+                  {channelPresentation.label}
+                </span>
+              ) : null}
             </div>
             {getMessageOwner(message)}
           </div>
@@ -199,11 +205,7 @@ export const RenderedMessage: FC<{
               __html: sanitized(message.subject || ''),
             }}
           ></p>
-          {expanded &&
-          (message.messageType === 'EMAIL' ||
-            message.messageType === 'WEB_MESSAGE' ||
-            message.messageType === 'DRAKEN' ||
-            message.messageType === 'MINASIDOR') ? (
+          {expanded && isCasedataReplyableMessageType(message.messageType) ? (
             <Button
               type="button"
               className="self-start"

--- a/frontend/src/casedata/hooks/useMessageTemplates.ts
+++ b/frontend/src/casedata/hooks/useMessageTemplates.ts
@@ -1,23 +1,11 @@
 import { User } from '@common/interfaces/user';
+import { EMAIL_INFORMATION_TEXT, MessageTemplates } from '@common/services/message-template-body-service';
 import { getTemplateRole, getTemplateType } from '@common/utils/template-metadata';
 import {
-  EMAIL_INFORMATION_TEXT,
   fetchTemplatesWithMetadata,
   replaceTemplateParameters,
-  TemplateInfo,
 } from '@supportmanagement/services/message-template-service';
 import { useEffect, useState } from 'react';
-
-export interface MessageTemplates {
-  internalSignature: string;
-  smsTemplate: string;
-  smsSignature: string;
-  emailSignature: string;
-  emailTemplates: TemplateInfo[];
-  smsTemplates: TemplateInfo[];
-  byId: Record<string, string>;
-  app: string;
-}
 
 interface UseMessageTemplatesResult {
   templates: MessageTemplates | null;

--- a/frontend/src/casedata/hooks/useMessageTemplates.ts
+++ b/frontend/src/casedata/hooks/useMessageTemplates.ts
@@ -73,7 +73,10 @@ export function useMessageTemplates(user: User, shouldLoad: boolean): UseMessage
         });
 
         const emailTemplates = appResult.templates.filter((t) => {
-          return getTemplateType(t) === 'email' && !['signature', 'publicdocuments'].includes(getTemplateRole(t) || '');
+          return (
+            getTemplateType(t) === 'email' &&
+            !['signature', 'publicdocuments', 'closing'].includes(getTemplateRole(t) || '')
+          );
         });
 
         // If no app-specific email templates, use default ones
@@ -88,14 +91,14 @@ export function useMessageTemplates(user: User, shouldLoad: boolean): UseMessage
             : [];
 
         const smsTemplates = appResult.templates.filter((t) => {
-          return getTemplateType(t) === 'sms' && getTemplateRole(t) !== 'signature';
+          return getTemplateType(t) === 'sms' && !['signature', 'closing'].includes(getTemplateRole(t) || '');
         });
 
         // If no app-specific sms templates, use default ones
         const fallbackSmsTemplates =
           smsTemplates.length === 0
             ? defaultResult.templates.filter((t) => {
-                return getTemplateType(t) === 'sms' && getTemplateRole(t) !== 'signature';
+                return getTemplateType(t) === 'sms' && !['signature', 'closing'].includes(getTemplateRole(t) || '');
               })
             : [];
 

--- a/frontend/src/casedata/services/casedata-message-reply-context-service.ts
+++ b/frontend/src/casedata/services/casedata-message-reply-context-service.ts
@@ -1,0 +1,40 @@
+import { MessageReplyContext } from '@common/interfaces/message-reply-context';
+import { MessageContactMeans } from '@common/services/message-template-body-service';
+import sanitized, { formatMessage, sanitizeHtmlMessageBody } from '@common/services/sanitizer-service';
+
+import { MessageNode } from './casedata-message-service';
+import { CasedataMessageType, isCasedataWebMessageType } from './casedata-message-types';
+
+const messageTypeToContactMeans: Partial<Record<CasedataMessageType, MessageContactMeans>> = {
+  [CasedataMessageType.Draken]: 'draken',
+  [CasedataMessageType.MinaSidor]: 'minasidor',
+};
+
+const getReplyContactMeans = (message: MessageNode): MessageContactMeans => {
+  if (isCasedataWebMessageType(message.messageType)) return 'webmessage';
+
+  return messageTypeToContactMeans[message.messageType as CasedataMessageType] ?? 'email';
+};
+
+export const buildCasedataReplyContext = (message: MessageNode, errandId?: string | number): MessageReplyContext => {
+  const contactMeans = getReplyContactMeans(message);
+  const replyTo = message.emailHeaders?.find((header) => header.header === 'MESSAGE_ID')?.values[0] ?? '';
+  const references = message.emailHeaders?.find((header) => header.header === 'REFERENCES')?.values ?? [];
+  const sender = message.conversationId ? `${message.firstName} ${message.lastName}` : message.email;
+  const historyHeader = `<br><br>-----Ursprungligt meddelande-----<br>Från: ${sender}<br>Skickat: ${message.sent}<br>Till: Sundsvalls kommun<br>Ämne: ${message.subject}<br><br>`;
+  const messageBody = message.htmlMessage
+    ? sanitizeHtmlMessageBody(message.htmlMessage)
+    : formatMessage(sanitized(message.message ?? ''));
+
+  return {
+    contactMeans,
+    headerReplyTo: replyTo,
+    headerReferences: [...references, replyTo].filter(Boolean).join(','),
+    recipients:
+      message.direction === 'OUTBOUND'
+        ? message.recipients?.map((email) => ({ value: email })) ?? []
+        : [{ value: message.email ?? '' }],
+    historyHtml: historyHeader + messageBody,
+    setupKey: `reply:${message.messageId || ''}:${contactMeans}:${errandId || ''}`,
+  };
+};

--- a/frontend/src/casedata/services/casedata-message-service.ts
+++ b/frontend/src/casedata/services/casedata-message-service.ts
@@ -2,6 +2,7 @@ import { CasedataMessageTabFormModel } from '@casedata/components/errand/tabs/me
 import { Attachment } from '@casedata/interfaces/attachment';
 import { IErrand } from '@casedata/interfaces/errand';
 import { sendAttachments } from '@casedata/services/casedata-attachment-service';
+import { CasedataMessageType } from '@casedata/services/casedata-message-types';
 import { Message, MessageStatus } from '@common/interfaces/message';
 import { Render, TemplateSelector } from '@common/interfaces/template';
 import { ApiResponse, apiService } from '@common/services/api-service';
@@ -235,7 +236,7 @@ const buildTree = (_list: MessageResponse[]) => {
   list.forEach((msg) => {
     msg.message = msg.message?.replace(/\r\n/g, '<br>');
     const id =
-      msg.messageType === 'EMAIL'
+      msg.messageType === CasedataMessageType.Email
         ? (msg.emailHeaders ?? []).find((h) => h.header === 'MESSAGE_ID')?.values?.[0]
         : msg.messageId;
     if (id) {
@@ -245,7 +246,7 @@ const buildTree = (_list: MessageResponse[]) => {
 
   list.forEach((msg) => {
     const id =
-      msg.messageType === 'EMAIL'
+      msg.messageType === CasedataMessageType.Email
         ? (msg.emailHeaders ?? []).find((h) => h.header === 'MESSAGE_ID')?.values?.[0]
         : msg.messageId;
     const parent = (msg.emailHeaders ?? []).find((h) => h.header === 'IN_REPLY_TO')?.values?.[0];

--- a/frontend/src/casedata/services/casedata-message-types.ts
+++ b/frontend/src/casedata/services/casedata-message-types.ts
@@ -1,0 +1,20 @@
+export const CasedataMessageType = {
+  Email: 'EMAIL',
+  Sms: 'SMS',
+  WebMessage: 'WEBMESSAGE',
+  WebMessageLegacy: 'WEB_MESSAGE',
+  DigitalMail: 'DIGITAL_MAIL',
+  Draken: 'DRAKEN',
+  MinaSidor: 'MINASIDOR',
+} as const;
+
+export type CasedataMessageType = (typeof CasedataMessageType)[keyof typeof CasedataMessageType];
+
+export const isCasedataWebMessageType = (messageType?: string | null): boolean =>
+  messageType === CasedataMessageType.WebMessage || messageType === CasedataMessageType.WebMessageLegacy;
+
+export const isCasedataReplyableMessageType = (messageType?: string | null): boolean =>
+  messageType === CasedataMessageType.Email ||
+  isCasedataWebMessageType(messageType) ||
+  messageType === CasedataMessageType.Draken ||
+  messageType === CasedataMessageType.MinaSidor;

--- a/frontend/src/common/hooks/use-message-body-template-state.ts
+++ b/frontend/src/common/hooks/use-message-body-template-state.ts
@@ -1,0 +1,31 @@
+import { useRef, useState } from 'react';
+
+export const useMessageBodyTemplateState = () => {
+  const [bodyEdited, setBodyEdited] = useState(false);
+  const bodyEditedRef = useRef(false);
+  const lastAppliedTemplateRef = useRef('');
+  const replyHistoryRef = useRef('');
+  const lastSetupKeyRef = useRef('');
+
+  const setBodyEditedState = (edited: boolean) => {
+    bodyEditedRef.current = edited;
+    setBodyEdited(edited);
+  };
+
+  const shouldSkipAutoApply = (setupKey: string): boolean => {
+    return bodyEditedRef.current && lastSetupKeyRef.current === setupKey;
+  };
+
+  const markAutoApplied = (setupKey: string) => {
+    lastSetupKeyRef.current = setupKey;
+  };
+
+  return {
+    bodyEdited,
+    lastAppliedTemplateRef,
+    replyHistoryRef,
+    setBodyEditedState,
+    shouldSkipAutoApply,
+    markAutoApplied,
+  };
+};

--- a/frontend/src/common/interfaces/message-reply-context.ts
+++ b/frontend/src/common/interfaces/message-reply-context.ts
@@ -1,0 +1,10 @@
+import { MessageContactMeans } from '@common/services/message-template-body-service';
+
+export interface MessageReplyContext {
+  contactMeans: MessageContactMeans;
+  headerReplyTo: string;
+  headerReferences: string;
+  recipients: { value: string }[];
+  historyHtml: string;
+  setupKey: string;
+}

--- a/frontend/src/common/services/feature-flag-service.ts
+++ b/frontend/src/common/services/feature-flag-service.ts
@@ -15,7 +15,9 @@ export const getFeatureFlags = async () => {
       return res;
     })
     .catch((e) => {
-      console.error('Something went wrong when fetching feature flags: ' + e);
+      if (process.env.NODE_ENV === 'production') {
+        console.error('Something went wrong when fetching feature flags: ' + e);
+      }
       throw e;
     });
 };

--- a/frontend/src/common/services/message-template-body-service.ts
+++ b/frontend/src/common/services/message-template-body-service.ts
@@ -15,7 +15,15 @@ export interface MessageTemplateInfo {
   identifier: string;
   name: string;
   content: string;
+  metadata?: Array<{ key: string; value: string }>;
 }
+
+const getTemplateRoleFromTemplate = (template: MessageTemplateInfo): string | undefined => {
+  const fromMetadata = template.metadata?.find((m) => m.key === 'templateRole')?.value?.toLowerCase();
+  if (fromMetadata) return fromMetadata;
+  const parts = template.identifier?.split('.') || [];
+  return parts.length >= 3 ? parts[2].toLowerCase() : undefined;
+};
 
 export interface MessageTemplates {
   internalSignature: string;
@@ -49,9 +57,15 @@ export const getTemplateOptions = (
 };
 
 export const getDefaultTemplateId = (templates: MessageTemplates | null, means: MessageContactMeans): string => {
-  return (
-    getTemplateOptions(templates, means).find((template) => template.identifier?.endsWith('.default'))?.identifier || ''
-  );
+  const options = getTemplateOptions(templates, means);
+  // Prefer templateRole metadata; fall back to identifier suffix for legacy templates.
+  const byRole = options.find((template) => getTemplateRoleFromTemplate(template) === 'default');
+  if (byRole) return byRole.identifier;
+  const bySuffix = options.find((template) => template.identifier?.endsWith('.default'));
+  if (bySuffix) return bySuffix.identifier;
+  // Last-resort fallback: pick the first available template so the body matches what the
+  // dropdown visually shows as selected when no template follows the .default convention.
+  return options[0]?.identifier || '';
 };
 
 export const getDefaultMessageBody = (

--- a/frontend/src/common/services/message-template-body-service.ts
+++ b/frontend/src/common/services/message-template-body-service.ts
@@ -1,0 +1,101 @@
+export type MessageContactMeans =
+  | 'email'
+  | 'sms'
+  | 'webmessage'
+  | 'digitalmail'
+  | 'paper'
+  | 'draken'
+  | 'minasidor'
+  | 'katla';
+
+export const EMAIL_INFORMATION_TEXT =
+  '<p><b>Vänligen ändra inte ämnesraden om du svarar på detta meddelande.</b></p><br>';
+
+export interface MessageTemplateInfo {
+  identifier: string;
+  name: string;
+  content: string;
+}
+
+export interface MessageTemplates {
+  internalSignature: string;
+  smsTemplate: string;
+  smsSignature: string;
+  emailSignature: string;
+  emailTemplates: MessageTemplateInfo[];
+  smsTemplates: MessageTemplateInfo[];
+  byId: Record<string, string>;
+  app: string;
+}
+
+export const supportsSelectableTemplates = (means: MessageContactMeans): means is 'email' | 'sms' =>
+  means === 'email' || means === 'sms';
+
+export const removeEmailInformation = (means: MessageContactMeans | string, template: string): string => {
+  if (means === 'email') return template;
+
+  return template
+    .replace(EMAIL_INFORMATION_TEXT, '')
+    .replace(/Vänligen ändra inte ämnesraden om du svarar på detta meddelande<br><br>?/gi, '')
+    .replace(/Vänligen ändra inte ämnesraden om du besvarar mejlet.<br>?/gi, '');
+};
+
+export const getTemplateOptions = (
+  templates: MessageTemplates | null,
+  means: MessageContactMeans
+): MessageTemplateInfo[] => {
+  if (!templates || !supportsSelectableTemplates(means)) return [];
+  return means === 'sms' ? templates.smsTemplates : templates.emailTemplates;
+};
+
+export const getDefaultTemplateId = (templates: MessageTemplates | null, means: MessageContactMeans): string => {
+  return (
+    getTemplateOptions(templates, means).find((template) => template.identifier?.endsWith('.default'))?.identifier || ''
+  );
+};
+
+export const getDefaultMessageBody = (
+  templates: MessageTemplates | null,
+  means: MessageContactMeans,
+  history = ''
+): string => {
+  if (!templates) return history;
+
+  switch (means) {
+    case 'draken':
+      return templates.internalSignature + history;
+    case 'sms':
+      return templates.smsTemplate + history;
+    default:
+      return removeEmailInformation(means, templates.emailSignature) + history;
+  }
+};
+
+export const buildMessageTemplateBody = ({
+  templates,
+  templateId,
+  means,
+  history = '',
+  includePublicDocumentsFooter = false,
+}: {
+  templates: MessageTemplates | null;
+  templateId: string;
+  means: MessageContactMeans;
+  history?: string;
+  includePublicDocumentsFooter?: boolean;
+}): string => {
+  if (!templates) return history;
+  if (!templateId) return getDefaultMessageBody(templates, means, history);
+
+  const content = templates.byId[templateId] || '';
+  if (means === 'sms') {
+    return content + templates.smsSignature + history;
+  }
+
+  const footerId = `${templates.app}.email.publicdocuments`;
+  const shouldAddFooter =
+    includePublicDocumentsFooter && (templateId.endsWith('.priority') || templateId.endsWith('.default'));
+  const footer = shouldAddFooter ? templates.byId[footerId] || '' : '';
+
+  return content + templates.emailSignature + footer + history;
+};

--- a/frontend/src/common/services/message-template-body-service.ts
+++ b/frontend/src/common/services/message-template-body-service.ts
@@ -31,7 +31,7 @@ export interface MessageTemplates {
 export const supportsSelectableTemplates = (means: MessageContactMeans): means is 'email' | 'sms' =>
   means === 'email' || means === 'sms';
 
-export const removeEmailInformation = (means: MessageContactMeans | string, template: string): string => {
+export const removeEmailInformation = (means: MessageContactMeans, template: string): string => {
   if (means === 'email') return template;
 
   return template

--- a/frontend/src/supportmanagement/components/support-errand/tabs/messages/render-support-message-reciever.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/tabs/messages/render-support-message-reciever.component.tsx
@@ -1,5 +1,6 @@
 import sanitized from '@common/services/sanitizer-service';
 import { Button } from '@sk-web-gui/button';
+import { SupportCommunicationType } from '@supportmanagement/services/support-communication-types';
 import { SupportErrand } from '@supportmanagement/services/support-errand-service';
 import { Message } from '@supportmanagement/services/support-message-service';
 import { getApplicantName } from '@supportmanagement/services/support-stakeholder-service';
@@ -11,22 +12,22 @@ const getReciever = (msg: Message, supportErrand: SupportErrand): string | strin
     return '';
   }
 
-  if (msg.communicationType === 'WEB_MESSAGE') {
+  if (msg.communicationType === SupportCommunicationType.WebMessage) {
     return msg.direction === 'INBOUND' ? 'Draken' : 'E-tjänst';
   }
-  if (msg.communicationType === 'MINASIDOR' && msg.direction === 'OUTBOUND') {
+  if (msg.communicationType === SupportCommunicationType.MinaSidor && msg.direction === 'OUTBOUND') {
     return getApplicantName(supportErrand);
   }
 
-  if (msg.communicationType === 'MINASIDOR' && msg.direction === 'INBOUND') {
+  if (msg.communicationType === SupportCommunicationType.MinaSidor && msg.direction === 'INBOUND') {
     return 'Draken';
   }
 
-  if (msg.communicationType === 'DRAKEN') {
+  if (msg.communicationType === SupportCommunicationType.Draken) {
     return 'Draken';
   }
 
-  if (msg.communicationType === 'EMAIL') {
+  if (msg.communicationType === SupportCommunicationType.Email) {
     return msg.recipients;
   }
   return msg?.target || '(okänd mottagare)';

--- a/frontend/src/supportmanagement/components/support-errand/tabs/messages/rendered-support-message.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/tabs/messages/rendered-support-message.component.tsx
@@ -3,6 +3,10 @@ import { MessageResponseDirectionEnum } from '@common/data-contracts/case-data/d
 import sanitized from '@common/services/sanitizer-service';
 import { Button, cx, Icon, useSnackbar } from '@sk-web-gui/react';
 import { useConfigStore, useSupportStore, useUserStore } from '@stores/index';
+import {
+  isSupportReplyableCommunicationType,
+  SupportCommunicationType,
+} from '@supportmanagement/services/support-communication-types';
 import { getSupportConversationAttachment } from '@supportmanagement/services/support-conversation-service';
 import { isSupportErrandLocked, validateAction } from '@supportmanagement/services/support-errand-service';
 import {
@@ -12,10 +16,33 @@ import {
   setMessageViewStatus,
 } from '@supportmanagement/services/support-message-service';
 import dayjs from 'dayjs';
-import { CornerDownRight, Image, Mail, Monitor, Paperclip, Smartphone, SquareMinus, SquarePlus } from 'lucide-react';
+import {
+  CornerDownRight,
+  Image,
+  type LucideIcon,
+  Mail,
+  Monitor,
+  Paperclip,
+  Smartphone,
+  SquareMinus,
+  SquarePlus,
+} from 'lucide-react';
 import { Dispatch, FC, SetStateAction, useEffect, useMemo, useState } from 'react';
 
 import { EmailRecipients, RenderSupportMessageReciever } from './render-support-message-reciever.component';
+
+type ChannelPresentation = {
+  Icon: LucideIcon;
+  label: string;
+};
+
+const communicationChannelPresentation: Partial<Record<SupportCommunicationType, ChannelPresentation>> = {
+  [SupportCommunicationType.Sms]: { Icon: Smartphone, label: 'Via SMS' },
+  [SupportCommunicationType.Email]: { Icon: Mail, label: 'Via e-post' },
+  [SupportCommunicationType.WebMessage]: { Icon: Monitor, label: 'Via e-tjänst' },
+  [SupportCommunicationType.Draken]: { Icon: Monitor, label: 'Via Draken' },
+  [SupportCommunicationType.MinaSidor]: { Icon: Monitor, label: 'Via Mina sidor' },
+};
 
 export const RenderedSupportMessage: FC<{
   update: () => void;
@@ -34,6 +61,8 @@ export const RenderedSupportMessage: FC<{
   // Changed logic for expanded message to see if it solve problem with unread message counter
   // const [expanded, setExpanded] = useState(!message?.children?.length ? true : false);
   const [expanded, setExpanded] = useState(false);
+  const channelPresentation = communicationChannelPresentation[message.communicationType];
+  const ChannelIcon = channelPresentation?.Icon;
 
   const allowed = useMemo(() => validateAction(supportErrand, user), [user, supportErrand]);
 
@@ -51,7 +80,7 @@ export const RenderedSupportMessage: FC<{
     if (!msg) {
       return '';
     }
-    if (msg.communicationType === 'WEB_MESSAGE') {
+    if (msg.communicationType === SupportCommunicationType.WebMessage) {
       return msg.direction === 'OUTBOUND' ? 'Draken' : msg.sender || 'E-tjänst';
     }
     return msg?.sender || '(okänd avsändare)';
@@ -61,7 +90,7 @@ export const RenderedSupportMessage: FC<{
     if (msg.direction === MessageResponseDirectionEnum.INBOUND) {
       const ownerInfomration =
         supportErrand.stakeholders?.filter((stakeholder) => stakeholder.role?.includes('PRIMARY')) ?? [];
-      const isWebMessageOpenE = msg.communicationType === 'WEB_MESSAGE';
+      const isWebMessageOpenE = msg.communicationType === SupportCommunicationType.WebMessage;
       const isOwnerStakeholderEmail = ownerInfomration.some((stakeholder) =>
         stakeholder.contactChannels?.some((value) => value.value === msg.sender)
       );
@@ -116,7 +145,7 @@ export const RenderedSupportMessage: FC<{
                   <p className="mr-md break-all font-bold">
                     Till: <RenderSupportMessageReciever selectedMessage={message} errand={supportErrand} />
                   </p>
-                  {message.communicationType === 'EMAIL' && message.ccRecipients?.length > 0 && (
+                  {message.communicationType === SupportCommunicationType.Email && message.ccRecipients?.length > 0 && (
                     <p className="mr-md break-all font-bold">
                       Kopia: <EmailRecipients recipients={message.ccRecipients} />
                     </p>
@@ -140,44 +169,12 @@ export const RenderedSupportMessage: FC<{
                   <span className="text-xs mx-sm">|</span>
                 </>
               ) : null}
-              <span className="flex text-xs whitespace-nowrap items-center">
-                {(() => {
-                  switch (message.communicationType) {
-                    case 'SMS':
-                      return (
-                        <>
-                          <Icon icon={<Smartphone />} size="1.5rem" className="align-sub mx-sm" /> Via SMS
-                        </>
-                      );
-                    case 'EMAIL':
-                      return (
-                        <>
-                          <Icon icon={<Mail />} size="1.5rem" className="align-sub mx-sm" /> Via e-post
-                        </>
-                      );
-                    case 'WEB_MESSAGE':
-                      return (
-                        <>
-                          <Icon icon={<Monitor />} size="1.5rem" className="align-sub mx-sm" /> Via e-tjänst
-                        </>
-                      );
-                    case 'DRAKEN':
-                      return (
-                        <>
-                          <Icon icon={<Monitor />} size="1.5rem" className="align-sub mx-sm" /> Via Draken
-                        </>
-                      );
-                    case 'MINASIDOR':
-                      return (
-                        <>
-                          <Icon icon={<Monitor />} size="1.5rem" className="align-sub mx-sm" /> Via Mina sidor
-                        </>
-                      );
-                    default:
-                      return '';
-                  }
-                })()}
-              </span>
+              {channelPresentation && ChannelIcon ? (
+                <span className="flex text-xs whitespace-nowrap items-center">
+                  <Icon icon={<ChannelIcon />} size="1.5rem" className="align-sub mx-sm" />
+                  {channelPresentation.label}
+                </span>
+              ) : null}
             </div>
             {getMessageOwner(message)}
           </div>
@@ -208,11 +205,7 @@ export const RenderedSupportMessage: FC<{
               __html: sanitized(message.subject || ''),
             }}
           ></p>
-          {expanded &&
-          (message.communicationType === 'EMAIL' ||
-            message.communicationType === 'WEB_MESSAGE' ||
-            message.communicationType === 'DRAKEN' ||
-            message.communicationType === 'MINASIDOR') ? (
+          {expanded && isSupportReplyableCommunicationType(message.communicationType) ? (
             <Button
               type="button"
               className="self-start"

--- a/frontend/src/supportmanagement/components/support-errand/tabs/messages/support-messages-tab.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/tabs/messages/support-messages-tab.tsx
@@ -1,7 +1,7 @@
 import { MessageWrapper } from '@common/components/message/message-wrapper.component';
-import { CommunicationCommunicationTypeEnum } from '@common/data-contracts/supportmanagement/data-contracts';
 import { Button, Divider, FormControl, FormLabel, Icon, Select } from '@sk-web-gui/react';
 import { useConfigStore, useSupportStore, useUserStore } from '@stores/index';
+import { SupportCommunicationType } from '@supportmanagement/services/support-communication-types';
 import { isSupportErrandLocked, Status, validateAction } from '@supportmanagement/services/support-errand-service';
 import { Message, setMessageViewStatus } from '@supportmanagement/services/support-message-service';
 import { Mail } from 'lucide-react';
@@ -136,11 +136,11 @@ export const SupportMessagesTab: FC<{
               <Select.Option defaultChecked={true} value={'allchannels'}>
                 Alla kanaler
               </Select.Option>
-              <Select.Option value={'DRAKEN'}>Draken</Select.Option>
-              <Select.Option value={CommunicationCommunicationTypeEnum.WEB_MESSAGE}>E-tjänst</Select.Option>
-              <Select.Option value={CommunicationCommunicationTypeEnum.EMAIL}>E-post</Select.Option>
-              <Select.Option value={'MINASIDOR'}>Mina sidor</Select.Option>
-              <Select.Option value={CommunicationCommunicationTypeEnum.SMS}>SMS</Select.Option>
+              <Select.Option value={SupportCommunicationType.Draken}>Draken</Select.Option>
+              <Select.Option value={SupportCommunicationType.WebMessage}>E-tjänst</Select.Option>
+              <Select.Option value={SupportCommunicationType.Email}>E-post</Select.Option>
+              <Select.Option value={SupportCommunicationType.MinaSidor}>Mina sidor</Select.Option>
+              <Select.Option value={SupportCommunicationType.Sms}>SMS</Select.Option>
             </Select>
           </FormControl>
         </div>

--- a/frontend/src/supportmanagement/components/support-message-form/support-message-form.component.tsx
+++ b/frontend/src/supportmanagement/components/support-message-form/support-message-form.component.tsx
@@ -6,10 +6,19 @@ import CommonNestedEmailArrayV2 from '@common/components/commonNestedEmailArrayV
 import CommonNestedPhoneArrayV2 from '@common/components/commonNestedPhoneArrayV2';
 import TextEditor from '@common/components/dynamic-text-editor';
 import FileUpload from '@common/components/file-upload/file-upload.component';
+import { useMessageBodyTemplateState } from '@common/hooks/use-message-body-template-state';
 import { isKA, isKC, isLOP } from '@common/services/application-service';
 import { invalidPhoneMessage, supportManagementPhonePattern } from '@common/services/helper-service';
+import {
+  buildMessageTemplateBody,
+  getDefaultMessageBody,
+  getDefaultTemplateId,
+  getTemplateOptions,
+  MessageContactMeans,
+  removeEmailInformation,
+} from '@common/services/message-template-body-service';
 import { getAllRelatedErrands, RelationWithErrandNumber } from '@common/services/relations-service';
-import sanitized, { sanitizeHtmlMessageBody } from '@common/services/sanitizer-service';
+import sanitized from '@common/services/sanitizer-service';
 import { getToastOptions } from '@common/utils/toast-message-settings';
 import { appConfig } from '@config/appconfig';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -45,19 +54,18 @@ import {
   setSupportErrandStatus,
   Status,
 } from '@supportmanagement/services/support-errand-service';
+import { buildSupportReplyContext } from '@supportmanagement/services/support-message-reply-context-service';
 import { Message, MessageRequest, sendMessage } from '@supportmanagement/services/support-message-service';
 import { getSupportOwnerStakeholder } from '@supportmanagement/services/support-stakeholder-service';
 import { File, Paperclip, X } from 'lucide-react';
-import { Dispatch, FC, SetStateAction, useEffect, useRef, useState } from 'react';
+import { Dispatch, FC, SetStateAction, useEffect, useState } from 'react';
 import { Resolver, useFieldArray, useForm } from 'react-hook-form';
 import * as yup from 'yup';
-
-import { removeEmailInformation } from '../templates/default-message-template';
 
 export interface SupportMessageFormModel {
   id: string;
   messageContact: boolean;
-  contactMeans: string;
+  contactMeans: MessageContactMeans;
   newEmail: string;
   emails: { value: string }[];
   newPhoneNumber: string;
@@ -154,32 +162,30 @@ export const SupportMessageForm: FC<{
   const [isAttachmentModalOpen, setIsAttachmentModalOpen] = useState<boolean>(false);
   const [selectedRelationId, setSelectedRelationId] = useState<string>('');
   const [relationErrands, setRelationErrands] = useState<RelationWithErrandNumber[]>([]);
-  const [bodyEdited, setBodyEdited] = useState(false);
-  const bodyEditedRef = useRef(false);
-  const lastAppliedTemplateRef = useRef<string>('');
-  const replyHistoryRef = useRef<string>('');
-  const lastMessageSetupKeyRef = useRef<string>('');
+  const {
+    bodyEdited,
+    lastAppliedTemplateRef,
+    replyHistoryRef,
+    setBodyEditedState,
+    shouldSkipAutoApply,
+    markAutoApplied,
+  } = useMessageBodyTemplateState();
 
   const confirm = useConfirm();
 
   const { templates } = useMessageTemplates(user, props.showMessageForm);
 
-  const setBodyEditedState = (edited: boolean) => {
-    bodyEditedRef.current = edited;
-    setBodyEdited(edited);
-  };
-
-  const emailBody = templates?.byId[`${templates.app}.email.default`]
-    ? templates.byId[`${templates.app}.email.default`] + templates.emailSignature
-    : '';
-  const smsBody = templates?.smsTemplate || '';
-  const internalSignature = templates?.internalSignature || '';
-
-  const getDefaultTemplateId = (means: string): string => {
-    if (!templates) return '';
-    const list = means === 'sms' ? templates.smsTemplates : templates.emailTemplates;
-    return list?.find((t) => t.identifier?.endsWith('.default'))?.identifier || '';
-  };
+  const emailBody = buildMessageTemplateBody({
+    templates,
+    templateId: getDefaultTemplateId(templates, 'email'),
+    means: 'email',
+  });
+  const smsBody = buildMessageTemplateBody({
+    templates,
+    templateId: getDefaultTemplateId(templates, 'sms'),
+    means: 'sms',
+  });
+  const internalSignature = getDefaultMessageBody(templates, 'draken');
 
   const closeAttachmentModal = () => {
     setIsAttachmentModalOpen(false);
@@ -193,7 +199,7 @@ export const SupportMessageForm: FC<{
         (Channels as Record<string, string>)[supportErrand.channel!] === Channels.ESERVICE ||
         (Channels as Record<string, string>)[supportErrand.channel!] === Channels.ESERVICE_INTERNAL
           ? 'webmessage'
-          : 'email',
+          : ('email' as MessageContactMeans),
       newEmail: '',
       newPhoneNumber: '',
       emails: [],
@@ -366,73 +372,40 @@ export const SupportMessageForm: FC<{
       });
   };
 
-  // Uses messageMeans locally inside the reply branch to avoid stale `contactMeans` from
-  // `watch()` after setValue. Fires on templates load so a reply opened before templates
-  // finished loading gets its body re-built once templates are available.
+  // Reply setup and new-message defaults. Headers, recipients and the selected template are
+  // synced unconditionally so the UI matches the current scenario; only the body is preserved
+  // when the user has already typed for this same scenario (so a late template load does not
+  // wipe their text).
   useEffect(() => {
     setReplying(!!props?.message?.communicationID);
 
     if (props.message) {
-      const messageMeans: SupportMessageFormModel['contactMeans'] =
-        props.message.communicationType === 'WEB_MESSAGE'
-          ? 'webmessage'
-          : props.message.communicationType === 'DRAKEN'
-          ? 'draken'
-          : props.message.communicationType === 'MINASIDOR'
-          ? 'minasidor'
-          : 'email';
-      const setupKey = `reply:${props.message.communicationID || ''}:${messageMeans}`;
-      if (bodyEditedRef.current && lastMessageSetupKeyRef.current === setupKey) return;
-      if (messageMeans !== contactMeans) {
-        setValue('contactMeans', messageMeans);
+      const replyContext = buildSupportReplyContext(props.message);
+      if (replyContext.contactMeans !== contactMeans) {
+        setValue('contactMeans', replyContext.contactMeans);
       }
-      const replyTo = props.message?.emailHeaders?.['MESSAGE_ID']?.[0] || '';
-      const references = props.message?.emailHeaders?.['REFERENCES'] || [];
-      references.push(replyTo);
-      setValue('headerReplyTo', replyTo);
-      setValue('headerReferences', references.join(','));
-      setValue(
-        'emails',
-        props.message.direction === 'OUTBOUND' ? [{ value: props.message?.target }] : [{ value: props.message.sender }]
-      );
-      const historyHeader = `<br><br>-----Ursprungligt meddelande-----<br>Från: ${props.message.sender}<br>Skickat: ${props.message.sent}<br>Till: Sundsvalls kommun<br>Ämne: ${props.message.subject}<br><br>`;
-      const historyBlock =
-        historyHeader +
-        (props.message.htmlMessageBody
-          ? sanitizeHtmlMessageBody(props.message.htmlMessageBody)
-          : props.message.messageBody);
+      setValue('headerReplyTo', replyContext.headerReplyTo);
+      setValue('headerReferences', replyContext.headerReferences);
+      setValue('emails', replyContext.recipients);
 
-      const signature = messageMeans === 'draken' ? internalSignature : removeEmailInformation(messageMeans, emailBody);
+      replyHistoryRef.current = replyContext.historyHtml;
 
-      replyHistoryRef.current = historyBlock;
-      setValue('messageBody', signature + historyBlock);
-
-      const defaultId = getDefaultTemplateId(messageMeans);
+      const defaultId = getDefaultTemplateId(templates, replyContext.contactMeans);
       setValue('messageTemplate', defaultId);
       lastAppliedTemplateRef.current = defaultId;
-      setBodyEditedState(false);
-      lastMessageSetupKeyRef.current = setupKey;
+
+      if (!shouldSkipAutoApply(replyContext.setupKey)) {
+        setValue('messageBody', getDefaultMessageBody(templates, replyContext.contactMeans) + replyContext.historyHtml);
+        setBodyEditedState(false);
+      }
+      markAutoApplied(replyContext.setupKey);
       trigger();
     } else {
       const setupKey = `new:${contactMeans}`;
-      if (bodyEditedRef.current && lastMessageSetupKeyRef.current === setupKey) return;
-      let body: string;
-      let prefillPhone = props.prefillPhone || '';
-
-      switch (contactMeans) {
-        case 'sms':
-          setValue('newPhoneNumber', prefillPhone);
-          body = smsBody;
-          clearErrors();
-          break;
-
-        case 'draken':
-          body = internalSignature;
-          break;
-
-        default:
-          body = removeEmailInformation(contactMeans, emailBody);
-          break;
+      const prefillPhone = props.prefillPhone || '';
+      if (contactMeans === 'sms') {
+        setValue('newPhoneNumber', prefillPhone);
+        clearErrors();
       }
 
       setValue('headerReplyTo', '');
@@ -441,13 +414,28 @@ export const SupportMessageForm: FC<{
       setValue('phoneNumbers', []);
 
       replyHistoryRef.current = '';
-      setValue('messageBody', sanitized(body));
 
-      const defaultId = getDefaultTemplateId(contactMeans);
+      const defaultId = getDefaultTemplateId(templates, contactMeans);
       setValue('messageTemplate', defaultId);
       lastAppliedTemplateRef.current = defaultId;
-      setBodyEditedState(false);
-      lastMessageSetupKeyRef.current = setupKey;
+
+      if (!shouldSkipAutoApply(setupKey)) {
+        let body: string;
+        switch (contactMeans) {
+          case 'sms':
+            body = smsBody;
+            break;
+          case 'draken':
+            body = internalSignature;
+            break;
+          default:
+            body = removeEmailInformation(contactMeans, emailBody);
+            break;
+        }
+        setValue('messageBody', sanitized(body));
+        setBodyEditedState(false);
+      }
+      markAutoApplied(setupKey);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [contactMeans, props.message, templates]);
@@ -624,9 +612,12 @@ export const SupportMessageForm: FC<{
                   const defaultBody = contactMeans === 'sms' ? smsBody : emailBody;
                   setValue('messageBody', sanitized(defaultBody) + history);
                 } else {
-                  const content = templates.byId[templateId] || '';
-                  const signature = contactMeans === 'sms' ? templates.smsSignature : templates.emailSignature;
-                  setValue('messageBody', sanitized(content + signature) + history);
+                  const templateBody = buildMessageTemplateBody({
+                    templates,
+                    templateId,
+                    means: contactMeans,
+                  });
+                  setValue('messageBody', sanitized(templateBody) + history);
                 }
                 lastAppliedTemplateRef.current = templateId;
                 setBodyEditedState(false);
@@ -654,7 +645,7 @@ export const SupportMessageForm: FC<{
               }
             }}
           >
-            {(contactMeans === 'email' ? templates.emailTemplates : templates.smsTemplates)?.map((t) => (
+            {getTemplateOptions(templates, contactMeans).map((t) => (
               <Select.Option key={t.identifier} value={t.identifier}>
                 {t.name}
               </Select.Option>
@@ -884,7 +875,7 @@ export const SupportMessageForm: FC<{
           type="button"
           loading={isSending}
           loadingText="Skickar meddelande"
-          disabled={isSending || formState.isSubmitting || !formState.isValid || contactMeans === ''}
+          disabled={isSending || formState.isSubmitting || !formState.isValid}
           onClick={handleSubmit(onSubmit)}
           data-cy="send-message-button"
         >

--- a/frontend/src/supportmanagement/components/support-message-form/support-message-form.component.tsx
+++ b/frontend/src/supportmanagement/components/support-message-form/support-message-form.component.tsx
@@ -155,11 +155,19 @@ export const SupportMessageForm: FC<{
   const [selectedRelationId, setSelectedRelationId] = useState<string>('');
   const [relationErrands, setRelationErrands] = useState<RelationWithErrandNumber[]>([]);
   const [bodyEdited, setBodyEdited] = useState(false);
+  const bodyEditedRef = useRef(false);
   const lastAppliedTemplateRef = useRef<string>('');
+  const replyHistoryRef = useRef<string>('');
+  const lastMessageSetupKeyRef = useRef<string>('');
 
   const confirm = useConfirm();
 
   const { templates } = useMessageTemplates(user, props.showMessageForm);
+
+  const setBodyEditedState = (edited: boolean) => {
+    bodyEditedRef.current = edited;
+    setBodyEdited(edited);
+  };
 
   const emailBody = templates?.byId[`${templates.app}.email.default`]
     ? templates.byId[`${templates.app}.email.default`] + templates.emailSignature
@@ -216,13 +224,6 @@ export const SupportMessageForm: FC<{
     clearErrors,
     formState: { errors },
   } = formControls;
-
-  useEffect(() => {
-    if (templates && emailBody && !props.message) {
-      setValue('messageBody', sanitized(emailBody));
-      setValue('messageBodyPlaintext', emailBody);
-    }
-  }, [templates, emailBody, props.message, setValue]);
 
   const {
     contactMeans,
@@ -365,20 +366,26 @@ export const SupportMessageForm: FC<{
       });
   };
 
+  // Uses messageMeans locally inside the reply branch to avoid stale `contactMeans` from
+  // `watch()` after setValue. Fires on templates load so a reply opened before templates
+  // finished loading gets its body re-built once templates are available.
   useEffect(() => {
     setReplying(!!props?.message?.communicationID);
 
     if (props.message) {
-      setValue(
-        'contactMeans',
+      const messageMeans: SupportMessageFormModel['contactMeans'] =
         props.message.communicationType === 'WEB_MESSAGE'
           ? 'webmessage'
           : props.message.communicationType === 'DRAKEN'
           ? 'draken'
           : props.message.communicationType === 'MINASIDOR'
           ? 'minasidor'
-          : 'email'
-      );
+          : 'email';
+      const setupKey = `reply:${props.message.communicationID || ''}:${messageMeans}`;
+      if (bodyEditedRef.current && lastMessageSetupKeyRef.current === setupKey) return;
+      if (messageMeans !== contactMeans) {
+        setValue('contactMeans', messageMeans);
+      }
       const replyTo = props.message?.emailHeaders?.['MESSAGE_ID']?.[0] || '';
       const references = props.message?.emailHeaders?.['REFERENCES'] || [];
       references.push(replyTo);
@@ -389,19 +396,26 @@ export const SupportMessageForm: FC<{
         props.message.direction === 'OUTBOUND' ? [{ value: props.message?.target }] : [{ value: props.message.sender }]
       );
       const historyHeader = `<br><br>-----Ursprungligt meddelande-----<br>Från: ${props.message.sender}<br>Skickat: ${props.message.sent}<br>Till: Sundsvalls kommun<br>Ämne: ${props.message.subject}<br><br>`;
+      const historyBlock =
+        historyHeader +
+        (props.message.htmlMessageBody
+          ? sanitizeHtmlMessageBody(props.message.htmlMessageBody)
+          : props.message.messageBody);
 
-      let signature = contactMeans === 'draken' ? internalSignature : removeEmailInformation(contactMeans, emailBody);
+      const signature = messageMeans === 'draken' ? internalSignature : removeEmailInformation(messageMeans, emailBody);
 
-      setValue(
-        'messageBody',
-        signature +
-          historyHeader +
-          (props.message.htmlMessageBody
-            ? sanitizeHtmlMessageBody(props.message.htmlMessageBody)
-            : props.message.messageBody)
-      );
+      replyHistoryRef.current = historyBlock;
+      setValue('messageBody', signature + historyBlock);
+
+      const defaultId = getDefaultTemplateId(messageMeans);
+      setValue('messageTemplate', defaultId);
+      lastAppliedTemplateRef.current = defaultId;
+      setBodyEditedState(false);
+      lastMessageSetupKeyRef.current = setupKey;
       trigger();
     } else {
+      const setupKey = `new:${contactMeans}`;
+      if (bodyEditedRef.current && lastMessageSetupKeyRef.current === setupKey) return;
       let body: string;
       let prefillPhone = props.prefillPhone || '';
 
@@ -426,12 +440,15 @@ export const SupportMessageForm: FC<{
       setValue('emails', []);
       setValue('phoneNumbers', []);
 
+      replyHistoryRef.current = '';
       setValue('messageBody', sanitized(body));
+
+      const defaultId = getDefaultTemplateId(contactMeans);
+      setValue('messageTemplate', defaultId);
+      lastAppliedTemplateRef.current = defaultId;
+      setBodyEditedState(false);
+      lastMessageSetupKeyRef.current = setupKey;
     }
-    const defaultId = !props.message ? getDefaultTemplateId(contactMeans) : '';
-    setValue('messageTemplate', defaultId);
-    lastAppliedTemplateRef.current = defaultId;
-    setBodyEdited(!!props.message);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [contactMeans, props.message, templates]);
 
@@ -602,16 +619,17 @@ export const SupportMessageForm: FC<{
               const templateId = e.currentTarget.value;
               const apply = () => {
                 setValue('messageTemplate', templateId);
+                const history = replyHistoryRef.current;
                 if (!templateId) {
                   const defaultBody = contactMeans === 'sms' ? smsBody : emailBody;
-                  setValue('messageBody', sanitized(defaultBody));
+                  setValue('messageBody', sanitized(defaultBody) + history);
                 } else {
                   const content = templates.byId[templateId] || '';
                   const signature = contactMeans === 'sms' ? templates.smsSignature : templates.emailSignature;
-                  setValue('messageBody', sanitized(content + signature));
+                  setValue('messageBody', sanitized(content + signature) + history);
                 }
                 lastAppliedTemplateRef.current = templateId;
-                setBodyEdited(false);
+                setBodyEditedState(false);
               };
 
               if (bodyEdited) {
@@ -660,7 +678,7 @@ export const SupportMessageForm: FC<{
                 setValue('messageBody', e.target.value.markup ?? '');
                 setValue('messageBodyPlaintext', e.target.value.plainText ?? '');
                 trigger('messageBody');
-                setBodyEdited(true);
+                setBodyEditedState(true);
               }}
             />
           </div>

--- a/frontend/src/supportmanagement/components/support-message-form/support-message-form.component.tsx
+++ b/frontend/src/supportmanagement/components/support-message-form/support-message-form.component.tsx
@@ -679,7 +679,13 @@ export const SupportMessageForm: FC<{
                 setValue('messageBody', e.target.value.markup ?? '');
                 setValue('messageBodyPlaintext', e.target.value.plainText ?? '');
                 trigger('messageBody');
-                setBodyEditedState(true);
+              }}
+              onTextChange={(_delta, _oldDelta, source) => {
+                // Only treat user input as an edit; ignore programmatic / silent updates
+                // so setValue() on body does not flag the form as dirty and skip auto-apply.
+                if (source === 'user') {
+                  setBodyEditedState(true);
+                }
               }}
             />
           </div>

--- a/frontend/src/supportmanagement/components/support-message-form/support-message-form.component.tsx
+++ b/frontend/src/supportmanagement/components/support-message-form/support-message-form.component.tsx
@@ -618,16 +618,16 @@ export const SupportMessageForm: FC<{
               const apply = () => {
                 setValue('messageTemplate', templateId);
                 const history = replyHistoryRef.current;
-                if (!templateId) {
-                  const defaultBody = contactMeans === 'sms' ? smsBody : emailBody;
-                  setValue('messageBody', sanitized(defaultBody) + history);
-                } else {
+                if (templateId) {
                   const templateBody = buildMessageTemplateBody({
                     templates,
                     templateId,
                     means: contactMeans,
                   });
                   setValue('messageBody', sanitized(templateBody) + history);
+                } else {
+                  const defaultBody = contactMeans === 'sms' ? smsBody : emailBody;
+                  setValue('messageBody', sanitized(defaultBody) + history);
                 }
                 lastAppliedTemplateRef.current = templateId;
                 setBodyEditedState(false);

--- a/frontend/src/supportmanagement/components/support-message-form/support-message-form.component.tsx
+++ b/frontend/src/supportmanagement/components/support-message-form/support-message-form.component.tsx
@@ -25,6 +25,7 @@ import {
   Modal,
   RadioButton,
   Select,
+  useConfirm,
   useSnackbar,
 } from '@sk-web-gui/react';
 import { useConfigStore, useSupportStore, useUserStore } from '@stores/index';
@@ -47,7 +48,7 @@ import {
 import { Message, MessageRequest, sendMessage } from '@supportmanagement/services/support-message-service';
 import { getSupportOwnerStakeholder } from '@supportmanagement/services/support-stakeholder-service';
 import { File, Paperclip, X } from 'lucide-react';
-import { Dispatch, FC, SetStateAction, useEffect, useState } from 'react';
+import { Dispatch, FC, SetStateAction, useEffect, useRef, useState } from 'react';
 import { Resolver, useFieldArray, useForm } from 'react-hook-form';
 import * as yup from 'yup';
 
@@ -153,6 +154,10 @@ export const SupportMessageForm: FC<{
   const [isAttachmentModalOpen, setIsAttachmentModalOpen] = useState<boolean>(false);
   const [selectedRelationId, setSelectedRelationId] = useState<string>('');
   const [relationErrands, setRelationErrands] = useState<RelationWithErrandNumber[]>([]);
+  const [bodyEdited, setBodyEdited] = useState(false);
+  const lastAppliedTemplateRef = useRef<string>('');
+
+  const confirm = useConfirm();
 
   const { templates } = useMessageTemplates(user, props.showMessageForm);
 
@@ -161,6 +166,12 @@ export const SupportMessageForm: FC<{
     : '';
   const smsBody = templates?.smsTemplate || '';
   const internalSignature = templates?.internalSignature || '';
+
+  const getDefaultTemplateId = (means: string): string => {
+    if (!templates) return '';
+    const list = means === 'sms' ? templates.smsTemplates : templates.emailTemplates;
+    return list?.find((t) => t.identifier?.endsWith('.default'))?.identifier || '';
+  };
 
   const closeAttachmentModal = () => {
     setIsAttachmentModalOpen(false);
@@ -417,9 +428,12 @@ export const SupportMessageForm: FC<{
 
       setValue('messageBody', sanitized(body));
     }
-    setValue('messageTemplate', '');
+    const defaultId = !props.message ? getDefaultTemplateId(contactMeans) : '';
+    setValue('messageTemplate', defaultId);
+    lastAppliedTemplateRef.current = defaultId;
+    setBodyEdited(!!props.message);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [contactMeans, props.message]);
+  }, [contactMeans, props.message, templates]);
 
   useEffect(() => {
     getAllRelatedErrands(municipalityId, supportErrand.id!).then(setRelationErrands);
@@ -586,20 +600,42 @@ export const SupportMessageForm: FC<{
             size="sm"
             onChange={(e) => {
               const templateId = e.currentTarget.value;
-              setValue('messageTemplate', templateId);
+              const apply = () => {
+                setValue('messageTemplate', templateId);
+                if (!templateId) {
+                  const defaultBody = contactMeans === 'sms' ? smsBody : emailBody;
+                  setValue('messageBody', sanitized(defaultBody));
+                } else {
+                  const content = templates.byId[templateId] || '';
+                  const signature = contactMeans === 'sms' ? templates.smsSignature : templates.emailSignature;
+                  setValue('messageBody', sanitized(content + signature));
+                }
+                lastAppliedTemplateRef.current = templateId;
+                setBodyEdited(false);
+              };
 
-              if (!templateId) {
-                const defaultBody = contactMeans === 'sms' ? smsBody : emailBody;
-                setValue('messageBody', sanitized(defaultBody));
-                return;
+              if (bodyEdited) {
+                confirm
+                  .showConfirmation(
+                    'Skriv över texten?',
+                    'Att byta mall ersätter den text du har skrivit. Vill du fortsätta?',
+                    'Ja, skriv över',
+                    'Avbryt',
+                    'info',
+                    'info'
+                  )
+                  .then((confirmed) => {
+                    if (confirmed) {
+                      apply();
+                    } else {
+                      setValue('messageTemplate', lastAppliedTemplateRef.current);
+                    }
+                  });
+              } else {
+                apply();
               }
-
-              const content = templates.byId[templateId] || '';
-              const signature = contactMeans === 'sms' ? templates.smsSignature : templates.emailSignature;
-              setValue('messageBody', sanitized(content + signature));
             }}
           >
-            <Select.Option value="">Välj mall</Select.Option>
             {(contactMeans === 'email' ? templates.emailTemplates : templates.smsTemplates)?.map((t) => (
               <Select.Option key={t.identifier} value={t.identifier}>
                 {t.name}
@@ -624,6 +660,7 @@ export const SupportMessageForm: FC<{
                 setValue('messageBody', e.target.value.markup ?? '');
                 setValue('messageBodyPlaintext', e.target.value.plainText ?? '');
                 trigger('messageBody');
+                setBodyEdited(true);
               }}
             />
           </div>

--- a/frontend/src/supportmanagement/components/support-message-form/support-message-form.component.tsx
+++ b/frontend/src/supportmanagement/components/support-message-form/support-message-form.component.tsx
@@ -239,6 +239,7 @@ export const SupportMessageForm: FC<{
     existingAttachments,
     messageBody,
     messageBodyPlaintext,
+    messageTemplate,
   } = watch();
 
   const {
@@ -395,7 +396,15 @@ export const SupportMessageForm: FC<{
       lastAppliedTemplateRef.current = defaultId;
 
       if (!shouldSkipAutoApply(replyContext.setupKey)) {
-        setValue('messageBody', getDefaultMessageBody(templates, replyContext.contactMeans) + replyContext.historyHtml);
+        setValue(
+          'messageBody',
+          buildMessageTemplateBody({
+            templates,
+            templateId: defaultId,
+            means: replyContext.contactMeans,
+            history: replyContext.historyHtml,
+          })
+        );
         setBodyEditedState(false);
       }
       markAutoApplied(replyContext.setupKey);
@@ -603,6 +612,7 @@ export const SupportMessageForm: FC<{
             {...register('messageTemplate')}
             className="w-full text-dark-primary"
             size="sm"
+            value={messageTemplate ?? ''}
             onChange={(e) => {
               const templateId = e.currentTarget.value;
               const apply = () => {

--- a/frontend/src/supportmanagement/components/templates/default-message-template.ts
+++ b/frontend/src/supportmanagement/components/templates/default-message-template.ts
@@ -1,4 +1,5 @@
 import { User } from '@common/interfaces/user';
+import { removeEmailInformation } from '@common/services/message-template-body-service';
 import { getEmailTemplate, getSmsTemplate } from '@supportmanagement/services/message-template-service';
 
 const APP = process.env.NEXT_PUBLIC_APPLICATION || '';
@@ -29,14 +30,4 @@ export async function getDefaultSmsBody(user: User, variant: string = 'default')
   return content;
 }
 
-export function removeEmailInformation(contactMeans: string, template: string): string {
-  let temporaryTemplate = template;
-  if (contactMeans !== 'email' && template.includes('Vänligen ändra inte ämnesraden')) {
-    temporaryTemplate = temporaryTemplate.replace(
-      /Vänligen ändra inte ämnesraden om du svarar på detta meddelande<br><br>?/gi,
-      ''
-    );
-    temporaryTemplate = temporaryTemplate.replace(/Vänligen ändra inte ämnesraden om du besvarar mejlet.<br>?/gi, '');
-  }
-  return temporaryTemplate;
-}
+export { removeEmailInformation };

--- a/frontend/src/supportmanagement/services/message-template-service.ts
+++ b/frontend/src/supportmanagement/services/message-template-service.ts
@@ -17,9 +17,9 @@
 
 import { ApiResponse, apiService } from '@common/services/api-service';
 import { base64Decode } from '@common/services/helper-service';
+import { EMAIL_INFORMATION_TEXT } from '@common/services/message-template-body-service';
 
-export const EMAIL_INFORMATION_TEXT =
-  '<p><b>Vänligen ändra inte ämnesraden om du svarar på detta meddelande.</b></p><br>';
+export { EMAIL_INFORMATION_TEXT };
 
 export interface TemplateApiResponse {
   identifier?: string;

--- a/frontend/src/supportmanagement/services/support-communication-types.ts
+++ b/frontend/src/supportmanagement/services/support-communication-types.ts
@@ -1,0 +1,15 @@
+export const SupportCommunicationType = {
+  Email: 'EMAIL',
+  Sms: 'SMS',
+  WebMessage: 'WEB_MESSAGE',
+  Draken: 'DRAKEN',
+  MinaSidor: 'MINASIDOR',
+} as const;
+
+export type SupportCommunicationType = (typeof SupportCommunicationType)[keyof typeof SupportCommunicationType];
+
+export const isSupportReplyableCommunicationType = (communicationType: SupportCommunicationType): boolean =>
+  communicationType === SupportCommunicationType.Email ||
+  communicationType === SupportCommunicationType.WebMessage ||
+  communicationType === SupportCommunicationType.Draken ||
+  communicationType === SupportCommunicationType.MinaSidor;

--- a/frontend/src/supportmanagement/services/support-message-reply-context-service.ts
+++ b/frontend/src/supportmanagement/services/support-message-reply-context-service.ts
@@ -1,0 +1,33 @@
+import { MessageReplyContext } from '@common/interfaces/message-reply-context';
+import { MessageContactMeans } from '@common/services/message-template-body-service';
+import { sanitizeHtmlMessageBody } from '@common/services/sanitizer-service';
+
+import { SupportCommunicationType } from './support-communication-types';
+import { Message } from './support-message-service';
+
+const communicationTypeToContactMeans: Partial<Record<SupportCommunicationType, MessageContactMeans>> = {
+  [SupportCommunicationType.WebMessage]: 'webmessage',
+  [SupportCommunicationType.Draken]: 'draken',
+  [SupportCommunicationType.MinaSidor]: 'minasidor',
+};
+
+const getReplyContactMeans = (message: Message): MessageContactMeans => {
+  return communicationTypeToContactMeans[message.communicationType] ?? 'email';
+};
+
+export const buildSupportReplyContext = (message: Message): MessageReplyContext => {
+  const contactMeans = getReplyContactMeans(message);
+  const replyTo = message.emailHeaders?.['MESSAGE_ID']?.[0] || '';
+  const references = message.emailHeaders?.['REFERENCES'] || [];
+  const historyHeader = `<br><br>-----Ursprungligt meddelande-----<br>Från: ${message.sender}<br>Skickat: ${message.sent}<br>Till: Sundsvalls kommun<br>Ämne: ${message.subject}<br><br>`;
+  const messageBody = message.htmlMessageBody ? sanitizeHtmlMessageBody(message.htmlMessageBody) : message.messageBody;
+
+  return {
+    contactMeans,
+    headerReplyTo: replyTo,
+    headerReferences: [...references, replyTo].filter(Boolean).join(','),
+    recipients: message.direction === 'OUTBOUND' ? [{ value: message.target }] : [{ value: message.sender }],
+    historyHtml: historyHeader + messageBody,
+    setupKey: `reply:${message.communicationID || ''}:${contactMeans}`,
+  };
+};

--- a/frontend/src/supportmanagement/services/support-message-service.ts
+++ b/frontend/src/supportmanagement/services/support-message-service.ts
@@ -4,8 +4,10 @@ import { toBase64 } from '@common/utils/toBase64';
 import dayjs from 'dayjs';
 import { CCommunicationAttachment } from 'src/data-contracts/backend/data-contracts';
 import { v4 as uuidv4 } from 'uuid';
+
 import { getClosingTemplate } from './message-template-service';
 import { SingleSupportAttachment } from './support-attachment-service';
+import { SupportCommunicationType } from './support-communication-types';
 import { Channels, ContactChannelType, SupportErrand } from './support-errand-service';
 import { applicantContactChannel } from './support-stakeholder-service';
 
@@ -30,7 +32,7 @@ export interface MessageRequest {
 export interface Message {
   communicationAttachments: CCommunicationAttachment[];
   communicationID: string;
-  communicationType: string;
+  communicationType: SupportCommunicationType;
   direction: string;
   errandNumber: string;
   messageBody: string;
@@ -297,12 +299,18 @@ export const buildTree = (_list: Message[]) => {
   );
   list.forEach((msg) => {
     msg.messageBody = msg.messageBody?.replace(/\r\n/g, '<br>');
-    const id = msg.communicationType === 'EMAIL' ? msg.emailHeaders?.['MESSAGE_ID']?.[0] : msg.communicationID;
+    const id =
+      msg.communicationType === SupportCommunicationType.Email
+        ? msg.emailHeaders?.['MESSAGE_ID']?.[0]
+        : msg.communicationID;
     nodesMap.set(id, { ...msg, children: [] });
   });
 
   list.forEach((msg) => {
-    const id = msg.communicationType === 'EMAIL' ? msg.emailHeaders?.['MESSAGE_ID']?.[0] : msg.communicationID;
+    const id =
+      msg.communicationType === SupportCommunicationType.Email
+        ? msg.emailHeaders?.['MESSAGE_ID']?.[0]
+        : msg.communicationID;
     const parent = msg.emailHeaders?.['IN_REPLY_TO']?.[0];
     if (parent) {
       const parentMsg = nodesMap.get(parent);


### PR DESCRIPTION
## Summary

Three small improvements to the "Välj meddelandemall" selector in both the casedata message composer and the supportmanagement message form (the latter shares the `useMessageTemplates` hook with casedata):

- **Pre-select the default template ("Grundmallen")** when the form opens or the contact channel changes. The empty `Välj mall` placeholder option is removed — selecting it produced the same body as the `.default` template (just without the email footer), so the two choices were effectively duplicates.
- **Confirm before overwriting edited text.** If the user has typed in the editor, or the form is in a reply state with quoted history, switching template now triggers a confirmation dialog. Cancelling restores the previously applied template in the dropdown. No prompt when the body is still pristine template content.
- **Exclude `closing`-role templates ("Avslutningsmail")** from the dropdown. The default-fallback already filtered these out; the app-specific (KA/MEX/PT/…) branch and SMS branches did not. Both paths now exclude `closing` consistently for email and SMS.

## Reply ↔ template interaction

Picking a template during a reply used to wipe the quoted history block. The reply citation is now stored in a ref and re-appended whenever a template is applied — so switching templates keeps the `-----Ursprungligt meddelande-----` block intact at the bottom of the body. The default template is now also pre-selected in reply mode.

## Hardening (review follow-ups)

- **Race condition between template-load and reply-body effects** in casedata: the `[contactMeans, templates]` effect would, when templates finished loading after a reply body had been built, call `applyTemplate('')` and overwrite the quoted-history body with `defaultSignature()`. The effect now skips body work entirely when `props.message` is set and lets the reply effect own that state.
- **Stale closure on `contactMeans`** in both forms: when the reply effect did `setValue('contactMeans', messageType)`, downstream code (signature lookup, default template id) read the previous render's `contactMeans` from `watch()`. A local `messageMeans` variable is now used throughout the reply branch.
- **Reply → new message leak** in casedata: closing an email reply left the body with quoted history because `setValue('contactMeans', 'email')` is a no-op when already `'email'` (Effect 1 doesn't re-fire). The else branch now explicitly applies the default template for the new-message channel.
- **Non-email channels regressed to email-default** in casedata: `getDefaultTemplateId('draken'|'webmessage'|'minasidor'|'katla')` used to return an email template id, which then ran through the email branch of `buildTemplateBody`. It now returns `''` for those channels, falling back to `defaultSignature()` (Draken → `internalSignature`; others → email signature without `email_information`).
- **Auto-apply could overwrite typed text** when templates loaded asynchronously: both effects now guard the auto-apply with `bodyEditedRef && lastSetupKey === setupKey`, preserving user edits while still re-applying on real scenario changes (channel switch, different message).
- **Helper ordering**: `defaultSignature`, `getDefaultTemplateId`, `buildTemplateBody` and `applyTemplate` moved above the useEffects. `buildTemplateBody` now takes `history` as a parameter instead of reading `replyHistoryRef` implicitly.

## Files

- `frontend/src/casedata/hooks/useMessageTemplates.ts` — exclude `closing` from app + fallback filters for both email and SMS
- `frontend/src/casedata/components/errand/tabs/messages/message-composer.component.tsx` — default template auto-select, placeholder removal, overwrite confirm, reply citation preservation, race + stale-closure + leak + channel-default fixes, helper reordering
- `frontend/src/supportmanagement/components/support-message-form/support-message-form.component.tsx` — same UX changes plus stale-closure fix and auto-apply guard

## Test plan

- [ ] Open new message in casedata: default template (Grundmallen) is pre-selected, body matches.
- [ ] Switch contact channel (e-post → SMS): default template for the new channel is selected.
- [ ] Type something in the editor → switch template: confirmation appears.
- [ ] Accept confirmation: template is applied, body replaced.
- [ ] Cancel confirmation: dropdown reverts to previous template, body unchanged.
- [ ] Open a reply to an existing message: Grundmall pre-selected, body = template + signature + quoted history.
- [ ] During reply, pick another template: citation block remains at the bottom.
- [ ] Open a reply, close the message view, open it again: quoted history remains intact (no flicker/wipe when templates load).
- [ ] Close an email reply and open a fresh new message: body is the email default template, no citation lingering.
- [ ] Open a new message on Draken channel: body is `internalSignature` (no email content); on webmessage/minasidor: email signature without `email_information`.
- [ ] Open form on slow connection, start typing before templates load: typed text is not wiped when templates arrive.
- [ ] No `closing`/Avslutningsmail entries appear in the dropdown for any app.
- [ ] Repeat the above in the supportmanagement message form.

## Editor onChange / TEXT_CHANGE fix

The `@sk-web-gui/text-editor` wraps Quill's `TEXT_CHANGE` event into a generic `onChange` that fires for *any* change — including the `setValue()` calls we make to populate the body programmatically. That caused `setBodyEditedState(true)` to fire as soon as the reply effect set its initial (templates-loading) body, so when templates finished loading and the effect re-fired, `shouldSkipAutoApply` returned true and the proper template body never replaced the placeholder body. Symptom: dropdown synced to "Grundmall" but the body stayed as the quoted history only.

The bodyEdited flag is now flipped in `onTextChange` (which carries Quill's `source` parameter) and only counts `source === 'user'` as an edit.

Also hardened `getDefaultTemplateId` with two extra detection strategies: prefer metadata `templateRole === 'default'`, fall back to identifier suffix, then to the first available template option. Keeps the dropdown's visual selection in sync with the body content regardless of how an app's templates are named.

- [ ] Verified manually in LoP support form: reply to an email message → dropdown shows Grundmall AND body shows template content + signature + quoted history.
