### PR TITLE
fix: show startdate on contract page

### DIFF
--- a/frontend/src/casedata/components/errand/tabs/contract/contract-form.tsx
+++ b/frontend/src/casedata/components/errand/tabs/contract/contract-form.tsx
@@ -554,6 +554,24 @@ export const ContractForm: FC<{
             <div className="flex flex-col gap-24">
               <div className="flex gap-18 justify-start">
                 <FormControl id="startDate" className="w-full">
+                  <FormLabel>Startdatum</FormLabel>
+                  <Input
+                    type="date"
+                    min={dayjs().format('YYYY-MM-DD')}
+                    readOnly
+                    {...register('startDate')}
+                    data-cy="avtalstid-startdatum"
+                  />
+                  {formState.errors.startDate && (
+                    <div className="my-sm text-error">
+                      <FormErrorMessage>{formState.errors.startDate?.message}</FormErrorMessage>
+                    </div>
+                  )}
+                </FormControl>
+                <div className="w-full"></div>
+              </div>
+              <div className="flex gap-18 justify-start">
+                <FormControl id="currentPeriod.startDate" className="w-full">
                   <FormLabel>Avtalet gäller från</FormLabel>
                   <Input
                     type="date"
@@ -568,7 +586,7 @@ export const ContractForm: FC<{
                     </div>
                   )}
                 </FormControl>
-                <FormControl id="endDate" className="w-full">
+                <FormControl id="currentPeriod.endDate" className="w-full">
                   <FormLabel>Avtalet gäller till och med</FormLabel>
                   <Input
                     type="date"


### PR DESCRIPTION
Startdatum (contract.startDate) bör visas, utöver currentPeriod.startDate och currentPeriod.endDate).

Jira https://jira.sundsvall.se/browse/DRAKEN-3537

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).
