### PR TITLE
fix: preserve personalNumber when editing existing stakeholder

### DIFF
--- a/frontend/cypress/e2e/case-data/pt/errandPage-base-info-tab-pt.cy.ts
+++ b/frontend/cypress/e2e/case-data/pt/errandPage-base-info-tab-pt.cy.ts
@@ -248,5 +248,39 @@ onlyOn(Cypress.env('application_name') === 'PT', () => {
         expect(request.body.contactInformation[1].value).to.equal('test@example.com');
       });
     });
+
+    // https://jira.sundsvall.se/browse/DRAKEN-4258
+    it('keeps personId on the applicant when editing first and last name', () => {
+      const applicant = mockPTErrand_base.data.stakeholders.find((s) => s.roles.includes(Role.APPLICANT));
+      cy.intercept('GET', '**/errand/errandNumber/*', mockPTErrand_base).as('getErrand');
+      cy.intercept(
+        'PATCH',
+        `**/errands/${mockPTErrand_base.data.id}/stakeholders/${applicant?.id}`,
+        mockPTErrand_base
+      ).as('patchErrand');
+
+      visit();
+
+      cy.get('[data-cy="registered-applicants"] [data-cy="rendered-APPLICANT"]').should('exist');
+      cy.get('[data-cy="registered-applicants"] [data-cy="edit-stakeholder-button"]')
+        .first()
+        .should('exist')
+        .click();
+
+      cy.get('[data-cy="contact-firstName"]').should('have.value', applicant?.firstName);
+      cy.get('[data-cy="contact-lastName"]').should('have.value', applicant?.lastName);
+
+      cy.get('[data-cy="contact-firstName"]').clear().type('Annat Förnamn');
+      cy.get('[data-cy="contact-lastName"]').clear().type('Annat Efternamn');
+
+      cy.get('button').contains('Ändra uppgifter').should('exist').click();
+      cy.get('[data-cy="save-and-continue-button"]').should('exist').click();
+
+      cy.wait('@patchErrand').should(({ request }) => {
+        expect(request.body.firstName).to.equal('Annat Förnamn');
+        expect(request.body.lastName).to.equal('Annat Efternamn');
+        expect(request.body.personId).to.equal(applicant?.personId);
+      });
+    });
   });
 });

--- a/frontend/cypress/e2e/case-data/pt/errandPage-base-info-tab-pt.cy.ts
+++ b/frontend/cypress/e2e/case-data/pt/errandPage-base-info-tab-pt.cy.ts
@@ -148,7 +148,6 @@ onlyOn(Cypress.env('application_name') === 'PT', () => {
     });
 
     it('allows editing all fields on an existing contact person if errand was created in web UI', () => {
-      const res = mockPTErrand_base;
       const contact = [
         {
           id: '667',
@@ -192,7 +191,7 @@ onlyOn(Cypress.env('application_name') === 'PT', () => {
           extraParameters: {} as any,
         },
       ];
-      res.data.stakeholders = contact;
+      const res = { ...mockPTErrand_base, data: { ...mockPTErrand_base.data, stakeholders: contact } };
       cy.intercept('GET', '**/errand/errandNumber/*', res).as('getErrand');
       cy.intercept(
         'PATCH',
@@ -249,7 +248,6 @@ onlyOn(Cypress.env('application_name') === 'PT', () => {
       });
     });
 
-    // https://jira.sundsvall.se/browse/DRAKEN-4258
     it('keeps personId on the applicant when editing first and last name', () => {
       const applicant = mockPTErrand_base.data.stakeholders.find((s) => s.roles.includes(Role.APPLICANT));
       cy.intercept('GET', '**/errand/errandNumber/*', mockPTErrand_base).as('getErrand');

--- a/frontend/src/casedata/components/errand/forms/simplified-contact-form.component.tsx
+++ b/frontend/src/casedata/components/errand/forms/simplified-contact-form.component.tsx
@@ -2,7 +2,6 @@ import { ContactModal } from '@casedata/components/errand/forms/contact-modal.co
 import { Channels } from '@casedata/interfaces/channels';
 import { Role } from '@casedata/interfaces/role';
 import { CasedataOwnerOrContact } from '@casedata/interfaces/stakeholder';
-import { useCasedataStore } from '@stores/index';
 import { isValidOrgNumber } from '@common/services/adress-service';
 import {
   invalidOrgNumberMessage,
@@ -17,6 +16,7 @@ import {
 import { appConfig } from '@config/appconfig';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Button, FormControl, Input } from '@sk-web-gui/react';
+import { useCasedataStore } from '@stores/index';
 import { Pen } from 'lucide-react';
 import { FC, useEffect, useState } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
@@ -260,7 +260,8 @@ export const SimplifiedContactForm: FC<{
 
   useEffect(() => {
     if (
-      (manual || editing) &&
+      manual &&
+      !editing &&
       (formState.dirtyFields?.firstName || formState.dirtyFields?.lastName || formState.dirtyFields?.organizationName)
     ) {
       resetPersonNumber();

--- a/frontend/src/supportmanagement/components/new-contacts/support-simplified-contact-form.component.tsx
+++ b/frontend/src/supportmanagement/components/new-contacts/support-simplified-contact-form.component.tsx
@@ -12,9 +12,9 @@ import {
   usernamePattern,
 } from '@common/services/helper-service';
 import { appConfig } from '@config/appconfig';
-import { useConfigStore, useMetadataStore } from '@stores/index';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Button, FormControl, Input } from '@sk-web-gui/react';
+import { useConfigStore, useMetadataStore } from '@stores/index';
 import {
   emptyContact,
   ExternalIdType,
@@ -227,7 +227,8 @@ export const SupportSimplifiedContactForm: FC<{
 
   useEffect(() => {
     if (
-      (manual || editing) &&
+      manual &&
+      !editing &&
       (formState.dirtyFields?.firstName || formState.dirtyFields?.lastName || formState.dirtyFields?.organizationName)
     ) {
       resetPersonNumber();


### PR DESCRIPTION
## Summary
- The `resetPersonNumber` effect in both `simplified-contact-form.component.tsx` (casedata) and `support-simplified-contact-form.component.tsx` (support) cleared `personalNumber`/`personId` whenever `firstName`, `lastName` or `organizationName` changed — also in `editing` mode.
- When the case owner's name was edited and "Ändra uppgifter" was clicked, the identifier was wiped on the stakeholder, blocking adding services and moving to decision (Drake had a remove-and-re-add workaround, Katla did not).
- Gate the reset on `manual && !editing` to match the sibling effect at the top of the same form. Identifiers are still cleared when starting a fresh manual add but preserved when correcting names on an already registered stakeholder.


https://jira.sundsvall.se/browse/DRAKEN-4258