### PR TITLE
fix: tillåt redigering av Slutdatum på uppsägningsärenden med autoExtend

### DIFF
--- a/frontend/src/casedata/components/errand/tabs/contract/contract-form.tsx
+++ b/frontend/src/casedata/components/errand/tabs/contract/contract-form.tsx
@@ -793,14 +793,7 @@ export const ContractForm: FC<{
               </FormControl>
               <FormControl id="endDate" className="w-full">
                 <FormLabel>Slutdatum</FormLabel>
-                <Input
-                  type="date"
-                  readOnly={
-                    !isEditable('cancellation') || watch().extension?.autoExtend || !watch().currentPeriod?.endDate
-                  }
-                  {...register('endDate')}
-                  data-cy="endDate"
-                />
+                <Input type="date" readOnly={!isEditable('cancellation')} {...register('endDate')} data-cy="endDate" />
               </FormControl>
             </div>
             <div className="flex gap-18 justify-start">


### PR DESCRIPTION
## Sammanfattning
- Slutdatum-fältet i sektionen "Uppsägning anmälan" på Avtal-fliken var låst (`readOnly`) när avtalet hade `extension.autoExtend = true` eller saknade `currentPeriod.endDate` — exakt det scenario man behöver fältet för.
- Resultat: går inte att registrera ett uppsägningsdatum på ett auto-förlängande avtal (t.ex. MEX-2026-000410).
- Tar bort `autoExtend`- och `!currentPeriod.endDate`-villkoren. Slutdatum är nu redigerbart så länge användaren har redigeringsrätt för cancellation-sektionen.

## Fråga till granskare
Sektionen visas redan bara för `UPDATECONTRACT`, `MEX_TERMINATION_OF_LEASE` och `contractOveriewMode`, så jag tog bort `autoExtend`-villkoret helt istället för att gatra det per case-typ. Är det rätt nivå, eller ska vi behålla `autoExtend`-spärren för t.ex. `UPDATECONTRACT` och bara släppa den för `MEX_TERMINATION_OF_LEASE`?

## Testplan
- [ ] Öppna MEX-2026-000410 (test) → Avtal-fliken → "Uppsägning anmälan"
- [ ] Verifiera att Slutdatum-fältet går att fylla i trots att avtalet har `autoExtend: true`
- [ ] Spara och verifiera att värdet persisteras

https://jira.sundsvall.se/browse/DRAKEN-4221