### PR TITLE
fix: save organization partyId under stakeholder personId field

### DIFF
--- a/frontend/cypress/e2e/kontaktcenter/errandPage-base-info-tab-kc.cy.ts
+++ b/frontend/cypress/e2e/kontaktcenter/errandPage-base-info-tab-kc.cy.ts
@@ -33,6 +33,7 @@ import {
   supportManagementPersonSearch,
 } from '../utils/stakeholder-search-cy';
 import { mockStakeholderStatus } from './fixtures/mockStakeholderStatus';
+import { mockResolvedRelations } from '../case-data/fixtures/mockRelations';
 
 onlyOn(Cypress.env('application_name') === 'KC', () => {
   describe('Errand page', () => {
@@ -66,6 +67,8 @@ onlyOn(Cypress.env('application_name') === 'KC', () => {
       );
       cy.intercept('GET', '**/sourcerelations/**/**', mockRelations).as('getSourceRelations');
       cy.intercept('GET', '**/targetrelations/**/**', mockRelations).as('getTargetRelations');
+      cy.intercept('GET', '**/resolvedrelations/**/**', mockResolvedRelations).as('getResolvedRelations');
+      cy.intercept('GET', '**/relations/referredfrom/**', mockRelations).as('getReferredfromRelations');
       cy.intercept('GET', '**/namespace/errands/**/communication/conversations', mockConversations).as(
         'getConversations'
       );

--- a/frontend/src/common/services/adress-service.ts
+++ b/frontend/src/common/services/adress-service.ts
@@ -260,7 +260,7 @@ export const searchOrganization: (orgNr: string) => Promise<AddressResult | unde
               street: res.address.addressArea,
             };
             return {
-              personId: '',
+              personId: res.partyId,
               firstName: '',
               lastName: '',
               organizationName: res.name,

--- a/frontend/src/supportmanagement/components/new-contacts/support-contact-search-field.component.tsx
+++ b/frontend/src/supportmanagement/components/new-contacts/support-contact-search-field.component.tsx
@@ -82,7 +82,9 @@ export const SupportContactSearchField: FC<SupportSearchFieldProps> = ({
             return;
           }
           if (!isArray(res)) {
-            form.setValue(`externalId`, res.personId, { shouldDirty: true });
+            if (searchMode === 'person' || searchMode === 'employee') {
+              form.setValue(`externalId`, res.personId, { shouldDirty: true });
+            }
             form.setValue(`firstName`, res.firstName, { shouldDirty: true });
             form.setValue(`lastName`, res.lastName, { shouldDirty: true });
             form.setValue(`organizationName`, res.organizationName, {


### PR DESCRIPTION
Problem: partyId sparas inte för organisationsstakeholders på ärenden, och när man lägger till en sådan stakeholder som part på ett avtal i MEX och försöker spara så får man ett felmeddelande pga felaktigt partyId i Contract.

Lösning: när adressinfo hämtas för organisationsstakeholdern så ska partyId sparas under fältet personId. Frontend ska sedan spara detta på stakeholdern på lämpligt sätt. I Casedata blir detta fältet personId på stakeholdern. I Supportmanagement finns inget fält för detta utan bara externalId där redan orgnumret sparas. Så för supportmanagement kan vi inte spara både partyId och orgnummer. Om detta behövs i framtiden behöver vi justera hanteringen.

Jira https://jira.sundsvall.se/browse/DRAKEN-4278

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
