### PR TITLE
fix: route decision messages via Katla and digital mail instead of OpenE

### DIFF
--- a/backend/src/controllers/message.controller.ts
+++ b/backend/src/controllers/message.controller.ts
@@ -7,7 +7,6 @@ import {
   sendDecisionToDigitalMail,
   sendDecisionToKatla,
   sendDecisionToMinaSidor,
-  sendDecisionToOpenE,
   sendEmail,
   sendSms,
   sendWebMessage,
@@ -63,14 +62,10 @@ export class MessageController {
     }
 
     const minasidor_success = await sendDecisionToMinaSidor(baseURL, errandData.data.id!.toString(), req.user, pdf);
-    if (errandData.data.externalCaseId) {
-      const openE_success = await sendDecisionToOpenE(errandData.data, req.user, pdf);
-      return [minasidor_success, openE_success];
-    } else {
-      const katla_success = await sendDecisionToKatla(baseURL, errandData.data, req.user, pdf);
-      const digitalMail_success = await sendDecisionToDigitalMail(errandData.data, req.user, pdf);
-      return [minasidor_success, katla_success, digitalMail_success];
-    }
+    const katla_success = await sendDecisionToKatla(baseURL, errandData.data, req.user, pdf);
+    const digitalMail_success = await sendDecisionToDigitalMail(errandData.data, req.user, pdf);
+
+    return [minasidor_success, katla_success, digitalMail_success];
   }
 
   @Post('/casedata/:municipalityId/sms')

--- a/backend/src/services/message.service.ts
+++ b/backend/src/services/message.service.ts
@@ -457,62 +457,6 @@ export const sendDecisionToKatla = async (baseURL: string, errand: ErrandDTO, us
     });
 };
 
-export const sendDecisionToOpenE = (errand: ErrandDTO, user: User, pdf: Attachment) => {
-  const url = `${MESSAGING_SERVICE}/${MUNICIPALITY_ID}/webmessage`;
-  const apiService = new ApiService();
-
-  const attachments = [
-    {
-      base64Data: pdf.file,
-      fileName: `${pdf.name}.pdf`,
-      mimeType: pdf.mimeType,
-    } as WebMessageAttachment,
-  ];
-  const message: WebMessageRequest = {
-    party: {
-      partyId: getOwnerStakeholder(errand)?.personId,
-      externalReferences: [
-        {
-          key: 'flowInstanceId',
-          value: errand.externalCaseId,
-        },
-      ],
-    },
-    message: 'Beslut fattat i ärende',
-    attachments,
-  } as WebMessageRequest;
-
-  return apiService
-    .post<AgnosticMessageResponse, WebMessageRequest>({ url, data: message }, user)
-    .then(async (res: ApiResponse<AgnosticMessageResponse>) => {
-      return saveMessageOnErrand(
-        MUNICIPALITY_ID!,
-        errand,
-        {
-          message: message.message,
-          id: res.data.messageId,
-          messageType: 'WEBMESSAGE',
-          messageClassification: MessageClassification.Informationsmeddelande,
-          header_message_Id: '',
-          header_reply_to: '',
-          header_references: '',
-        },
-        user,
-      )
-        .then(async _ => {
-          return { data: res.data, message: `Message sent to OpenE` };
-        })
-        .catch(e => {
-          logger.error('Error when saving message id:', e);
-          return { data: res.data, message: `Message to OpenE sent but id could not be stored` };
-        });
-    })
-    .catch(e => {
-      logger.error('Error when sending message to OpenE:', e);
-      throw e;
-    });
-};
-
 export const sendDecisionToDigitalMail = (errand: ErrandDTO, user: User, pdf: Attachment) => {
   const url = `${MESSAGING_SERVICE}/${MUNICIPALITY_ID}/letter?async=false`;
   const apiService = new ApiService();


### PR DESCRIPTION
## Vad

Tar bort routing av beslut till OpenE. Tidigare skickades beslut till OpenE när ärendet hade ett `externalCaseId`, annars till Katla + digital post. Nu går beslut alltid via **Mina sidor + Katla + digital post**, oavsett `externalCaseId`.

## Ändringar

- `message.controller.ts`: tar bort `if (externalCaseId)`-grenen i `sendDecision`; alltid `sendDecisionToMinaSidor` + `sendDecisionToKatla` + `sendDecisionToDigitalMail`.
- `message.service.ts`: tar bort den nu oanvända `sendDecisionToOpenE`-hjälparen.

## Beteendeförändring

Ärenden med `externalCaseId` får inte längre sitt beslut skickat som webmessage till OpenE — de följer nu samma väg som övriga ärenden. Inga tester refererar den borttagna vägen.
