### PR TITLE
feat(casedata): centralize decision message sending in backend for MEX and PT

### DIFF
--- a/backend/src/controllers/message.controller.ts
+++ b/backend/src/controllers/message.controller.ts
@@ -4,6 +4,7 @@ import { validationMiddleware } from '@middlewares/validation.middleware';
 import ApiService from '@services/api.service';
 import {
   generateMessageId,
+  sendDecisionForMex,
   sendDecisionToDigitalMail,
   sendDecisionToKatla,
   sendDecisionToMinaSidor,
@@ -23,7 +24,7 @@ import { Errand as ErrandDTO, MessageResponse as IMessageResponse } from '@/data
 import { EmailAttachment, EmailRequest, SmsRequest, WebMessageAttachment, WebMessageRequest } from '@/data-contracts/messaging/data-contracts';
 import { AgnosticMessageResponse, DecisionMessageDto, MessageClassification, MessageDto, MessageResponse, SmsDto } from '@/dtos/message.dto';
 import { HttpException } from '@/exceptions/HttpException';
-import { isPT } from '@/services/application.service';
+import { isMEX, isPT } from '@/services/application.service';
 import { logger } from '@/utils/logger';
 import { apiURL, base64Encode } from '@/utils/util';
 
@@ -43,12 +44,21 @@ export class MessageController {
   async decisionMessage(
     @Req() req: RequestWithUser,
     @Param('municipalityId') municipalityId: string,
-    @Body() messageDto: { errandId: string },
+    @Body() messageDto: DecisionMessageDto,
   ): Promise<{ data: AgnosticMessageResponse; message: string }[]> {
     const baseURL = apiURL(this.SERVICE);
 
     const errandsUrl = `${municipalityId}/${process.env.CASEDATA_NAMESPACE}/errands/${messageDto.errandId}`;
     const errandData = await this.apiService.get<ErrandDTO>({ url: errandsUrl, baseURL }, req.user);
+
+    if (isMEX()) {
+      return [await sendDecisionForMex(municipalityId, req, errandData, messageDto.html ?? '', messageDto.plaintext ?? '')];
+    }
+
+    // PT Ånge (2260) sends decisions manually outside Draken.
+    if (municipalityId === '2260') {
+      return [];
+    }
 
     const decision = errandData.data?.decisions?.find(d => d.decisionType === 'FINAL');
     const pdf = decision?.attachments?.[0];

--- a/backend/src/dtos/message.dto.ts
+++ b/backend/src/dtos/message.dto.ts
@@ -59,6 +59,16 @@ export class SmsDto {
 export class DecisionMessageDto {
   @IsString()
   errandId!: string;
+
+  // Pre-rendered decision body used by MEX (email uses html, webmessage uses plaintext).
+  // PT ignores these and attaches the saved decision PDF instead.
+  @IsString()
+  @IsOptional()
+  html?: string;
+
+  @IsString()
+  @IsOptional()
+  plaintext?: string;
 }
 
 export class MessageResponse implements IMessageResponse {

--- a/backend/src/services/message.service.ts
+++ b/backend/src/services/message.service.ts
@@ -31,11 +31,12 @@ import {
   WebMessageAttachment,
   WebMessageRequest,
 } from '@/data-contracts/messaging/data-contracts';
+import { HttpException } from '@/exceptions/HttpException';
 import { RequestWithUser } from '@/interfaces/auth.interface';
-import { apiURL, base64ToByteArray } from '@/utils/util';
+import { apiURL, base64Encode, base64ToByteArray } from '@/utils/util';
 
 import ApiService, { ApiResponse } from './api.service';
-import { getOwnerStakeholder } from './stakeholder.service';
+import { getOwnerStakeholder, getOwnerStakeholderEmail } from './stakeholder.service';
 
 interface SmsMessage {
   party?: {
@@ -523,4 +524,55 @@ export const sendDecisionToDigitalMail = (errand: ErrandDTO, user: User, pdf: At
       logger.error('Error when sending digital mail:', e);
       throw e;
     });
+};
+
+// Sends a MEX decision through a single channel, chosen the same way the frontend used to choose it:
+// webmessage for e-service errands, otherwise email to the owner. The decision body is rendered by
+// the frontend and passed in (html for email, plaintext for webmessage).
+export const sendDecisionForMex = async (
+  municipalityId: string,
+  req: RequestWithUser,
+  errandData: ApiResponse<ErrandDTO>,
+  html: string,
+  plaintext: string,
+): Promise<{ data: AgnosticMessageResponse; message: string }> => {
+  const errand = errandData.data;
+
+  if (errand.externalCaseId) {
+    const owner = getOwnerStakeholder(errand);
+    const message = {
+      party: {
+        ...(owner?.personId && { partyId: owner.personId }),
+        externalReferences: [{ key: 'flowInstanceId', value: errand.externalCaseId }],
+      },
+      message: plaintext,
+    } as WebMessageRequest;
+    return sendWebMessage(municipalityId, message, req, errandData);
+  }
+
+  const ownerEmail = getOwnerStakeholderEmail(errand);
+  if (ownerEmail) {
+    const cleanedBody = html.replace(/<p><br \/><\/p>/g, '');
+    const message = {
+      party: {
+        // Fake uuid since Messaging demands one
+        partyId: uuidv4(),
+      },
+      emailAddress: ownerEmail,
+      subject: `Ärende #${errand.errandNumber}`,
+      message: cleanedBody,
+      htmlMessage: base64Encode(cleanedBody),
+      sender: {
+        name: process.env.CASEDATA_SENDER,
+        address: process.env.CASEDATA_SENDER_EMAIL,
+        replyTo: process.env.CASEDATA_REPLY_TO,
+      },
+      headers: {
+        MESSAGE_ID: [generateMessageId()],
+      },
+    } as EmailRequest;
+    return sendEmail(municipalityId, message, req, errandData, MessageClassification.Informationsmeddelande);
+  }
+
+  throw new HttpException(400, 'Ärendeägaren har inga godkända kontaktsätt');
 };

--- a/frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx
@@ -31,20 +31,14 @@ import {
   validateErrandForDecision,
   validateStatusForDecision,
 } from '@casedata/services/casedata-errand-service';
-import { sendDecisionMessage, sendMessage } from '@casedata/services/casedata-message-service';
-import {
-  getOwnerStakeholder,
-  validateOwnerForSendingDecision,
-  validateOwnerForSendingDecisionByEmail,
-  validateOwnerForSendingDecisionByLetter,
-} from '@casedata/services/casedata-stakeholder-service';
+import { sendDecisionMessage } from '@casedata/services/casedata-message-service';
+import { getOwnerStakeholder, validateOwnerForSendingDecision } from '@casedata/services/casedata-stakeholder-service';
 import { getErrandContract } from '@casedata/services/contract-service';
 import { triggerErrandPhaseChange } from '@casedata/services/process-service';
 import TextEditor from '@common/components/dynamic-text-editor';
 import { getLatestRjsfSchema } from '@common/components/json/utils/schema-utils';
 import { TemplatePdfPreview } from '@common/components/template-preview/template-pdf-preview.component';
 import { Law } from '@common/data-contracts/case-data/data-contracts';
-import { MessageClassification } from '@common/interfaces/message';
 import { Template } from '@common/interfaces/template';
 import { isMEX, isPT } from '@common/services/application-service';
 import { base64Decode } from '@common/services/helper-service';
@@ -74,12 +68,9 @@ import { FC, useEffect, useMemo, useRef, useState } from 'react';
 import { Resolver, useForm } from 'react-hook-form';
 import * as yup from 'yup';
 
-import { CasedataMessageTabFormModel } from '../messages/message-composer.component';
 import { ServiceListComponent } from '../services/casedata-service-list.component';
 import { useErrandServices } from '../services/useErrandService';
 import { SendDecisionDialogComponent } from './send-decision-dialog.component';
-
-export type ContactMeans = 'webmessage' | 'email' | 'digitalmail' | false;
 
 export interface DecisionFormModel {
   id?: string;
@@ -353,54 +344,13 @@ export const CasedataDecisionTab: FC<{
       await saveDecision(municipalityId, errand, data, 'FINAL', rendered.pdfBase64);
 
       const renderedHtml = await renderHtml(errand, data, 'decision');
-      const owner = getOwnerStakeholder(errand);
-      const recipientEmail = owner?.emails?.[0]?.value;
-      const contactMeans: ContactMeans = errand.externalCaseId
-        ? 'webmessage'
-        : validateOwnerForSendingDecisionByEmail(errand)
-        ? 'email'
-        : validateOwnerForSendingDecisionByLetter(errand)
-        ? 'digitalmail'
-        : false;
-      if (contactMeans === 'email' && !recipientEmail) {
-        throw new Error('Ingen e-postadress för mottagare hittades');
-      }
-      if (!contactMeans) {
-        toastMessage({
-          position: 'bottom',
-          closeable: false,
-          message: 'Ärendeägaren har inga godkända kontaktsätt',
-          status: 'error',
-        });
-        return;
-      }
-      const messageData: CasedataMessageTabFormModel = {
-        contactMeans,
-        messageClassification: MessageClassification.Informationsmeddelande,
-        emails: [{ value: recipientEmail }],
-        newEmail: '',
-        phoneNumbers: [],
-        newPhoneNumber: '',
-        messageAttachments: [],
-        messageBody: base64Decode(renderedHtml.htmlBase64),
-        messageBodyPlaintext: data.descriptionPlaintext,
-        attachUtredning: false,
-        existingAttachments: [],
-        addExisting: '',
-        newAttachments: [],
-        newItem: undefined,
-        headerReplyTo: '',
-        headerReferences: '',
-      };
-      if (isMEX()) {
-        await sendMessage(municipalityId, errand, messageData);
-      } else if (isPT() && municipalityId === '2260') {
-        // PT Ånge - do nothing, they handle sending themselves
-      } else if (isPT()) {
-        await sendDecisionMessage(municipalityId, errand);
-      } else {
-        throw new Error('Kontaktsätt saknas');
-      }
+      // Channel selection and sending is handled by the backend for both MEX and PT.
+      await sendDecisionMessage(
+        municipalityId,
+        errand,
+        base64Decode(renderedHtml.htmlBase64),
+        data.descriptionPlaintext
+      );
       await updateErrandStatus(municipalityId, errand.id.toString(), ErrandStatus.Beslutad);
       const drafts = await getDraftAssets({
         municipalityId,

--- a/frontend/src/casedata/services/casedata-message-service.ts
+++ b/frontend/src/casedata/services/casedata-message-service.ts
@@ -13,21 +13,28 @@ import { UploadFile } from '@sk-web-gui/react';
 import dayjs from 'dayjs';
 import { MessageResponse } from 'src/data-contracts/backend/data-contracts';
 
-export const sendDecisionMessage: (municipalityId: string, errand: IErrand) => Promise<boolean> = (
-  municipalityId,
-  errand
-) => {
+export const sendDecisionMessage: (
+  municipalityId: string,
+  errand: IErrand,
+  html: string,
+  plaintext: string
+) => Promise<boolean> = (municipalityId, errand, html, plaintext) => {
   return apiService
-    .post<ApiResponse<MessageResponse>[], { errandId: string }>(`casedata/${municipalityId}/message/decision`, {
-      errandId: errand.id.toString(),
-    })
+    .post<ApiResponse<MessageResponse>[], { errandId: string; html: string; plaintext: string }>(
+      `casedata/${municipalityId}/message/decision`,
+      {
+        errandId: errand.id.toString(),
+        html,
+        plaintext,
+      }
+    )
     .then((res) => {
       const allSuccess = res.data.every((c) => c?.data?.messageId);
       if (allSuccess) return true;
       throw new Error('Not all channels returned a messageId');
     })
-    .catch(() => {
-      throw new Error('Något gick fel när beslutet skulle skickas');
+    .catch((e) => {
+      throw new Error(e?.response?.data?.message || 'Något gick fel när beslutet skulle skickas');
     });
 };
 


### PR DESCRIPTION
## Bakgrund

Beslutsutskicket hanterades olika beroende på ärendetyp: för **MEX** valdes kanal och skickades helt i frontend (`casedata-decision-tab`), medan **PT** delegerade till backend. Den här uppdelningen gjorde flödet svårt att följa. DRAKEN-4309 samlar all kanal-logik på ett ställe.

## Ändring

All kanalval och utskick av beslut sker nu i backend-endpointen `POST /casedata/:municipalityId/message/decision` för **både MEX och PT**. Frontend renderar beslutsdokumentet (PDF + html/plaintext) och delegerar routingen.

### Backend
- `DecisionMessageDto` tar emot valfria `html`/`plaintext` (används av MEX; PT bifogar den sparade besluts-PDF:en som tidigare).
- Ny `sendDecisionForMex` väljer kanal **exakt** som frontend gjorde: webmessage för e-tjänsteärenden (`externalCaseId`), annars e-post till ägaren. Återanvänder befintliga `sendWebMessage`/`sendEmail`.
- PT Ånge-undantaget (kommun `2260`, skickas manuellt) flyttat in i endpointen.
- PT:s Mina sidor/OpenE/Katla/Digital post-routing är oförändrad.

### Frontend
- `casedata-decision-tab`: hela `isMEX()/isPT()`-branschningen + `contactMeans`-logiken + `messageData`-bygget ersatt av ett anrop till `sendDecisionMessage`. Oanvända importer och typen `ContactMeans` borttagna.
- `sendDecisionMessage(municipalityId, errand, html, plaintext)` skickar med den renderade kroppen och ytan-visar nu backendens felmeddelande.

## Funktionellt resultat
- **MEX webmessage & e-post:** identiskt mot tidigare (samma innehåll, mottagare och subject).
- **PT (inkl. Ånge):** oförändrat.
- **MEX utan e-post men med personId:** denna väg felade redan tidigare (utskick till tom adress → generiskt fel). Den ger nu ett tydligt `400 "Ärendeägaren har inga godkända kontaktsätt"`. Samma utfall (inget skickas), tydligare meddelande. Riktigt brevutskick för MEX är en separat feature.

https://jira.sundsvall.se/browse/DRAKEN-4309