### PR TITLE
feat(casedata): consolidate PT/FT/RFT investigation templates into one

### DIFF
--- a/frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx
@@ -855,31 +855,35 @@ export const CasedataDecisionTab: FC<{
         <Input data-cy="decision-description-input" type="hidden" {...register('description')} />
         <Input type="hidden" {...register('errandId')} />
 
-        {!isMEX() && (
-          <TemplatePdfPreview identifier={selectedTemplate?.identifier} parameters={buildTemplateParameters()} />
-        )}
-
-        <div className={cx('h-[48rem] overflow-hidden')} data-cy="decision-richtext-wrapper">
-          <TextEditor
-            className={cx('mb-md h-[80%] max-w-[95.9rem]')}
-            readOnly={isErrandLocked(errand) || isSent()}
-            onChange={(e) => {
-              setValue('description', e.target.value.markup ?? '', {
-                shouldDirty: true,
-                shouldValidate: true,
-              });
-              setValue('descriptionPlaintext', e.target.value.plainText ?? '', {
-                shouldValidate: true,
-              });
-            }}
-            value={{ markup: description, plainText: descriptionPlaintext }}
-          />
-        </div>
-        <div className="my-sm text-error">
-          {errors.description && formState.isDirty && (
-            <FormErrorMessage>{errors.description?.message}</FormErrorMessage>
-          )}
-        </div>
+        <Disclosure variant="alt" data-cy="decision-text-disclosure" initalOpen className="mb-24">
+          <Disclosure.Header>
+            <Disclosure.Title>Beslutstext</Disclosure.Title>
+            <Disclosure.Button />
+          </Disclosure.Header>
+          <Disclosure.Content>
+            <div className={cx('h-[48rem] overflow-hidden')} data-cy="decision-richtext-wrapper">
+              <TextEditor
+                className={cx('mb-md h-[80%] max-w-[95.9rem]')}
+                readOnly={isErrandLocked(errand) || isSent()}
+                onChange={(e) => {
+                  setValue('description', e.target.value.markup ?? '', {
+                    shouldDirty: true,
+                    shouldValidate: true,
+                  });
+                  setValue('descriptionPlaintext', e.target.value.plainText ?? '', {
+                    shouldValidate: true,
+                  });
+                }}
+                value={{ markup: description, plainText: descriptionPlaintext }}
+              />
+            </div>
+            <div className="my-sm text-error">
+              {errors.description && formState.isDirty && (
+                <FormErrorMessage>{errors.description?.message}</FormErrorMessage>
+              )}
+            </div>
+          </Disclosure.Content>
+        </Disclosure>
 
         {showApprovedServices && (
           <div className="pb-20">
@@ -912,6 +916,10 @@ export const CasedataDecisionTab: FC<{
               </Alert.Content>
             </Alert>
           </div>
+        )}
+
+        {!isMEX() && (
+          <TemplatePdfPreview identifier={selectedTemplate?.identifier} parameters={buildTemplateParameters()} />
         )}
 
         <div className="flex justify-start gap-md">

--- a/frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx
@@ -907,16 +907,25 @@ export const CasedataDecisionTab: FC<{
         )}
         {showNoServicesInfo && (
           <div className="pb-20">
-            <Alert type="info" data-cy="decision-services-info-alert">
-              <Alert.Icon />
-              <Alert.Content>
-                <Alert.Content.Title>Inga insatser kommer att fattas</Alert.Content.Title>
-                <Alert.Content.Description>
-                  Insatser tilldelas endast vid bifall. Med detta utfall registreras inga insatser på ärendet när
-                  beslutet skickas.
-                </Alert.Content.Description>
-              </Alert.Content>
-            </Alert>
+            <Disclosure variant="alt" data-cy="decision-no-services-disclosure" initalOpen>
+              <Disclosure.Header>
+                <Disclosure.Icon icon={<HandHelping size={18} />} />
+                <Disclosure.Title>Insatser</Disclosure.Title>
+                <Disclosure.Button />
+              </Disclosure.Header>
+              <Disclosure.Content>
+                <Alert type="info" data-cy="decision-services-info-alert">
+                  <Alert.Icon />
+                  <Alert.Content>
+                    <Alert.Content.Title>Inga insatser kommer att fattas</Alert.Content.Title>
+                    <Alert.Content.Description>
+                      Insatser tilldelas endast vid bifall. Med detta utfall registreras inga insatser på ärendet när
+                      beslutet skickas.
+                    </Alert.Content.Description>
+                  </Alert.Content>
+                </Alert>
+              </Disclosure.Content>
+            </Disclosure>
           </div>
         )}
 

--- a/frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx
@@ -69,7 +69,7 @@ import {
 } from '@sk-web-gui/react';
 import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
 import dayjs from 'dayjs';
-import { Download, SendHorizontal } from 'lucide-react';
+import { Download, Gavel, HandHelping, SendHorizontal } from 'lucide-react';
 import { FC, useEffect, useMemo, useRef, useState } from 'react';
 import { Resolver, useForm } from 'react-hook-form';
 import * as yup from 'yup';
@@ -857,6 +857,7 @@ export const CasedataDecisionTab: FC<{
 
         <Disclosure variant="alt" data-cy="decision-text-disclosure" initalOpen className="mb-24">
           <Disclosure.Header>
+            <Disclosure.Icon icon={<Gavel size={18} />} />
             <Disclosure.Title>Beslutstext</Disclosure.Title>
             <Disclosure.Button />
           </Disclosure.Header>
@@ -889,6 +890,7 @@ export const CasedataDecisionTab: FC<{
           <div className="pb-20">
             <Disclosure variant="alt" data-cy="decision-services-disclosure" initalOpen>
               <Disclosure.Header>
+                <Disclosure.Icon icon={<HandHelping size={18} />} />
                 <Disclosure.Title>
                   <span className="flex items-center gap-12">
                     <span>Insatser som bifalls</span>

--- a/frontend/src/casedata/components/errand/tabs/investigation/casedata-investigation-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/investigation/casedata-investigation-tab.tsx
@@ -365,7 +365,6 @@ export const CasedataInvestigationTab: FC<{
               </>
             )}
           </div>
-          <TemplatePdfPreview identifier={previewTemplate.identifier} parameters={previewTemplate.parameters} />
           <Input type="hidden" {...register('id')} />
           <Input data-cy="utredning-description-input" type="hidden" {...register('description')} />
           <Input type="hidden" {...register('errandNumber')} />
@@ -410,6 +409,7 @@ export const CasedataInvestigationTab: FC<{
               </Disclosure>
             );
           })()}
+          <TemplatePdfPreview identifier={previewTemplate.identifier} parameters={previewTemplate.parameters} />
           <div className="flex justify-left gap-10">
             <Button
               data-cy="save-utredning-button"

--- a/frontend/src/casedata/services/casedata-decision-service.ts
+++ b/frontend/src/casedata/services/casedata-decision-service.ts
@@ -305,6 +305,15 @@ export const mapServicesToTemplateParams = (services: Service[]): Record<string,
   });
 };
 
+// Heading per case-type family for sbk.investigation. Parking permit has no heading; the empty value
+// makes the template's conditional block render nothing (content-neutral for PT). National before FT:
+// FTNationalCaseTypes is a subset of FTCaseType.
+const getInvestigationDocumentTitle = (errand: IErrand): string => {
+  if (isFTNationalErrand(errand)) return 'Riksfärdtjänst';
+  if (isFTErrand(errand)) return 'Färdtjänst';
+  return '';
+};
+
 export const buildPdfTemplate: (
   errand: IErrand,
   formData: UtredningFormModel | DecisionFormModel,
@@ -328,12 +337,17 @@ export const buildPdfTemplate: (
   let identifier = `mex.decision`;
   let capacity = '';
 
+  // RPH cancellation uses the decision template even from the investigation tab.
+  const isRphCancellation = isPT() && !isFTErrand(errand) && !isFTNationalErrand(errand) && outcome === 'cancellation';
+
   if (isMEX()) {
     identifier = `mex.decision`;
+  } else if (isPT() && templateType === 'investigation' && !isRphCancellation) {
+    identifier = 'sbk.investigation';
   } else if (isPT() && isFTNationalErrand(errand)) {
-    identifier = templateType === 'investigation' ? 'sbk.rft.investigation' : `sbk.rft.decision.${outcome}`;
+    identifier = `sbk.rft.decision.${outcome}`;
   } else if (isPT() && isFTErrand(errand)) {
-    identifier = templateType === 'investigation' ? 'sbk.ft.investigation' : `sbk.ft.decision.${outcome}`;
+    identifier = `sbk.ft.decision.${outcome}`;
   } else if (isPT()) {
     const extraParametersCapacity = errand.extraParameters?.find(
       (parameter) => parameter.key === 'application.applicant.capacity'
@@ -378,6 +392,9 @@ export const buildPdfTemplate: (
     parameters['creationDate'] = dayjs(decision?.created).format('YYYY-MM-DD');
     parameters['disabilityReason'] =
       errand.extraParameters.find((p) => p.key === 'application.reason')?.values?.[0] ?? '';
+    if (identifier === 'sbk.investigation') {
+      parameters['documentTitle'] = getInvestigationDocumentTitle(errand);
+    }
   } else if (templateType === 'decision') {
     parameters['decisionText'] = wrapWithWordBreak(formData.description);
     parameters['decisionDate'] = dayjs(decision?.decidedAt).format('YYYY-MM-DD');


### PR DESCRIPTION
## Bakgrund

Utredningen renderades från **6 separata mallar** (`sbk.ft.investigation`, `sbk.rft.investigation`, `sbk.rph.investigation.{driver|passenger}.{approval|rejection}`) som i praktiken var samma dokument. Den faktiska variationen (förare/passagerare, bifall/avslag) bor i **fraserna**, inte i dokumentmallen. Att filerna underhölls var för sig hade lett till drift och buggar (t.ex. en kvarlämnad `TEST`-sträng och inkonsekvent namnvariabel).

## Ändring

- All utredningsrendering pekar nu på **en** gemensam mall, `sbk.investigation` (upplagd i templating-storet).
- `buildPdfTemplate` dirigerar PT/FT/RFT-utredning till `sbk.investigation`. Ärendetyps-specifik rubrik skickas som render-parametern `documentTitle` (`Färdtjänst`/`Riksfärdtjänst`; tom för parkeringstillstånd → ingen rubrik).
- Mappningen härleds via `isFTNationalErrand`/`isFTErrand`, så nya FT-ärendetyper (t.ex. busskort, förnyelse) fångas automatiskt utan ny mall.
- **Oförändrat:** hela beslutsvägen samt RPH avskrivning (`cancellation`), som även från utredningsfliken renderas från beslutsmallen.

## Funktionellt resultat

- **PT-utredning:** oförändrat utseende (ingen rubrik).
- **FT/RFT-utredning:** rubrik "Utredning – Färdtjänst/Riksfärdtjänst" på det gemensamma brevhuvudet.
- Validerat mot templating-API:t i TEST – PT, FT och RFT renderade korrekt.

## UI-ändringar (utrednings- och beslutsflik)

- **Utredningsfliken:** Utredningsmall-fältet visas nu ovanför mallförhandsgranskningen (tidigare tvärtom).
- **Beslutsfliken:** samma ordning som utredningsfliken – beslutstextfältet ligger i en disclosure ("Beslutstext"), insatser under fältet, och mallförhandsgranskningen längst ned.
- "Inga insatser kommer att fattas"-infon visas nu i en egen "Insatser"-disclosure (samma stil som "Insatser som bifalls").
- Disclosure-ikoner (lucide): `Gavel` för beslutstext, `HandHelping` för insatser (`ClipboardPenLine` för utredningsmall sedan tidigare).

## Att tänka på vid avveckling

De 6 gamla mallarna kan tas bort efter verifiering – men **radera inte med prefix**: fraserna (`sbk.rph.investigation.phrases.*`) och skeleton (`sbk.ft/rft.investigation.skeleton`) lever kvar och delar prefix med de gamla mallarna.

https://jira.sundsvall.se/browse/DRAKEN-4312
https://jira.sundsvall.se/browse/DRAKEN-4316
