### PR TITLE
feat(casedata): mark errands as confidential and warn on export

### DIFF
--- a/backend/src/config/api-config.ts
+++ b/backend/src/config/api-config.ts
@@ -30,7 +30,7 @@ export const APIS = [
   },
   {
     name: 'case-data',
-    version: '12.1',
+    version: '12.4',
   },
   {
     name: 'supportmanagement',

--- a/backend/src/config/api-config.ts
+++ b/backend/src/config/api-config.ts
@@ -30,7 +30,7 @@ export const APIS = [
   },
   {
     name: 'case-data',
-    version: '12.4',
+    version: '12.5',
   },
   {
     name: 'supportmanagement',

--- a/backend/src/controllers/export.controller.ts
+++ b/backend/src/controllers/export.controller.ts
@@ -31,6 +31,8 @@ export class ExportController {
   ): Promise<any> {
     const renderRequest: RenderRequest = {
       identifier: 'sbk.errands.export',
+      // The templating API accepts an object for parameters even though the generated
+      // contract narrows it to string; cast to keep the existing render payload.
       parameters: {
         errands: data.map(e => ({
           errandNumber: e.errandNumber,
@@ -38,7 +40,7 @@ export class ExportController {
           status: e.status?.statusType,
           created: e.created,
         })),
-      },
+      } as unknown as RenderRequest['parameters'],
     };
 
     const url = `${this.TEMPLATING_SERVICE}/${MUNICIPALITY_ID}/render/pdf`;
@@ -127,6 +129,8 @@ export class ExportController {
 
     const renderRequest: RenderRequest = {
       identifier: 'sbk.singleerrand.export',
+      // The templating API accepts an object for parameters even though the generated
+      // contract narrows it to string; cast to keep the existing render payload.
       parameters: {
         errand: {
           errandNumber: data.errandNumber,
@@ -136,7 +140,7 @@ export class ExportController {
           decisions,
           extraParameters,
         },
-      },
+      } as unknown as RenderRequest['parameters'],
     };
 
     const url = `${this.TEMPLATING_SERVICE}/${MUNICIPALITY_ID}/render/pdf`;

--- a/backend/src/data-contracts/billing-data-collector/data-contracts.ts
+++ b/backend/src/data-contracts/billing-data-collector/data-contracts.ts
@@ -123,20 +123,20 @@ export interface EventRequest {
 }
 
 export interface PageScheduledBilling {
-  /** @format int64 */
-  totalElements?: number;
   /** @format int32 */
   totalPages?: number;
+  /** @format int64 */
+  totalElements?: number;
   /** @format int32 */
   size?: number;
   content?: ScheduledBilling[];
   /** @format int32 */
   number?: number;
   pageable?: PageableObject;
-  /** @format int32 */
-  numberOfElements?: number;
   first?: boolean;
   last?: boolean;
+  /** @format int32 */
+  numberOfElements?: number;
   sort?: SortObject;
   empty?: boolean;
 }

--- a/backend/src/data-contracts/billingpreprocessor/data-contracts.ts
+++ b/backend/src/data-contracts/billingpreprocessor/data-contracts.ts
@@ -257,8 +257,8 @@ export interface PageableObject {
 
 export interface SortObject {
   empty?: boolean;
-  unsorted?: boolean;
   sorted?: boolean;
+  unsorted?: boolean;
 }
 
 export enum GetFileStatusesForMonthParamsMonthEnum {

--- a/backend/src/data-contracts/case-data/data-contracts.ts
+++ b/backend/src/data-contracts/case-data/data-contracts.ts
@@ -584,10 +584,6 @@ export interface JsonNode {
   null?: boolean;
   object?: boolean;
   float?: boolean;
-  valueNode?: boolean;
-  container?: boolean;
-  missingNode?: boolean;
-  nodeType?: JsonNodeNodeTypeEnum;
   integralNumber?: boolean;
   pojo?: boolean;
   floatingPointNumber?: boolean;
@@ -600,9 +596,13 @@ export interface JsonNode {
   /** @deprecated */
   textual?: boolean;
   binary?: boolean;
+  valueNode?: boolean;
+  container?: boolean;
+  missingNode?: boolean;
+  nodeType?: JsonNodeNodeTypeEnum;
+  number?: boolean;
   string?: boolean;
   boolean?: boolean;
-  number?: boolean;
   embeddedValue?: boolean;
 }
 
@@ -1030,6 +1030,8 @@ export interface PatchErrand {
   labels?: string[];
   /** The current status of the errand */
   status?: Status;
+  /** Whether the errand is confidential or not */
+  confidential?: boolean;
 }
 
 export interface PatchDecision {
@@ -1085,8 +1087,8 @@ export interface PageableObject {
   /** @format int64 */
   offset?: number;
   sort?: SortObject;
-  unpaged?: boolean;
   paged?: boolean;
+  unpaged?: boolean;
   /** @format int32 */
   pageNumber?: number;
   /** @format int32 */
@@ -1095,8 +1097,8 @@ export interface PageableObject {
 
 export interface SortObject {
   empty?: boolean;
-  sorted?: boolean;
   unsorted?: boolean;
+  sorted?: boolean;
 }
 
 export interface CommitMetadata {

--- a/backend/src/data-contracts/case-data/data-contracts.ts
+++ b/backend/src/data-contracts/case-data/data-contracts.ts
@@ -228,8 +228,8 @@ export interface ConstraintViolationProblem {
   title?: string;
   /** @format uri */
   instance?: string;
-  causeAsProblem?: ThrowableProblem;
   detail?: string;
+  causeAsProblem?: ThrowableProblem;
 }
 
 export interface ThrowableProblem {
@@ -499,10 +499,7 @@ export interface Errand {
    * @maxLength 255
    */
   phase?: string;
-  /**
-   * The current status of the errand
-   * @maxLength 255
-   */
+  /** The current status of the errand */
   status?: Status;
   /** The statuses connected to the errand */
   statuses?: Status[];
@@ -587,9 +584,11 @@ export interface JsonNode {
   null?: boolean;
   object?: boolean;
   float?: boolean;
-  string?: boolean;
-  boolean?: boolean;
-  number?: boolean;
+  valueNode?: boolean;
+  container?: boolean;
+  missingNode?: boolean;
+  nodeType?: JsonNodeNodeTypeEnum;
+  integralNumber?: boolean;
   pojo?: boolean;
   floatingPointNumber?: boolean;
   short?: boolean;
@@ -601,11 +600,9 @@ export interface JsonNode {
   /** @deprecated */
   textual?: boolean;
   binary?: boolean;
-  integralNumber?: boolean;
-  missingNode?: boolean;
-  valueNode?: boolean;
-  container?: boolean;
-  nodeType?: JsonNodeNodeTypeEnum;
+  string?: boolean;
+  boolean?: boolean;
+  number?: boolean;
   embeddedValue?: boolean;
 }
 
@@ -1087,8 +1084,8 @@ export interface PageErrand {
 export interface PageableObject {
   /** @format int64 */
   offset?: number;
-  unpaged?: boolean;
   sort?: SortObject;
+  unpaged?: boolean;
   paged?: boolean;
   /** @format int32 */
   pageNumber?: number;
@@ -1098,8 +1095,8 @@ export interface PageableObject {
 
 export interface SortObject {
   empty?: boolean;
-  unsorted?: boolean;
   sorted?: boolean;
+  unsorted?: boolean;
 }
 
 export interface CommitMetadata {

--- a/backend/src/data-contracts/contract/data-contracts.ts
+++ b/backend/src/data-contracts/contract/data-contracts.ts
@@ -332,7 +332,7 @@ export interface Fees {
    * @max 1
    */
   indexationRate?: number;
-  /** Additional information */
+  /** Additional information. Each entry must be non-blank and between 1 and 30 characters (used as invoice row descriptions). */
   additionalInformation?: string[];
 }
 
@@ -353,9 +353,9 @@ export type GeometryCollection = GeoJsonObject & {
 /** Invoicing details */
 export interface Invoicing {
   /** How often the lease is invoiced */
-  invoiceInterval?: IntervalType;
+  invoiceInterval: IntervalType;
   /** Invoiced in */
-  invoicedIn?: InvoicedIn;
+  invoicedIn: InvoicedIn;
 }
 
 /** Leasehold */
@@ -604,10 +604,6 @@ export interface JsonNode {
   null?: boolean;
   object?: boolean;
   float?: boolean;
-  valueNode?: boolean;
-  container?: boolean;
-  missingNode?: boolean;
-  nodeType?: JsonNodeNodeTypeEnum;
   integralNumber?: boolean;
   pojo?: boolean;
   floatingPointNumber?: boolean;
@@ -620,6 +616,10 @@ export interface JsonNode {
   /** @deprecated */
   textual?: boolean;
   binary?: boolean;
+  valueNode?: boolean;
+  container?: boolean;
+  missingNode?: boolean;
+  nodeType?: JsonNodeNodeTypeEnum;
   string?: boolean;
   boolean?: boolean;
   number?: boolean;
@@ -682,10 +682,10 @@ export interface PatchContract {
 export type SpecificationContractEntity = any;
 
 export interface PageContract {
-  /** @format int32 */
-  totalPages?: number;
   /** @format int64 */
   totalElements?: number;
+  /** @format int32 */
+  totalPages?: number;
   /** @format int32 */
   size?: number;
   content?: Contract[];

--- a/backend/src/data-contracts/jsonschema/data-contracts.ts
+++ b/backend/src/data-contracts/jsonschema/data-contracts.ts
@@ -16,11 +16,6 @@ export interface JsonNode {
   null?: boolean;
   object?: boolean;
   float?: boolean;
-  string?: boolean;
-  boolean?: boolean;
-  number?: boolean;
-  valueNode?: boolean;
-  container?: boolean;
   pojo?: boolean;
   floatingPointNumber?: boolean;
   short?: boolean;
@@ -32,9 +27,14 @@ export interface JsonNode {
   /** @deprecated */
   textual?: boolean;
   binary?: boolean;
+  missingNode?: boolean;
   nodeType?: JsonNodeNodeTypeEnum;
   integralNumber?: boolean;
-  missingNode?: boolean;
+  valueNode?: boolean;
+  container?: boolean;
+  number?: boolean;
+  string?: boolean;
+  boolean?: boolean;
   embeddedValue?: boolean;
 }
 
@@ -69,8 +69,8 @@ export interface ConstraintViolationProblem {
   title?: string;
   /** @format uri */
   instance?: string;
-  causeAsProblem?: ThrowableProblem;
   detail?: string;
+  causeAsProblem?: ThrowableProblem;
 }
 
 export interface ThrowableProblem {

--- a/backend/src/data-contracts/partyassets/data-contracts.ts
+++ b/backend/src/data-contracts/partyassets/data-contracts.ts
@@ -119,10 +119,6 @@ export interface JsonNode {
   null?: boolean;
   object?: boolean;
   float?: boolean;
-  valueNode?: boolean;
-  container?: boolean;
-  missingNode?: boolean;
-  nodeType?: JsonNodeNodeTypeEnum;
   integralNumber?: boolean;
   pojo?: boolean;
   floatingPointNumber?: boolean;
@@ -135,6 +131,10 @@ export interface JsonNode {
   /** @deprecated */
   textual?: boolean;
   binary?: boolean;
+  valueNode?: boolean;
+  container?: boolean;
+  nodeType?: JsonNodeNodeTypeEnum;
+  missingNode?: boolean;
   number?: boolean;
   string?: boolean;
   boolean?: boolean;

--- a/backend/src/data-contracts/supportmanagement/data-contracts.ts
+++ b/backend/src/data-contracts/supportmanagement/data-contracts.ts
@@ -161,7 +161,28 @@ export interface Label {
    * @pattern [A-Z0-9_]+
    */
   resourceName: string;
+  /**
+   * Indicates if the label is deprecated
+   * @default false
+   */
+  deprecated?: boolean;
   labels?: Label[];
+  /** Free-form key/value data owned by the client. Stored and returned as-is by the service, which does not interpret the contents (apart from rejecting duplicate keys per label). Keys are conventions agreed between clients (e.g. 'escalationEmail'). */
+  attributes?: LabelAttribute[];
+}
+
+/** Label attribute model. Free-form key/value data owned by the client; not interpreted by the service. Keys are conventions agreed between clients (e.g. 'escalationEmail'). */
+export interface LabelAttribute {
+  /**
+   * Attribute key
+   * @minLength 1
+   */
+  key: string;
+  /**
+   * Attribute value
+   * @minLength 1
+   */
+  value: string;
 }
 
 /** Message exchange worker config model */
@@ -202,7 +223,7 @@ export interface EmailIntegration {
    * Number of days before incoming mail is rejected. Measured from when the errand was last touched. Rejection can only occur if status on errand equals 'inactiveStatus'.
    * @format int32
    */
-  daysOfInactivityBeforeReject?: number | string | null;
+  daysOfInactivityBeforeReject?: string | null;
   /** Status set on errand when email results in a new errand */
   statusForNew: string;
   /** Status on errand that will trigger a status change when email refers to an existing errand */
@@ -212,7 +233,7 @@ export interface EmailIntegration {
   /** Status of an inactive errand. This value relates to property 'daysOfInactivityBeforeReject'. If set to null, no rejection mail will be sent */
   inactiveStatus?: string | null;
   /** If true sender is added as stakeholder */
-  addSenderAsStakeholder?: boolean | string | null;
+  addSenderAsStakeholder?: string | null;
   /** Role set on stakeholder. */
   stakeholderRole?: string | null;
   /** Channel set on created errands */
@@ -259,11 +280,16 @@ export interface MessageExchangeSync {
 /** Filter on event type/subtype, used to limit which eventlog events trigger a notification */
 export interface EventFilter {
   /**
-   * Event type. Matches the eventlog EventType enum (CREATE, READ, UPDATE, DELETE, ACCESS, EXECUTE, CANCEL, DROP).
+   * Event type. Matches the eventlog EventType enum.
    * @minLength 1
+   * @pattern ^(CREATE|READ|UPDATE|DELETE|ACCESS|EXECUTE|CANCEL|DROP)$
    */
-  type: string;
-  /** Event subtype. If null, all subtypes of the given type match. */
+  type: EventFilterTypeEnum;
+  /**
+   * Event subtype. If null, all subtypes of the given type match.
+   * @minLength 0
+   * @maxLength 64
+   */
   subtype?: string;
 }
 
@@ -277,7 +303,8 @@ export interface Identifier {
   type: IdentifierTypeEnum;
   /**
    * Identifier value (AD-account name or partyId UUID)
-   * @minLength 1
+   * @minLength 0
+   * @maxLength 255
    */
   value: string;
 }
@@ -286,7 +313,11 @@ export interface Identifier {
 export interface NotificationChannel {
   /** Channel type */
   type: NotificationChannelTypeEnum;
-  /** Optional destination override (e.g. an alternative e-mail address or phone number). If omitted, the default destination derived from the subscriber's identifier is used. */
+  /**
+   * Optional destination override (e.g. an alternative e-mail address or phone number). If omitted, the default destination derived from the subscriber's identifier is used.
+   * @minLength 0
+   * @maxLength 255
+   */
   destination?: string;
 }
 
@@ -294,9 +325,13 @@ export interface NotificationChannel {
 export interface Subscriber {
   /** Unique identifier of the subscriber */
   id?: string;
-  /** Optional human-readable label. Useful when a person has several subscribers (e.g. one per role or purpose). */
+  /**
+   * Optional human-readable label. Useful when a person has several subscribers (e.g. one per role or purpose).
+   * @minLength 0
+   * @maxLength 255
+   */
   name?: string;
-  /** Identifier of the principal that ultimately receives notifications (AD-account or partyId). */
+  /** Identifier of the principal that ultimately receives notifications (AD-account or partyId). Immutable once created. */
   identifier?: Identifier;
   /** Channels the subscriber wants to receive notifications on. If empty, defaults to INTERNAL. */
   channels?: NotificationChannel[];
@@ -380,6 +415,11 @@ export interface Status {
    */
   sortOrder?: number | null;
   /**
+   * Indicates if the status is deprecated
+   * @default false
+   */
+  deprecated?: boolean;
+  /**
    * Timestamp when the status was created
    * @format date-time
    */
@@ -407,6 +447,11 @@ export interface Role {
    * @format int32
    */
   sortOrder?: number | null;
+  /**
+   * Indicates if the role is deprecated
+   * @default false
+   */
+  deprecated?: boolean;
   /**
    * Timestamp when the role was created
    * @format date-time
@@ -442,6 +487,11 @@ export interface Phase {
   /** Transitions from this phase */
   transitions?: PhaseTransition[];
   /**
+   * Indicates if the phase is deprecated
+   * @default false
+   */
+  deprecated?: boolean;
+  /**
    * Timestamp when the phase was created
    * @format date-time
    */
@@ -468,6 +518,11 @@ export interface PhaseTransition {
   targetPhaseDisplayName?: string;
   /** Description of the transition */
   description?: string;
+  /**
+   * Indicates if the phase transition is deprecated
+   * @default false
+   */
+  deprecated?: boolean;
 }
 
 /** ExternalIdType model */
@@ -486,6 +541,11 @@ export interface ExternalIdType {
    * @format int32
    */
   sortOrder?: number | null;
+  /**
+   * Indicates if the external ID type is deprecated
+   * @default false
+   */
+  deprecated?: boolean;
   /**
    * Timestamp when the external id type was created
    * @format date-time
@@ -515,6 +575,11 @@ export interface ContactReason {
    */
   sortOrder?: number | null;
   /**
+   * Indicates if the contact reason is deprecated
+   * @default false
+   */
+  deprecated?: boolean;
+  /**
    * Timestamp when the contact reason was created
    * @format date-time
    */
@@ -539,6 +604,11 @@ export interface Category {
    * @format int32
    */
   sortOrder?: number | null;
+  /**
+   * Indicates if the category is deprecated
+   * @default false
+   */
+  deprecated?: boolean;
   /** @uniqueItems true */
   types?: Type[];
   /**
@@ -567,6 +637,11 @@ export interface Type {
    * @format email
    */
   escalationEmail?: string;
+  /**
+   * Indicates if the type is deprecated
+   * @default false
+   */
+  deprecated?: boolean;
   /**
    * Timestamp when type was created
    * @format date-time
@@ -742,14 +817,10 @@ export interface JsonNode {
   number?: boolean;
   string?: boolean;
   boolean?: boolean;
+  integralNumber?: boolean;
   missingNode?: boolean;
   valueNode?: boolean;
   container?: boolean;
-  nodeType?: JsonNodeNodeTypeEnum;
-  bigInteger?: boolean;
-  /** @deprecated */
-  textual?: boolean;
-  integralNumber?: boolean;
   pojo?: boolean;
   floatingPointNumber?: boolean;
   short?: boolean;
@@ -757,7 +828,11 @@ export interface JsonNode {
   long?: boolean;
   double?: boolean;
   bigDecimal?: boolean;
+  bigInteger?: boolean;
+  /** @deprecated */
+  textual?: boolean;
   binary?: boolean;
+  nodeType?: JsonNodeNodeTypeEnum;
   embeddedValue?: boolean;
 }
 
@@ -1172,10 +1247,10 @@ export interface MetadataResponse {
 }
 
 export interface PageErrand {
-  /** @format int32 */
-  totalPages?: number;
   /** @format int64 */
   totalElements?: number;
+  /** @format int32 */
+  totalPages?: number;
   /** @format int32 */
   size?: number;
   content?: Errand[];
@@ -1193,19 +1268,19 @@ export interface PageErrand {
 export interface PageableObject {
   /** @format int64 */
   offset?: number;
-  unpaged?: boolean;
   sort?: SortObject;
   paged?: boolean;
   /** @format int32 */
   pageNumber?: number;
   /** @format int32 */
   pageSize?: number;
+  unpaged?: boolean;
 }
 
 export interface SortObject {
   empty?: boolean;
-  sorted?: boolean;
   unsorted?: boolean;
+  sorted?: boolean;
 }
 
 /** Revision model */
@@ -1343,10 +1418,10 @@ export interface EventMetaData {
 }
 
 export interface PageEvent {
-  /** @format int32 */
-  totalPages?: number;
   /** @format int64 */
   totalElements?: number;
+  /** @format int32 */
+  totalPages?: number;
   /** @format int32 */
   size?: number;
   content?: Event[];
@@ -1450,10 +1525,10 @@ export interface Message {
 }
 
 export interface PageMessage {
-  /** @format int32 */
-  totalPages?: number;
   /** @format int64 */
   totalElements?: number;
+  /** @format int32 */
+  totalPages?: number;
   /** @format int32 */
   size?: number;
   content?: Message[];
@@ -1499,6 +1574,22 @@ export interface ErrandAttachment {
 export interface CountResponse {
   /** @format int64 */
   count?: number;
+}
+
+/**
+ * Event type. Matches the eventlog EventType enum.
+ * @minLength 1
+ * @pattern ^(CREATE|READ|UPDATE|DELETE|ACCESS|EXECUTE|CANCEL|DROP)$
+ */
+export enum EventFilterTypeEnum {
+  CREATE = "CREATE",
+  READ = "READ",
+  UPDATE = "UPDATE",
+  DELETE = "DELETE",
+  ACCESS = "ACCESS",
+  EXECUTE = "EXECUTE",
+  CANCEL = "CANCEL",
+  DROP = "DROP",
 }
 
 /**

--- a/backend/src/data-contracts/supportmanagement/data-contracts.ts
+++ b/backend/src/data-contracts/supportmanagement/data-contracts.ts
@@ -51,8 +51,8 @@ export interface ConstraintViolationProblem {
   title?: string;
   /** @format uri */
   instance?: string;
-  causeAsProblem?: ThrowableProblem;
   detail?: string;
+  causeAsProblem?: ThrowableProblem;
 }
 
 export interface ThrowableProblem {
@@ -817,10 +817,11 @@ export interface JsonNode {
   number?: boolean;
   string?: boolean;
   boolean?: boolean;
-  integralNumber?: boolean;
-  missingNode?: boolean;
   valueNode?: boolean;
   container?: boolean;
+  missingNode?: boolean;
+  nodeType?: JsonNodeNodeTypeEnum;
+  integralNumber?: boolean;
   pojo?: boolean;
   floatingPointNumber?: boolean;
   short?: boolean;
@@ -832,7 +833,6 @@ export interface JsonNode {
   /** @deprecated */
   textual?: boolean;
   binary?: boolean;
-  nodeType?: JsonNodeNodeTypeEnum;
   embeddedValue?: boolean;
 }
 
@@ -1269,12 +1269,12 @@ export interface PageableObject {
   /** @format int64 */
   offset?: number;
   sort?: SortObject;
+  unpaged?: boolean;
   paged?: boolean;
   /** @format int32 */
   pageNumber?: number;
   /** @format int32 */
   pageSize?: number;
-  unpaged?: boolean;
 }
 
 export interface SortObject {

--- a/backend/src/data-contracts/templating/data-contracts.ts
+++ b/backend/src/data-contracts/templating/data-contracts.ts
@@ -98,7 +98,7 @@ export interface RenderRequest {
   version?: string | null;
   metadata?: KeyValue[];
   /** Parameters (string values may be BASE64-encoded, and in that case they should be on the form "BASE64:<base64-encoded-value>") */
-  parameters?: Record<string, any> | string | null;
+  parameters?: string | null;
 }
 
 export interface RenderResponse {
@@ -114,7 +114,7 @@ export interface DirectRenderRequest {
    */
   content: string;
   /** Parameters (string values may be BASE64-encoded, and in that case they should be on the form "BASE64:<base64-encoded-value>") */
-  parameters?: Record<string, any> | string | null;
+  parameters?: string | null;
 }
 
 export interface DirectRenderResponse {

--- a/backend/src/interfaces/errand.interface.ts
+++ b/backend/src/interfaces/errand.interface.ts
@@ -1,5 +1,5 @@
 import { Type } from 'class-transformer';
-import { IsArray, IsNumber, IsObject, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { IsArray, IsBoolean, IsNumber, IsObject, IsOptional, IsString, ValidateNested } from 'class-validator';
 
 import {
   Decision as DecisionDTO,
@@ -88,6 +88,9 @@ export class CreateErrandDto implements ErrandDTO {
   @IsString()
   @IsOptional()
   applicationReceived?: string;
+  @IsBoolean()
+  @IsOptional()
+  confidential?: boolean;
 }
 
 export class CPatchErrandDto implements IPatchErrandDTO {
@@ -153,4 +156,7 @@ export class CPatchErrandDto implements IPatchErrandDTO {
   @IsString()
   @IsOptional()
   applicationReceived?: string;
+  @IsBoolean()
+  @IsOptional()
+  confidential?: boolean;
 }

--- a/backend/src/services/errand.service.ts
+++ b/backend/src/services/errand.service.ts
@@ -51,6 +51,7 @@ export const makeErrandApiData: (errandData: CreateErrandDto | CPatchErrandDto, 
     ...(errandData.stakeholders && { stakeholders: errandData.stakeholders }),
     ...(errandData.relatesTo && { relatesTo: errandData.relatesTo }),
     ...(errandData.applicationReceived && { applicationReceived: errandData.applicationReceived }),
+    ...(errandData.confidential !== undefined && { confidential: errandData.confidential }),
   };
   return newErrand;
 };

--- a/frontend/cypress/e2e/case-data/mex/errandPage-sidebar-mex.cy.ts
+++ b/frontend/cypress/e2e/case-data/mex/errandPage-sidebar-mex.cy.ts
@@ -253,7 +253,7 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
         cy.get(`[aria-label="${mockSidebarButtons[6].label}"]`).should('exist').click();
         cy.get('[data-cy="basicInformation"]').should('exist');
         cy.get('[data-cy="export-button"]').should('exist').click();
-        cy.get('p').should('exist').contains('Detta ärende är inte avslutat. Vill du ändå exportera ärendet?');
+        cy.contains('Detta ärende är inte avslutat. Vill du ändå exportera ärendet?').should('exist');
       } else {
         // Export button should not exist when feature is disabled
         cy.get(`[aria-label="${mockSidebarButtons[6].label}"]`).should('exist');

--- a/frontend/cypress/e2e/case-data/mex/oversikt.cy.ts
+++ b/frontend/cypress/e2e/case-data/mex/oversikt.cy.ts
@@ -236,7 +236,7 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
     it('Can use export', () => {
       if (appConfig.features.useErrandExport) {
         cy.get('[data-cy="export-button"]').should('exist').click();
-        cy.get('p').should('exist').contains('Det finns ärenden som inte är avslutade. Vill du ändå exportera listan?');
+        cy.contains('Det finns ärenden som inte är avslutade. Vill du ändå exportera listan?').should('exist');
       } else {
         // Export button should not exist when feature is disabled
         cy.get('[data-cy="export-button"]').should('exist');

--- a/frontend/src/casedata/components/errand/tabs/overview/casedata-form.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/overview/casedata-form.component.tsx
@@ -7,9 +7,19 @@ import { Stakeholder } from '@casedata/interfaces/stakeholder';
 import { defaultMunicipality, getCaseLabels, isErrandLocked } from '@casedata/services/casedata-errand-service';
 import { LinkedErrandsDisclosure } from '@common/components/linked-errands-disclosure/linked-errands-disclosure.component';
 import { appConfig } from '@config/appconfig';
-import { cx, Disclosure, FormControl, FormErrorMessage, FormLabel, Input, Select } from '@sk-web-gui/react';
+import {
+  Checkbox,
+  cx,
+  Disclosure,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  Label,
+  Select,
+} from '@sk-web-gui/react';
 import { useConfigStore } from '@stores/index';
-import { CircleAlert } from 'lucide-react';
+import { CircleAlert, Lock } from 'lucide-react';
 import { Dispatch, FC, SetStateAction, useEffect } from 'react';
 import { useFormContext, UseFormReturn } from 'react-hook-form';
 
@@ -49,6 +59,7 @@ const CasedataForm: FC<CasedataFormProps> = ({
       setValue('priority', errand.priority);
       setValue('status', errand.status);
       setValue('phase', errand.phase);
+      setValue('confidential', errand.confidential ?? false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [errand]);
@@ -73,7 +84,7 @@ const CasedataForm: FC<CasedataFormProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formState.isValid]);
 
-  const { caseType, priority } = watch();
+  const { caseType, priority, confidential } = watch();
   const caseTypesHiddenFromRegistation = Object.keys(CaseTypesHiddenFromRegistration);
 
   return (
@@ -236,6 +247,35 @@ const CasedataForm: FC<CasedataFormProps> = ({
                       <FormErrorMessage>{'errors.priority?.message'}</FormErrorMessage>
                     </div>
                   )}
+                </FormControl>
+              </div>
+
+              <div className="flex flex-col gap-sm mb-lg">
+                <FormControl id="confidential">
+                  <div className="flex items-center gap-md flex-wrap">
+                    <Checkbox
+                      {...register('confidential')}
+                      disabled={errand ? isErrandLocked(errand) : false}
+                      data-cy="confidential-input"
+                    >
+                      Sekretessbelägg ärendet
+                    </Checkbox>
+                    {confidential ? (
+                      <Label
+                        rounded
+                        inverted
+                        color="error"
+                        className="inline-flex items-center gap-xs"
+                        data-cy="confidential-label"
+                      >
+                        <Lock size={14} /> Sekretess
+                      </Label>
+                    ) : null}
+                  </div>
+                  <p className="text-small text-dark-secondary mt-xs">
+                    Markerar hela ärendet som sekretessbelagt. Vid export visas en varning – det är handläggarens ansvar
+                    att maskera de uppgifter som omfattas av sekretess i det exporterade dokumentet.
+                  </p>
                 </FormControl>
               </div>
             </div>

--- a/frontend/src/casedata/interfaces/errand.ts
+++ b/frontend/src/casedata/interfaces/errand.ts
@@ -42,6 +42,8 @@ export interface ApiErrand {
   };
   notifications?: Notification[];
   relatesTo?: RelatedErrand[];
+  /** Whether the errand is confidential or not */
+  confidential?: boolean;
 }
 
 export interface ApiPagingData {
@@ -107,6 +109,8 @@ export interface IErrand {
   notifications?: Notification[];
   relatesTo?: RelatedErrand[];
   publicNote?: string;
+  /** Whether the errand is confidential or not */
+  confidential?: boolean;
 }
 
 export interface ErrandsData extends Data {
@@ -160,4 +164,5 @@ export interface RegisterErrandData {
     suspendedTo?: string;
   };
   relatesTo?: RelatedErrand[];
+  confidential?: boolean;
 }

--- a/frontend/src/casedata/services/casedata-errand-service.ts
+++ b/frontend/src/casedata/services/casedata-errand-service.ts
@@ -276,6 +276,7 @@ export const mapErrandToIErrand: (e: ApiErrand, municipalityId: string) => IErra
 
       notifications: e.notifications,
       relatesTo: e.relatesTo,
+      confidential: e.confidential ?? false,
     };
     return ierrand;
   } catch (err) {
@@ -621,6 +622,7 @@ const createApiErrandData: (data: Partial<IErrand>) => Partial<RegisterErrandDat
     ...(data.status && { status: data.status }),
     ...(data.statuses && { statuses: data.statuses }),
     ...(data.phase && { phase: data.phase }),
+    ...(data.confidential !== undefined && { confidential: data.confidential }),
     stakeholders: stakeholders,
   };
   return e;

--- a/frontend/src/common/components/confidential-export-alert/confidential-export-alert.component.tsx
+++ b/frontend/src/common/components/confidential-export-alert/confidential-export-alert.component.tsx
@@ -1,0 +1,22 @@
+import { Alert } from '@sk-web-gui/react';
+import { FC, ReactNode } from 'react';
+
+interface ConfidentialExportAlertProps {
+  title?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export const ConfidentialExportAlert: FC<ConfidentialExportAlertProps> = ({
+  title = 'Sekretessmarkerat ärende',
+  children,
+  className,
+}) => (
+  <Alert type="warning" className={className} data-cy="confidential-export-warning">
+    <Alert.Icon />
+    <Alert.Content>
+      <Alert.Content.Title>{title}</Alert.Content.Title>
+      <Alert.Content.Description>{children}</Alert.Content.Description>
+    </Alert.Content>
+  </Alert>
+);

--- a/frontend/src/common/components/export-button/export-button.component.tsx
+++ b/frontend/src/common/components/export-button/export-button.component.tsx
@@ -1,5 +1,6 @@
 import { ErrandsData } from '@casedata/interfaces/errand';
 import { ErrandStatus } from '@casedata/interfaces/errand-status';
+import { ExportConfirmationContent } from '@common/components/export-confirmation-content/export-confirmation-content.component';
 import { downloadPdf, exportErrands } from '@common/services/export-service';
 import { Button, useConfirm, useSnackbar } from '@sk-web-gui/react';
 import dayjs from 'dayjs';
@@ -19,6 +20,10 @@ export const ExportButton: FC<ExportButtonProps> = (props) => {
 
   const isErrandNotClosed = () => {
     return errands.errands.some((errand) => errand.status.statusType !== ErrandStatus.ArendeAvslutat);
+  };
+
+  const hasConfidential = () => {
+    return errands.errands.some((errand) => errand.confidential);
   };
 
   const handleExportErrands = () => {
@@ -48,16 +53,23 @@ export const ExportButton: FC<ExportButtonProps> = (props) => {
       loadingText="Exporterar..."
       leftIcon={<Download />}
       onClick={async () => {
+        const confidential = hasConfidential();
+        const notClosed = isErrandNotClosed();
+        const confidentialNotice =
+          'Listan innehåller sekretessmarkerade ärenden. Exporten kan innehålla sekretessbelagda uppgifter – det är ditt ansvar att maskera de delar som omfattas av sekretess efter export.';
         const confirmed = await exportConfirm.showConfirmation(
-          'Exportera listan?',
-          `${
-            isErrandNotClosed()
-              ? 'Det finns ärenden som inte är avslutade. Vill du ändå exportera listan?'
-              : 'Vill du exportera listan?'
-          }`,
+          confidential ? 'Exportera lista med sekretess?' : 'Exportera listan?',
+          <ExportConfirmationContent
+            confidential={confidential}
+            notClosed={notClosed}
+            confidentialTitle="Sekretessmarkerade ärenden"
+            confidentialNotice={confidentialNotice}
+            notClosedNotice="Det finns ärenden som inte är avslutade. Vill du ändå exportera listan?"
+            question="Vill du exportera listan?"
+          />,
           'Ja',
           'Nej',
-          'info'
+          confidential ? 'warning' : 'info'
         );
         if (confirmed) {
           handleExportErrands();

--- a/frontend/src/common/components/export-confirmation-content/export-confirmation-content.component.tsx
+++ b/frontend/src/common/components/export-confirmation-content/export-confirmation-content.component.tsx
@@ -1,0 +1,51 @@
+import { ConfidentialExportAlert } from '@common/components/confidential-export-alert/confidential-export-alert.component';
+import { Alert } from '@sk-web-gui/react';
+import { FC } from 'react';
+
+interface ExportConfirmationContentProps {
+  /** Whether the export contains at least one confidential errand. */
+  confidential?: boolean;
+  /** Whether the export contains at least one errand that is not closed. */
+  notClosed?: boolean;
+  /** Heading for the confidential alert (defaults to the single-errand wording). */
+  confidentialTitle?: string;
+  /** Body text for the confidential alert. */
+  confidentialNotice: string;
+  /** Full sentence shown in the "not closed" info alert (includes its own question). */
+  notClosedNotice: string;
+  /** Plain question shown when there is no "not closed" warning. */
+  question: string;
+}
+
+/**
+ * Shared body for the export confirmation dialog, used by both the single errand
+ * export and the errand list export. Renders an optional confidential warning and
+ * either a "not closed" info alert (which carries its own question) or the plain
+ * export question.
+ */
+export const ExportConfirmationContent: FC<ExportConfirmationContentProps> = ({
+  confidential,
+  notClosed,
+  confidentialTitle,
+  confidentialNotice,
+  notClosedNotice,
+  question,
+}) => (
+  <>
+    {confidential && (
+      <ConfidentialExportAlert title={confidentialTitle} className="mb-16">
+        {confidentialNotice}
+      </ConfidentialExportAlert>
+    )}
+    {notClosed ? (
+      <Alert type="info" className="mb-16" data-cy="export-not-closed-warning">
+        <Alert.Icon />
+        <Alert.Content>
+          <Alert.Content.Description>{notClosedNotice}</Alert.Content.Description>
+        </Alert.Content>
+      </Alert>
+    ) : (
+      <p>{question}</p>
+    )}
+  </>
+);

--- a/frontend/src/common/components/export/sidebar-export/sidebar-export.component.tsx
+++ b/frontend/src/common/components/export/sidebar-export/sidebar-export.component.tsx
@@ -1,4 +1,6 @@
 import { ErrandStatus } from '@casedata/interfaces/errand-status';
+import { ConfidentialExportAlert } from '@common/components/confidential-export-alert/confidential-export-alert.component';
+import { ExportConfirmationContent } from '@common/components/export-confirmation-content/export-confirmation-content.component';
 import { downloadPdf, exportSingleErrand } from '@common/services/export-service';
 import { Button, Checkbox, FormControl, useConfirm, useSnackbar } from '@sk-web-gui/react';
 import { useCasedataStore, useConfigStore } from '@stores/index';
@@ -36,6 +38,11 @@ export const SidebarExport: React.FC = () => {
   const isErrandNotClosed = () => {
     return errand.status.statusType !== ErrandStatus.ArendeAvslutat;
   };
+
+  const isConfidential = !!errand.confidential;
+
+  const confidentialNotice =
+    'Detta ärende är sekretessmarkerat. Exporten kan innehålla sekretessbelagda uppgifter – det är ditt ansvar att maskera de delar som omfattas av sekretess efter export. ';
 
   const handleSubmit = () => {
     setIsExportLoading(true);
@@ -78,6 +85,10 @@ export const SidebarExport: React.FC = () => {
         <span className="text-base md:text-large xl:text-lead font-semibold">Exportera ärende</span>
       </div>
 
+      {isConfidential ? (
+        <ConfidentialExportAlert className="mb-16">{confidentialNotice}</ConfidentialExportAlert>
+      ) : null}
+
       <FormControl className="w-full">
         <Checkbox {...register('basicInformation')} key="basicInformation" data-cy="basicInformation">
           Inkludera grunduppgifter
@@ -95,15 +106,17 @@ export const SidebarExport: React.FC = () => {
         <Button
           onClick={async () => {
             const confirmed = await exportConfirm.showConfirmation(
-              'Exportera ärende?',
-              `${
-                isErrandNotClosed()
-                  ? 'Detta ärende är inte avslutat. Vill du ändå exportera ärendet?'
-                  : 'Vill du exportera ärendet?'
-              }`,
+              isConfidential ? 'Exportera sekretessmarkerat ärende?' : 'Exportera ärende?',
+              <ExportConfirmationContent
+                confidential={isConfidential}
+                notClosed={isErrandNotClosed()}
+                confidentialNotice={confidentialNotice}
+                notClosedNotice="Detta ärende är inte avslutat. Vill du ändå exportera ärendet?"
+                question="Vill du exportera ärendet?"
+              />,
               'Ja',
               'Nej',
-              'info'
+              isConfidential ? 'warning' : 'info'
             );
             if (confirmed) {
               handleSubmit();

--- a/frontend/src/common/data-contracts/case-data/data-contracts.ts
+++ b/frontend/src/common/data-contracts/case-data/data-contracts.ts
@@ -909,6 +909,8 @@ export interface Errand {
   updatedBy?: string;
   /** Suspension information */
   suspension?: Suspension;
+  /** Whether the errand is confidential or not */
+  confidential?: boolean;
   /** Extra parameters for the errand */
   extraParameters?: ExtraParameter[];
   /**

--- a/frontend/src/supportmanagement/components/support-errand/sidebar/buttons/support-forward-errand-button.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/buttons/support-forward-errand-button.component.tsx
@@ -197,7 +197,6 @@ export const SupportForwardErrandButtonComponent: React.FC<{ disabled: boolean }
     if (element && !showFullDescription) {
       setIsDescriptionClamped(element.scrollHeight > element.clientHeight);
     }
-     
   }, [recipient, showModal, showFullDescription, supportErrand?.description]);
 
   const handleModal = () => {


### PR DESCRIPTION
## Vad

Gör det möjligt att markera hela ärenden som sekretessbelagda (`confidential`) och varnar handläggaren vid export av sekretessmarkerade ärenden. Det är upp till handläggaren att maskera de sekretessbelagda delarna i det exporterade dokumentet.

## Ändringar

**Sekretessfunktion (feat)**
- Kopplar in `confidential` hela vägen: frontend (`IErrand`/`ApiErrand`/`RegisterErrandData`, mappning i `mapErrandToIErrand`, spar/patch i `createApiErrandData`) och backend (`CPatchErrandDto`/`CreateErrandDto` + `makeErrandApiData`).
- Markerings-UI: checkbox "Sekretessbelägg ärendet" i översiktens "Om ärendet", med synlig sekretess-etikett. Låst när ärendet är låst.
- Exportvarning vid både enskild export och listexport, via återanvändbara komponenter:
  - `ConfidentialExportAlert` – warning-alert (designsystemets varningsikon).
  - `ExportConfirmationContent` – delad dialogkropp som komponerar sekretessvarning + "ej avslutat"-info-alert + frågan, används av både enskild- och listexport.
- Uppdaterade Cypress-asserts (varningstexten ligger nu i en alert i stället för ett `<p>`).

**Beroenden (chore)**
- Bumpar case-data API 12.1 → 12.4 och regenererar tillhörande data-contracts.

## Känd begränsning

Case-data-API:t (v12.4) saknar `confidential` i `PatchErrand`, så markering av *befintliga* ärenden persisteras inte via PATCH ännu (fältet finns bara på `Errand`/POST). API-teamet lägger till fältet i `PatchErrand` separat – frontend och backend är redan förberedda och börjar fungera så fort API:t stödjer det.

## Test

- ESLint, Prettier och `tsc` rent på alla berörda `src/`-filer (frontend + backend, 0 typfel).
- Manuellt: exportvarning visas för sekretessmarkerat ärende (enskild + lista); markering vid registrering skickas med i POST.

https://jira.sundsvall.se/browse/DRAKEN-1056

**Några bilder som visar UX**
<img width="1439" height="823" alt="Screenshot 2026-06-03 at 15 00 38" src="https://github.com/user-attachments/assets/20c2fbd0-5d56-47ed-8d87-b5f439bf3a7c" />
<img width="1439" height="823" alt="Screenshot 2026-06-03 at 15 00 43" src="https://github.com/user-attachments/assets/147e0058-ed48-4505-bb61-3a15be7d1b64" />
<img width="1439" height="1144" alt="Screenshot 2026-06-03 at 15 01 00" src="https://github.com/user-attachments/assets/7dd0d662-f778-43c6-bf1f-856673d07595" />
<img width="946" height="630" alt="Screenshot 2026-06-03 at 15 15 34" src="https://github.com/user-attachments/assets/35ff5e6c-e9d0-42e9-ad37-10f389106b90" />

