### PR TITLE
feat: remove additionalInformation[1] (user editable item)

### DIFF
--- a/frontend/cypress/e2e/case-data/mex/errandPage-contracts-tab-contract-mex.cy.ts
+++ b/frontend/cypress/e2e/case-data/mex/errandPage-contracts-tab-contract-mex.cy.ts
@@ -336,7 +336,6 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
       cy.get('[data-cy="invoice-markup-input"]').should('exist').type('TEST markup');
 
       cy.get('[data-cy="fees-additional-information-0-input"]').should('exist');
-      cy.get('[data-cy="fees-additional-information-1-input"]').should('exist').type('Foobar');
 
       cy.get('[data-cy="avtalstid-disclosure"] button.sk-btn-tertiary').should('exist').click();
       cy.get('[data-cy="avtalstid-start"]').should('exist').clear().type('2024-01-01');
@@ -356,7 +355,7 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
           monthly: 0,
           yearly: 120,
           total: 120,
-          additionalInformation: ['Avgift, lägenhetsarrende', 'Foobar'],
+          additionalInformation: ['Avgift, lägenhetsarrende'],
         });
       });
     });
@@ -838,11 +837,6 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
           cy.get('[data-cy="invoice-markup-input"]').should('not.have.attr', 'readonly');
           cy.get('[data-cy="invoice-markup-input"]').clear().type('NEW-REF-456');
           cy.get('[data-cy="invoice-markup-input"]').should('have.value', 'NEW-REF-456');
-
-          // Kompletterande avitext should still be editable
-          cy.get('[data-cy="fees-additional-information-1-input"]').should('not.have.attr', 'readonly');
-          cy.get('[data-cy="fees-additional-information-1-input"]').clear().type('Extra info');
-          cy.get('[data-cy="fees-additional-information-1-input"]').should('have.value', 'Extra info');
         });
 
         it('does not allow removing parties for ACTIVE contracts but allows editing roles and adding billing party', () => {

--- a/frontend/src/casedata/components/errand/tabs/contract/casedata-contract-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/contract/casedata-contract-tab.tsx
@@ -117,28 +117,6 @@ export const CasedataContractTab: FC<CasedataContractProps> = (props) => {
               .required('Förskott eller efterskott måste väljas'),
           }),
       }),
-      fees: yup.object({
-        // Validates only the user-editable supplementary avitext (index 1). The auto-generated
-        // avitext (index 0) is intentionally not validated here pending the backend length decision.
-        additionalInformation: yup
-          .array()
-          .test(
-            'supplementary-non-blank',
-            'Kompletterande avitext får inte vara enbart blanksteg',
-            (additionalInformation) => {
-              const supplementary = additionalInformation?.[1];
-              return !supplementary || supplementary.trim().length > 0;
-            }
-          )
-          .test(
-            'supplementary-max-length',
-            'Kompletterande avitext får vara högst 30 tecken',
-            (additionalInformation) => {
-              const supplementary = additionalInformation?.[1];
-              return !supplementary || supplementary.trim().length <= 30;
-            }
-          ),
-      }),
       extraParameters: yup.array().when(['generateInvoice', 'status'], ([generateInvoice, status], schema) => {
         if (status !== Status.ACTIVE) return schema;
 

--- a/frontend/src/casedata/components/errand/tabs/contract/contract-form.tsx
+++ b/frontend/src/casedata/components/errand/tabs/contract/contract-form.tsx
@@ -1062,25 +1062,6 @@ export const ContractForm: FC<{
                       ></Textarea>
                     </FormControl>
                   </div>
-                  <div className="flex gap-18 justify-start">
-                    <FormControl className="flex-grow">
-                      <FormLabel>Kompletterande avitext</FormLabel>
-                      <Textarea
-                        maxLength={30}
-                        maxLengthWarningText="Maxlängd 30 tecken"
-                        rows={3}
-                        className="w-full"
-                        readOnly={!isEditable('billing')}
-                        {...register('fees.additionalInformation.1')}
-                        data-cy="fees-additional-information-1-input"
-                      ></Textarea>
-                      {(formState.errors?.fees?.additionalInformation as { message?: string })?.message ? (
-                        <FormErrorMessage>
-                          {(formState.errors?.fees?.additionalInformation as { message?: string })?.message}
-                        </FormErrorMessage>
-                      ) : null}
-                    </FormControl>
-                  </div>
                 </>
               ) : null}
               {saveButton()}

--- a/frontend/src/casedata/services/contract-service.ts
+++ b/frontend/src/casedata/services/contract-service.ts
@@ -81,8 +81,6 @@ const feeDescriptionByContractType: Partial<Record<ContractType, string>> = {
   [ContractType.LEASEHOLD]: 'Avgift, tomträttsavgäld',
 };
 
-// Standardized invoice fee description (additionalInformation[0]). Curated to satisfy the contract API
-// rule (each entry non-blank, max 30 chars). Source: screenshots/addinfo.png.
 export const getFeeDescription = (type: ContractType, leaseType?: LeaseType): string => {
   if (type === ContractType.LEASE_AGREEMENT && leaseType) {
     return feeDescriptionByLeaseType[leaseType] ?? 'Övrig avgift';
@@ -523,11 +521,6 @@ export const lagenhetsArrendeToContract = (data: ContractData): Contract => {
         indexType: data.fees?.indexType ?? 'KPI 80',
       }),
     };
-    // Only include the supplementary avitext if it is non-blank (API rejects blank entries).
-    const supplementaryInfo = data.fees?.additionalInformation?.[1]?.trim();
-    if (supplementaryInfo) {
-      fees.additionalInformation?.push(supplementaryInfo);
-    }
   }
 
   // Strip personalNumber and stakeholderId from stakeholders before sending to API
@@ -585,12 +578,7 @@ export const contractToLagenhetsArrende = (contract: Contract): ContractData => 
     indexAdjusted: hasIndexation ? 'true' : 'false',
     fees: {
       ...contract.fees,
-      additionalInformation: [
-        // [0] = standardized fee description (read-only display, regenerated from type/leaseType).
-        feeDescription,
-        // [1] = preserve the saved supplementary avitext so it round-trips back into the form on load.
-        contract.fees?.additionalInformation?.[1] ?? '',
-      ],
+      additionalInformation: [feeDescription],
     },
   };
   return lagenhetsarrende;


### PR DESCRIPTION
Ta bort det editerbara fältet "Kompletterande avitext".

TEST: på avtalsfliken ska - under Löpande avgift - nu inte finnas "Kompletterande avitext" utan bara denna genererade:
<img width="793" height="228" alt="image" src="https://github.com/user-attachments/assets/08c3a9b1-315d-4c1f-b8f3-de28c07cafa2" />


Jira https://jira.sundsvall.se/browse/DRAKEN-4378

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [ ] New feature
- [x] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
