### PR TITLE
feat(channels): visa Mina sidor (MY_PAGES) i gränssnitt och filter

### DIFF
--- a/frontend/src/casedata/interfaces/channels.ts
+++ b/frontend/src/casedata/interfaces/channels.ts
@@ -5,6 +5,7 @@ export enum Channels {
   ESERVICE_KATLA = 'E-tjänst Färdstjänstregistrering',
   MOBILE = 'Telefon',
   SYSTEM = 'System',
+  MY_PAGES = 'Mina sidor',
 }
 
 export enum ApiChannels {
@@ -14,8 +15,17 @@ export enum ApiChannels {
   'E-tjänst Färdtjänstregistrering' = 'ESERVICE_KATLA',
   'Telefon' = 'MOBILE',
   'System' = 'SYSTEM',
+  'Mina sidor' = 'MY_PAGES',
 }
 export const AppChannels = {
-  MEX: [Channels.EMAIL, Channels.ESERVICE, Channels.WEB_UI, Channels.MOBILE, Channels.SYSTEM],
-  PT: [Channels.EMAIL, Channels.ESERVICE, Channels.WEB_UI, Channels.ESERVICE_KATLA, Channels.MOBILE, Channels.SYSTEM],
+  MEX: [Channels.EMAIL, Channels.ESERVICE, Channels.WEB_UI, Channels.MOBILE, Channels.SYSTEM, Channels.MY_PAGES],
+  PT: [
+    Channels.EMAIL,
+    Channels.ESERVICE,
+    Channels.WEB_UI,
+    Channels.ESERVICE_KATLA,
+    Channels.MOBILE,
+    Channels.SYSTEM,
+    Channels.MY_PAGES,
+  ],
 };


### PR DESCRIPTION
## Beskrivning
Ärenden som skapas från Mina sidor använder nu kanalen `MY_PAGES` på errand i CaseData. Denna PR gör att kanalen framgår i Draken-gränssnittet, med samma befintliga logik som övriga kanaler.

## Ändringar
- Lägger till `MY_PAGES = 'Mina sidor'` i `Channels`-enumet och `'Mina sidor' = 'MY_PAGES'` i `ApiChannels` (för konvertering vid sparande).
- Inkluderar `Channels.MY_PAGES` i `AppChannels` för både MEX och PT.

Backend (`ErrandChannelEnum`) stöder redan `MY_PAGES` — detta ytar kanalen i frontend.

## Effekt (allt via befintlig, dynamisk logik)
- **Ärendevyn** – "Inkom via" visar "Mina sidor".
- **Startvyns filter** – "Inkom via"-filtret får en kryssruta för Mina sidor.
- **Filter-taggar** – visar "Mina sidor"-chip.
- **Ärendelistan** – visar kanalen i tabellen.
- **Service-lagret** – konverterar `MY_PAGES` ↔ "Mina sidor" i båda riktningarna.

## Test
- `tsc --noEmit` passerar utan fel i berörda filer.

https://jira.sundsvall.se/browse/DRAKEN-3688
