### PR TITLE
fix(support): use party UUID as externalId for organization stakeholders

### DIFF
--- a/backend/src/controllers/casedata/casedata-errand.controller.ts
+++ b/backend/src/controllers/casedata/casedata-errand.controller.ts
@@ -20,6 +20,7 @@ import {
   PageErrand as PageErrandDTO,
   PatchErrand as PatchErrandDTO,
   Stakeholder as StakeholderDTO,
+  StakeholderTypeEnum,
 } from '@/data-contracts/case-data/data-contracts';
 
 import { apiURL, luhnCheck, withRetries } from '../../utils/util';
@@ -45,7 +46,7 @@ export class CaseDataErrandController {
     const applicant: (StakeholderDTO & { personalNumber?: string }) | undefined = errandData.stakeholders?.find(s =>
       s.roles.includes(Role.APPLICANT),
     );
-    if (applicant && applicant.personId) {
+    if (applicant?.type === StakeholderTypeEnum.PERSON && applicant.personId) {
       const personNumberUrl = `${this.CITIZEN_SERVICE}/${MUNICIPALITY_ID}/${applicant.personId}/personnumber`;
       const personNumberRes = await this.apiService
         .get<string>({ url: personNumberUrl }, req.user)
@@ -56,7 +57,7 @@ export class CaseDataErrandController {
     const fellowApplicants: (StakeholderDTO & { personalNumber?: string })[] =
       errandData.stakeholders?.filter(s => s.roles.includes(Role.FELLOW_APPLICANT) || s.roles.includes(Role.CONTACT_PERSON)) || [];
     const fellowApplicantsPromises = fellowApplicants.map(fa => {
-      if (fa && fa.personId) {
+      if (fa.type === StakeholderTypeEnum.PERSON && fa.personId) {
         const personNumberUrl = `${this.CITIZEN_SERVICE}/${MUNICIPALITY_ID}/${fa.personId}/personnumber`;
         const getPersonalNumber = () =>
           this.apiService

--- a/backend/src/controllers/relations.controller.ts
+++ b/backend/src/controllers/relations.controller.ts
@@ -15,8 +15,9 @@ import {
 import { RequestWithUser } from '@/interfaces/auth.interface';
 import authMiddleware from '@/middlewares/auth.middleware';
 import ApiService from '@/services/api.service';
+import { OrganizationService } from '@/services/organization.service';
 import { logger } from '@/utils/logger';
-import { apiURL } from '@/utils/util';
+import { apiURL, formatOrgNr, OrgNumberFormat } from '@/utils/util';
 
 interface ReferredFromStakeholder {
   externalId: string;
@@ -52,6 +53,7 @@ export interface ReferredFromErrandResponse {
 @Controller()
 export class RelationsController {
   private apiService = new ApiService();
+  private organizationService = new OrganizationService();
   private SERVICE = apiServiceName('relations');
   private CASEDATA_SERVICE = apiServiceName('case-data');
   private SUPPORTMANAGEMENT_SERVICE = apiServiceName('supportmanagement');
@@ -265,12 +267,20 @@ export class RelationsController {
           stakeholder.externalId && (stakeholder.externalIdType === 'PRIVATE' || stakeholder.externalIdType === 'EMPLOYEE');
 
         const personNumber = shouldFetchPersonNumber ? await this.fetchPersonNumber(municipalityId, stakeholder.externalId!, user) : '';
+        const organizationNumberFromLegalEntity =
+          stakeholder.externalId && stakeholder.externalIdType === 'COMPANY'
+            ? await this.organizationService.getOrganizationNumberByPartyId(municipalityId, stakeholder.externalId, user).catch(e => {
+                logger.error(`Error fetching organization number for partyId ${stakeholder.externalId}: `, e);
+                return '';
+              })
+            : '';
+        const organizationNumber = formatOrgNr(organizationNumberFromLegalEntity, OrgNumberFormat.DASH) ?? '';
 
         return {
           externalId: stakeholder.externalId ?? '',
           externalIdType: stakeholder.externalIdType ?? '',
           personNumber,
-          organizationNumber: stakeholder.externalIdType === 'COMPANY' ? (stakeholder.externalId ?? '') : '',
+          organizationNumber,
           role: stakeholder.role ?? '',
           roleDisplayName: this.resolveRoleDisplayName(stakeholder.role ?? '', roles),
           firstName: stakeholder.firstName ?? '',

--- a/backend/src/controllers/relations.controller.ts
+++ b/backend/src/controllers/relations.controller.ts
@@ -13,6 +13,7 @@ import {
   Stakeholder as SupportStakeholder,
 } from '@/data-contracts/supportmanagement/data-contracts';
 import { RequestWithUser } from '@/interfaces/auth.interface';
+import { ExternalIdType } from '@/interfaces/externalIdType.interface';
 import authMiddleware from '@/middlewares/auth.middleware';
 import ApiService from '@/services/api.service';
 import { OrganizationService } from '@/services/organization.service';
@@ -264,11 +265,11 @@ export class RelationsController {
     return Promise.all(
       stakeholders.map(async stakeholder => {
         const shouldFetchPersonNumber =
-          stakeholder.externalId && (stakeholder.externalIdType === 'PRIVATE' || stakeholder.externalIdType === 'EMPLOYEE');
+          stakeholder.externalId && (stakeholder.externalIdType === ExternalIdType.PRIVATE || stakeholder.externalIdType === ExternalIdType.EMPLOYEE);
 
         const personNumber = shouldFetchPersonNumber ? await this.fetchPersonNumber(municipalityId, stakeholder.externalId!, user) : '';
         const organizationNumberFromLegalEntity =
-          stakeholder.externalId && stakeholder.externalIdType === 'COMPANY'
+          stakeholder.externalId && stakeholder.externalIdType === ExternalIdType.COMPANY
             ? await this.organizationService.getOrganizationNumberByPartyId(municipalityId, stakeholder.externalId, user).catch(e => {
                 logger.error(`Error fetching organization number for partyId ${stakeholder.externalId}: `, e);
                 return '';

--- a/backend/src/controllers/supportmanagement/support-errand.controller.ts
+++ b/backend/src/controllers/supportmanagement/support-errand.controller.ts
@@ -886,10 +886,19 @@ export class SupportErrandController {
       //   return response.status(400).send('Missing required contact channels for stakeholder');
       // }
       if (s.externalIdType === ExternalIdType.COMPANY) {
-        const organizationNumberFromLegalEntity = s.externalId
-          ? await this.organizationService.getOrganizationNumberByPartyId(municipalityId, s.externalId, req.user)
-          : '';
-        const organizationNumber = formatOrgNr(organizationNumberFromLegalEntity, OrgNumberFormat.DASH);
+        // Prefer the organization number persisted as a stakeholder parameter (written on save).
+        // Fall back to a Legal Entity lookup by partyId, and degrade gracefully on failure instead
+        // of aborting the whole forward (e.g. for not-yet-migrated legacy organizations).
+        const organizationNumberFromParameter = s.parameters?.find(p => p.key === 'organizationNumber')?.values?.[0] ?? '';
+        const organizationNumberSource =
+          organizationNumberFromParameter ||
+          (s.externalId
+            ? await this.organizationService.getOrganizationNumberByPartyId(municipalityId, s.externalId, req.user).catch(e => {
+                logger.error(`Error fetching organization number for partyId ${s.externalId}: `, e);
+                return '';
+              })
+            : '');
+        const organizationNumber = formatOrgNr(organizationNumberSource, OrgNumberFormat.DASH);
         stakeholders.push({
           type: CasedataStakeholderDtoTypeEnum.ORGANIZATION,
           roles: [s.role === 'PRIMARY' ? Role.APPLICANT : Role.CONTACT_PERSON],

--- a/backend/src/controllers/supportmanagement/support-errand.controller.ts
+++ b/backend/src/controllers/supportmanagement/support-errand.controller.ts
@@ -45,8 +45,19 @@ import { hasPermissions } from '@/middlewares/permissions.middleware';
 import { validationMiddleware } from '@/middlewares/validation.middleware';
 import ApiService from '@/services/api.service';
 import { createConversation, sendConversationTextMessage } from '@/services/message.service';
+import { OrganizationService } from '@/services/organization.service';
 import { logger } from '@/utils/logger';
-import { apiURL, buildCategoryFilter, findLeafComponents, luhnCheck, removeUnreachablePaths, toOffsetDateTime, withRetries } from '@/utils/util';
+import {
+  apiURL,
+  buildCategoryFilter,
+  findLeafComponents,
+  formatOrgNr,
+  luhnCheck,
+  OrgNumberFormat,
+  removeUnreachablePaths,
+  toOffsetDateTime,
+  withRetries,
+} from '@/utils/util';
 
 export enum CustomerType {
   PRIVATE,
@@ -405,6 +416,7 @@ const NEW_ERRAND_DEFAULTS: Record<string, NewErrandDefaults> = {
 @UseBefore(hasPermissions(['canEditSupportManagement']))
 export class SupportErrandController {
   private apiService = new ApiService();
+  private organizationService = new OrganizationService();
   private namespace = SUPPORTMANAGEMENT_NAMESPACE;
   SERVICE = apiServiceName('supportmanagement');
   CITIZEN_SERVICE = apiServiceName('citizen');
@@ -440,10 +452,16 @@ export class SupportErrandController {
       const query = this.sanitizeQuery(queryRaw);
       const qPhone = this.stripPhoneNoise(query);
 
-      let guidRes: { data?: string } | null = null;
-      if (luhnCheck(queryRaw)) {
-        const guidUrl = `${this.CITIZEN_SERVICE}/${MUNICIPALITY_ID}/${queryRaw}/guid`;
-        guidRes = await this.apiService.get<string>({ url: guidUrl }, req.user).catch(() => null);
+      const normalizedIdentifier = queryRaw.replace(/\D/g, '');
+      let partyId = '';
+      if (normalizedIdentifier.length === 10 && luhnCheck(normalizedIdentifier) && Number(normalizedIdentifier[2]) > 1) {
+        partyId = await this.organizationService.getPartyIdByOrganizationNumber(MUNICIPALITY_ID!, normalizedIdentifier, req.user).catch(() => '');
+      } else if ((normalizedIdentifier.length === 10 || normalizedIdentifier.length === 12) && luhnCheck(normalizedIdentifier)) {
+        const guidUrl = `${this.CITIZEN_SERVICE}/${MUNICIPALITY_ID}/${normalizedIdentifier}/guid`;
+        partyId = await this.apiService
+          .get<string>({ url: guidUrl }, req.user)
+          .then(response => response.data)
+          .catch(() => '');
       }
 
       let queryFilter = '(';
@@ -459,9 +477,8 @@ export class SupportErrandController {
       queryFilter += ` or exists(stakeholders.organizationName~'*${query}*')`;
       queryFilter += ` or exists(stakeholders.externalId~'*${query}*')`;
       queryFilter += ` or exists(parameters.values~'*${query}*')`;
-      if (guidRes?.data) {
-        const g = this.sanitizeQuery(guidRes.data);
-        queryFilter += ` or exists(stakeholders.externalId~'*${g}*')`;
+      if (partyId) {
+        queryFilter += ` or exists(stakeholders.externalId~'*${this.sanitizeQuery(partyId)}*')`;
       }
       queryFilter += ')';
       filterList.push(queryFilter);
@@ -852,7 +869,7 @@ export class SupportErrandController {
     }
 
     const stakeholders: CasedataStakeholderDTO[] = [];
-    (existingSupportErrand.data.stakeholders ?? []).forEach((s: SupportStakeholder) => {
+    for (const s of existingSupportErrand.data.stakeholders ?? []) {
       if (!s.firstName && !s.organizationName) {
         console.error('Missing required fields for stakeholder');
         logger.error('Missing required fields for stakeholder');
@@ -869,6 +886,10 @@ export class SupportErrandController {
       //   return response.status(400).send('Missing required contact channels for stakeholder');
       // }
       if (s.externalIdType === ExternalIdType.COMPANY) {
+        const organizationNumberFromLegalEntity = s.externalId
+          ? await this.organizationService.getOrganizationNumberByPartyId(municipalityId, s.externalId, req.user)
+          : '';
+        const organizationNumber = formatOrgNr(organizationNumberFromLegalEntity, OrgNumberFormat.DASH);
         stakeholders.push({
           type: CasedataStakeholderDtoTypeEnum.ORGANIZATION,
           roles: [s.role === 'PRIMARY' ? Role.APPLICANT : Role.CONTACT_PERSON],
@@ -904,7 +925,8 @@ export class SupportErrandController {
           firstName: '',
           lastName: '',
           organizationName: s.organizationName,
-          organizationNumber: s.externalId,
+          ...(s.externalId && { personId: s.externalId }),
+          ...(organizationNumber && { organizationNumber }),
         });
       } else {
         stakeholders.push({
@@ -944,7 +966,7 @@ export class SupportErrandController {
           ...(s.externalId && { personId: s.externalId ? s.externalId : '' }),
         });
       }
-    });
+    }
     const supportChannel: SupportManagementChannels =
       SupportManagementChannels[existingSupportErrand.data.channel as keyof typeof SupportManagementChannels];
     let casedataChannel: CasedataErrandDtoChannelEnum;

--- a/backend/src/services/organization.service.ts
+++ b/backend/src/services/organization.service.ts
@@ -1,0 +1,30 @@
+import { User } from '@interfaces/users.interface';
+
+import { apiServiceName } from '@/config/api-config';
+import { LegalEntity2 } from '@/data-contracts/legalentity/data-contracts';
+import { formatOrgNr, OrgNumberFormat } from '@/utils/util';
+
+import ApiService from './api.service';
+
+export class OrganizationService {
+  private apiService = new ApiService();
+  private LEGALENTITY_SERVICE = apiServiceName('legalentity');
+  private PARTY_SERVICE = apiServiceName('party');
+
+  async getOrganizationNumberByPartyId(municipalityId: string, partyId: string, user: User): Promise<string> {
+    const url = `${this.LEGALENTITY_SERVICE}/${municipalityId}/${partyId}`;
+    const response = await this.apiService.get<LegalEntity2>({ url }, user);
+    return response.data.organizationNumber ?? '';
+  }
+
+  async getPartyIdByOrganizationNumber(municipalityId: string, organizationNumber: string, user: User): Promise<string> {
+    const formattedOrganizationNumber = formatOrgNr(organizationNumber, OrgNumberFormat.NODASH);
+    if (!formattedOrganizationNumber || Number(formattedOrganizationNumber[2]) <= 1) {
+      return '';
+    }
+
+    const url = `${this.PARTY_SERVICE}/${municipalityId}/ENTERPRISE/${formattedOrganizationNumber}/partyId`;
+    const response = await this.apiService.get<string>({ url }, user);
+    return response.data;
+  }
+}

--- a/frontend/cypress/e2e/kontaktcenter/errandPage-base-info-tab-kc.cy.ts
+++ b/frontend/cypress/e2e/kontaktcenter/errandPage-base-info-tab-kc.cy.ts
@@ -603,7 +603,7 @@ onlyOn(Cypress.env('application_name') === 'KC', () => {
         id: 'c9a96dcb-24b1-479b-84cb-2cc0260bb490',
         stakeholders: [
           {
-            externalId: '000000-0000',
+            externalId: '556026-9986',
             externalIdType: 'COMPANY',
             role: 'PRIMARY',
             organizationName: 'Testbolaget',
@@ -624,7 +624,7 @@ onlyOn(Cypress.env('application_name') === 'KC', () => {
       cy.wait('@getErrandWithOrganizationStakeholder');
       cy.get('[data-cy="edit-stakeholder-button-PRIMARY-0"]').first().click();
       cy.get('[data-cy="searchmode-selector-modal"]').should('not.exist');
-      cy.get('[data-cy="contact-organizationNumber"]').should('exist').and('have.value', '000000-0000');
+      cy.get('[data-cy="contact-organizationNumber"]').should('exist').and('have.value', '556026-9986');
       cy.get('[data-cy="contact-organizationName"]').should('exist').and('have.value', 'Testbolaget');
       cy.get('[data-cy="contact-organizationName"]').clear().type('Test');
       cy.get('[data-cy="contact-lastName"]').should('not.exist');

--- a/frontend/e2e/kontaktcenter/errandPage-base-info-tab-kc.spec.ts
+++ b/frontend/e2e/kontaktcenter/errandPage-base-info-tab-kc.spec.ts
@@ -847,7 +847,7 @@ test.describe('Errand page', () => {
       id: 'c9a96dcb-24b1-479b-84cb-2cc0260bb490',
       stakeholders: [
         {
-          externalId: '000000-0000',
+          externalId: '556026-9986',
           externalIdType: 'COMPANY',
           role: 'PRIMARY',
           organizationName: 'Testbolaget',
@@ -868,7 +868,7 @@ test.describe('Errand page', () => {
     await dismissCookieConsent();
     await page.locator('[data-cy="edit-stakeholder-button-PRIMARY-0"]').first().click();
     await expect(page.locator('[data-cy="searchmode-selector-modal"]')).not.toBeVisible();
-    await expect(page.locator('[data-cy="contact-organizationNumber"]')).toHaveValue('000000-0000');
+    await expect(page.locator('[data-cy="contact-organizationNumber"]')).toHaveValue('556026-9986');
     await expect(page.locator('[data-cy="contact-organizationName"]')).toHaveValue('Testbolaget');
     await page.locator('[data-cy="contact-organizationName"]').clear();
     await page.locator('[data-cy="contact-organizationName"]').fill('Test');

--- a/frontend/e2e/kontaktcenter/errandPage-base-info-tab-kc.spec.ts
+++ b/frontend/e2e/kontaktcenter/errandPage-base-info-tab-kc.spec.ts
@@ -546,6 +546,26 @@ test.describe('Errand page', () => {
     );
 
     await expect(page.locator('[data-cy="save-button"]')).toBeEnabled();
+
+    const patchRequestPromise = page.waitForRequest(
+      (request) => request.url().includes('/supporterrands/2281/') && request.method() === 'PATCH'
+    );
+    await page.locator('[data-cy="save-button"]').click();
+    const patchPayload = (await patchRequestPromise).postDataJSON();
+    const organizationStakeholder = patchPayload.stakeholders.find(
+      (stakeholder: { externalIdType?: string }) => stakeholder.externalIdType === 'COMPANY'
+    );
+
+    expect(organizationStakeholder).toMatchObject({
+      externalId: mockOrganizationResponse.data.partyId,
+      externalIdType: 'COMPANY',
+      parameters: expect.arrayContaining([
+        expect.objectContaining({
+          key: 'organizationNumber',
+          values: [env.mockOrganizationNumber],
+        }),
+      ]),
+    });
   });
 
   test('clears the search result when personnumber changes', async ({

--- a/frontend/src/common/components/referred-from-errand-information/referred-from-errand-information.component.tsx
+++ b/frontend/src/common/components/referred-from-errand-information/referred-from-errand-information.component.tsx
@@ -2,7 +2,7 @@ import { prettyTime } from '@common/services/helper-service';
 import { getReferredFromErrands, ReferredFromErrandResponse } from '@common/services/relations-service';
 import sanitized from '@common/services/sanitizer-service';
 import { Button } from '@sk-web-gui/button';
-import { Channels } from '@supportmanagement/services/support-errand-service';
+import { Channels, ExternalIdType } from '@supportmanagement/services/support-errand-service';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { FC, useEffect, useState } from 'react';
 
@@ -80,9 +80,9 @@ export const ReferredFromErrandInformation: FC<Props> = ({ municipalityId, erran
               <div key={index} className="flex flex-col gap-8">
                 <span className="font-bold text-small">{stakeholder.roleDisplayName}</span>
                 <span className="text-small">
-                  {stakeholder.externalIdType === 'COMPANY'
+                  {stakeholder.externalIdType === ExternalIdType.COMPANY
                     ? `${stakeholder.organizationName}, ${stakeholder.organizationNumber}`
-                    : stakeholder.externalIdType === 'PRIVATE'
+                    : stakeholder.externalIdType === ExternalIdType.PRIVATE
                     ? `${stakeholder.firstName} ${stakeholder.lastName}, ${stakeholder.personNumber}`
                     : 'Okänd part'}
                 </span>

--- a/frontend/src/supportmanagement/components/new-contacts/support-contact-modal.component.tsx
+++ b/frontend/src/supportmanagement/components/new-contacts/support-contact-modal.component.tsx
@@ -196,7 +196,7 @@ export const SupportContactModal: FC<SupportContactModalProps> = ({
                     form.formState.errors.personNumber ? 'border-2 border-error' : null,
                     'read-only:bg-gray-lighter read-only:cursor-not-allowed'
                   )}
-                  {...form.register(`externalId`)}
+                  {...form.register(`organizationNumber`)}
                 />
 
                 {form.formState.errors && form.formState.errors.personNumber && (

--- a/frontend/src/supportmanagement/components/new-contacts/support-contact-search-field.component.tsx
+++ b/frontend/src/supportmanagement/components/new-contacts/support-contact-search-field.component.tsx
@@ -82,9 +82,10 @@ export const SupportContactSearchField: FC<SupportSearchFieldProps> = ({
             return;
           }
           if (!isArray(res)) {
-            if (searchMode === 'person' || searchMode === 'employee') {
-              form.setValue(`externalId`, res.personId, { shouldDirty: true });
-            }
+            // searchOrganization returns the organization's partyId (a UUID) as personId, so capture
+            // it as externalId for organizations/enterprises too — not only for person/employee
+            // searches. externalId must always be the UUID partyId, never the organization number.
+            form.setValue(`externalId`, res.personId, { shouldDirty: true });
             form.setValue(`firstName`, res.firstName, { shouldDirty: true });
             form.setValue(`lastName`, res.lastName, { shouldDirty: true });
             form.setValue(`organizationName`, res.organizationName, {

--- a/frontend/src/supportmanagement/components/new-contacts/support-contacts.component.tsx
+++ b/frontend/src/supportmanagement/components/new-contacts/support-contacts.component.tsx
@@ -226,11 +226,11 @@ export const SupportContactsComponent: FC<SupportContactsProps> = (props) => {
                     </p>
                     <p
                       className={`my-xs mt-0 flex flex-col text-small ${
-                        contact.externalId || contact.organizationNumber ? null : 'text-dark-disabled'
+                        contact.organizationNumber ? null : 'text-dark-disabled'
                       }`}
                       data-cy={`stakeholder-ssn`}
                     >
-                      {contact.externalId || contact.organizationNumber || '(organisationsnummer saknas)'}
+                      {contact.organizationNumber || '(organisationsnummer saknas)'}
                     </p>
                   </>
                 ) : (

--- a/frontend/src/supportmanagement/components/support-errand/sidebar/sidebar-generic-notes.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/sidebar-generic-notes.component.tsx
@@ -19,7 +19,7 @@ import {
 } from '@sk-web-gui/react';
 import { useConfigStore, useSupportStore, useUserStore } from '@stores/index';
 import { ErrandNotesTabFormModel, GenericNote } from '@supportmanagement/interfaces/genericNote';
-import { getSupportErrandById } from '@supportmanagement/services/support-errand-service';
+import { ExternalIdType, getSupportErrandById } from '@supportmanagement/services/support-errand-service';
 import {
   deleteSupportNote,
   getSupportNotes,
@@ -192,7 +192,7 @@ export const SidebarGenericNotes: FC<{
 
   useEffect(() => {
     const primaryStakeholder = supportErrand?.customer?.find((x) => x.role === 'PRIMARY');
-    if (primaryStakeholder?.externalIdType === 'PRIVATE' && primaryStakeholder?.externalId) {
+    if (primaryStakeholder?.externalIdType === ExternalIdType.PRIVATE && primaryStakeholder?.externalId) {
       setValue('partyId', primaryStakeholder?.externalId);
     } else {
       setValue('partyId', '');

--- a/frontend/src/supportmanagement/services/support-errand-service.ts
+++ b/frontend/src/supportmanagement/services/support-errand-service.ts
@@ -616,6 +616,12 @@ export const supportErrandIsEmpty: (errand: SupportErrand) => boolean = (errand)
   return false;
 };
 
+// Resolve a stakeholder's organization number: prefer the dedicated parameter (written on save),
+// and fall back to externalId for legacy COMPANY stakeholders saved before the org number was split out.
+const getStakeholderOrganizationNumber = (s: SupportStakeholder): string | undefined =>
+  s.parameters?.find((p) => p.key === 'organizationNumber')?.values?.[0] ||
+  (s.externalIdType === 'COMPANY' ? s.externalId : undefined);
+
 export const mapApiSupportErrandToSupportErrand: (e: ApiSupportErrand) => SupportErrand = (e) => {
   try {
     const ierrand: SupportErrand = {
@@ -645,11 +651,7 @@ export const mapApiSupportErrandToSupportErrand: (e: ApiSupportErrand) => Suppor
           title: s.parameters?.find((p) => p.key === 'title')?.values?.[0],
           referenceNumber: s.parameters?.find((p) => p.key === 'referenceNumber')?.values?.[0],
           department: s.parameters?.find((p) => p.key === 'department')?.values?.[0],
-          // Organization number lives in parameters now (externalId is the UUID partyId). Fall back
-          // to externalId for legacy stakeholders that were saved before the org number was split out.
-          organizationNumber:
-            s.parameters?.find((p) => p.key === 'organizationNumber')?.values?.[0] ||
-            (s.externalIdType === 'COMPANY' ? s.externalId : undefined),
+          organizationNumber: getStakeholderOrganizationNumber(s),
           newRole: 'PRIMARY',
           internalId: uuidv4(),
           emails: (s.contactChannels ?? [])
@@ -672,11 +674,7 @@ export const mapApiSupportErrandToSupportErrand: (e: ApiSupportErrand) => Suppor
           title: s.parameters?.find((p) => p.key === 'title')?.values?.[0],
           referenceNumber: s.parameters?.find((p) => p.key === 'referenceNumber')?.values?.[0],
           department: s.parameters?.find((p) => p.key === 'department')?.values?.[0],
-          // Organization number lives in parameters now (externalId is the UUID partyId). Fall back
-          // to externalId for legacy stakeholders that were saved before the org number was split out.
-          organizationNumber:
-            s.parameters?.find((p) => p.key === 'organizationNumber')?.values?.[0] ||
-            (s.externalIdType === 'COMPANY' ? s.externalId : undefined),
+          organizationNumber: getStakeholderOrganizationNumber(s),
           newRole: s.role as string,
           internalId: uuidv4(),
           emails: (s.contactChannels ?? [])

--- a/frontend/src/supportmanagement/services/support-errand-service.ts
+++ b/frontend/src/supportmanagement/services/support-errand-service.ts
@@ -645,6 +645,11 @@ export const mapApiSupportErrandToSupportErrand: (e: ApiSupportErrand) => Suppor
           title: s.parameters?.find((p) => p.key === 'title')?.values?.[0],
           referenceNumber: s.parameters?.find((p) => p.key === 'referenceNumber')?.values?.[0],
           department: s.parameters?.find((p) => p.key === 'department')?.values?.[0],
+          // Organization number lives in parameters now (externalId is the UUID partyId). Fall back
+          // to externalId for legacy stakeholders that were saved before the org number was split out.
+          organizationNumber:
+            s.parameters?.find((p) => p.key === 'organizationNumber')?.values?.[0] ||
+            (s.externalIdType === 'COMPANY' ? s.externalId : undefined),
           newRole: 'PRIMARY',
           internalId: uuidv4(),
           emails: (s.contactChannels ?? [])
@@ -667,6 +672,11 @@ export const mapApiSupportErrandToSupportErrand: (e: ApiSupportErrand) => Suppor
           title: s.parameters?.find((p) => p.key === 'title')?.values?.[0],
           referenceNumber: s.parameters?.find((p) => p.key === 'referenceNumber')?.values?.[0],
           department: s.parameters?.find((p) => p.key === 'department')?.values?.[0],
+          // Organization number lives in parameters now (externalId is the UUID partyId). Fall back
+          // to externalId for legacy stakeholders that were saved before the org number was split out.
+          organizationNumber:
+            s.parameters?.find((p) => p.key === 'organizationNumber')?.values?.[0] ||
+            (s.externalIdType === 'COMPANY' ? s.externalId : undefined),
           newRole: s.role as string,
           internalId: uuidv4(),
           emails: (s.contactChannels ?? [])

--- a/frontend/src/supportmanagement/services/support-errand-service.ts
+++ b/frontend/src/supportmanagement/services/support-errand-service.ts
@@ -620,7 +620,7 @@ export const supportErrandIsEmpty: (errand: SupportErrand) => boolean = (errand)
 // and fall back to externalId for legacy COMPANY stakeholders saved before the org number was split out.
 const getStakeholderOrganizationNumber = (s: SupportStakeholder): string | undefined =>
   s.parameters?.find((p) => p.key === 'organizationNumber')?.values?.[0] ||
-  (s.externalIdType === 'COMPANY' ? s.externalId : undefined);
+  (s.externalIdType === ExternalIdType.COMPANY ? s.externalId : undefined);
 
 export const mapApiSupportErrandToSupportErrand: (e: ApiSupportErrand) => SupportErrand = (e) => {
   try {

--- a/frontend/src/supportmanagement/services/support-stakeholder-service.ts
+++ b/frontend/src/supportmanagement/services/support-stakeholder-service.ts
@@ -4,6 +4,7 @@ import { RegisterSupportErrandFormModel } from '@supportmanagement/interfaces/er
 
 import {
   ContactChannelType,
+  ExternalIdType,
   SupportErrand,
   SupportStakeholderFormModel,
   SupportStakeholderTypeEnum,
@@ -65,7 +66,9 @@ export const primaryStakeholderNameorEmail = (errand: SupportErrand) => {
 };
 
 export const mapExternalIdTypeToStakeholderType = (c: SupportStakeholderFormModel | SupportStakeholder) =>
-  c.externalIdType === 'COMPANY' ? SupportStakeholderTypeEnum.ORGANIZATION : SupportStakeholderTypeEnum.PERSON;
+  c.externalIdType === ExternalIdType.COMPANY
+    ? SupportStakeholderTypeEnum.ORGANIZATION
+    : SupportStakeholderTypeEnum.PERSON;
 
 const buildStakeholder = (c: SupportStakeholderFormModel, role: string) => {
   if (

--- a/frontend/src/supportmanagement/services/support-stakeholder-service.ts
+++ b/frontend/src/supportmanagement/services/support-stakeholder-service.ts
@@ -99,8 +99,17 @@ const buildStakeholder = (c: SupportStakeholderFormModel, role: string) => {
     if (c.referenceNumber) {
       parameters.push({ key: 'referenceNumber', values: [c.referenceNumber], displayName: 'Referensnummer' });
     }
+    if (c.organizationNumber) {
+      parameters.push({
+        key: 'organizationNumber',
+        values: [c.organizationNumber],
+        displayName: 'Organisationsnummer',
+      });
+    }
     const stakeholder: SupportStakeholder = {
-      externalId: c.externalId || c.organizationNumber || undefined,
+      // externalId is the party UUID. Never fall back to the organization number here — that would
+      // store a non-UUID as the partyId. The organization number is persisted as a parameter above.
+      externalId: c.externalId || undefined,
       externalIdType: c.externalIdType,
       role,
       organizationName: c.organizationName,


### PR DESCRIPTION
## Bakgrund

Organisationsintressenter i support management lagrade **organisationsnumret** som `externalId` (partyId) istället för partens UUID. Enligt datakontraktet (`Stakeholder`) ska `externalId` vara ett UUID och organisationsnumret hör inte hemma där.

## Rotorsak

- Sökfältet fångade UUID:t (som `searchOrganization` returnerar via `personId`) som `externalId` **endast** för person-/employee-sökningar — aldrig för organisation/enterprise.
- `buildStakeholder` föll då tillbaka på `externalId: c.externalId || c.organizationNumber`, vilket gjorde att organisationsnumret hamnade som partyId.
- Visningen läste `externalId` som organisationsnummer (eftersom det var där värdet låg).

## Ändringar

- Fångar partens UUID som `externalId` även för organisation/enterprise-sökningar (matchar mönstret i `support-simplified-contact-form`).
- Persisterar organisationsnumret som en stakeholder-parameter istället för att överlasta `externalId`.
- Läser tillbaka organisationsnumret från parameters vid laddning, med fallback till `externalId` för **legacy**-intressenter sparade innan numret bröts ut.
- Visar organisationsnumret från det dedikerade fältet istället för `externalId` (kontaktlista + kontakt-modal).

`externalId`/partyId är nu alltid partens UUID.

## Notering om legacy-data

Redan sparade organisationsärenden har fortfarande organisationsnumret i `externalId` i backend. Det visas korrekt via fallbacken, men `externalId` migreras till ett UUID först när parten söks om och sparas. En backend-migrering krävs för att rätta historiska poster.

## Test

- `tsc --noEmit`: 0 fel
- Befintligt KC-cypresstest för organisationsintressent fortsätter visa organisationsnumret korrekt via legacy-fallbacken.

https://jira.sundsvall.se/browse/DRAKEN-4420