### PR TITLE
feat: fritextfält för resor vid riksfärdtjänst från e-tjänst

### DIFF
--- a/frontend/src/casedata/components/errand/extraparameter-templates/paratransit-templates/paratransit-national-eservice.ts
+++ b/frontend/src/casedata/components/errand/extraparameter-templates/paratransit-templates/paratransit-national-eservice.ts
@@ -25,7 +25,7 @@ export const nationalEservice_UppgiftFieldTemplate: UppgiftField[] = notificatio
           value: '',
           label: 'Resor',
           description:
-            'Fritext från e-tjänsten: vilken kommun och ort resan sker från och till, samt datum eller månad.',
+            'Ange vilken kommun och vilken ort du ska åka från och till. Ange även vilket datum resan ska ske. Vet du inte exakt datum anger du månad.',
           formField: {
             type: 'textarea',
           },

--- a/frontend/src/casedata/components/errand/extraparameter-templates/paratransit-templates/paratransit-national-eservice.ts
+++ b/frontend/src/casedata/components/errand/extraparameter-templates/paratransit-templates/paratransit-national-eservice.ts
@@ -1,0 +1,36 @@
+/**
+ * OBS: Denna fritextshantering finns på grund av begränsningar i e-tjänsten openE.
+ * openE saknar stöd för den specialhantering vi byggt i denna applikation med
+ * x antal resor med egna strukturerade fält. Vi kan därför inte bygga reslistan
+ * som vi vill för ärenden som kommer in den vägen – openE löser det i stället med
+ * ett enda fritextfält. Den här mallen speglar den begränsningen.
+ */
+import { UppgiftField } from '@casedata/services/casedata-extra-parameters-service';
+
+import { notificationNational_UppgiftFieldTemplate } from './paratransit-notification-national';
+
+// Nyckeln som fritextfältet läser/sparar. E-tjänsten skickar in restexten på denna
+// extraParameter-nyckel. Måste matcha exakt det e-tjänsten skickar.
+export const NATIONAL_ESERVICE_JOURNEY_FIELD = 'personal.journeyText';
+
+// Variant av den nationella riksfärdtjänstmallen (Ansökan riksfärdtjänst) som används
+// när ärendet kommit in via e-tjänsten (Channels.ESERVICE). E-tjänsten saknar stöd för
+// den strukturerade reslistan (x antal resor med egna fält), så där anges resorna som en
+// enda fritext. Här byts därför den repeterbara journey-gruppen mot ett textarea-fält.
+export const nationalEservice_UppgiftFieldTemplate: UppgiftField[] = notificationNational_UppgiftFieldTemplate.map(
+  (field) =>
+    field.field === 'personal.journey'
+      ? ({
+          field: NATIONAL_ESERVICE_JOURNEY_FIELD,
+          value: '',
+          label: 'Resor',
+          description:
+            'Fritext från e-tjänsten: vilken kommun och ort resan sker från och till, samt datum eller månad.',
+          formField: {
+            type: 'textarea',
+          },
+          section: 'Yttre omständigheter',
+          required: true,
+        } as UppgiftField)
+      : field
+);

--- a/frontend/src/casedata/components/errand/tabs/details/casedata-details-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/details/casedata-details-tab.tsx
@@ -151,12 +151,12 @@ export const CasedataDetailsTab: React.FC<CasedataDetailsProps> = (props) => {
   const sections: { label: string; icon: IconName }[] = [
     { label: 'Övergripande', icon: 'text' },
     { label: 'Datum', icon: 'calendar' },
-    { label: 'Uppsägning', icon: 'file-signature' },
+    { label: 'Uppsägning', icon: 'file-pen' },
     { label: 'Köpa & sälja', icon: 'wallet' },
     { label: 'Vägbidrag', icon: 'helping-hand' },
-    { label: 'Yttre omständigheter', icon: 'clipboard-signature' },
+    { label: 'Yttre omständigheter', icon: 'clipboard-pen' },
     { label: 'Personlig information', icon: 'person-standing' },
-    { label: 'Medicinskt utlåtande', icon: 'clipboard-signature' },
+    { label: 'Medicinskt utlåtande', icon: 'clipboard-pen' },
   ];
 
   return (

--- a/frontend/src/casedata/components/errand/tabs/details/casedata-formfield-renderer.tsx
+++ b/frontend/src/casedata/components/errand/tabs/details/casedata-formfield-renderer.tsx
@@ -11,6 +11,7 @@ import {
   Combobox,
   cx,
   FormControl,
+  FormHelperText,
   FormLabel,
   Input,
   RadioButton,
@@ -201,7 +202,7 @@ export const CasedataFormFieldRenderer: FC<Props> = ({ detail, idx, form, errand
     return (
       <div key={`${detail.field}-${idx}`} className="w-full mt-lg">
         {detail.label && <FormLabel className="mb-md">{detail.label}</FormLabel>}
-        {detail.description && <p className="text-sm text-gray-600 mb-md">{detail.description}</p>}
+        {detail.description && <p className="mb-md text-small text-dark-secondary">{detail.description}</p>}
         <RepeatableFieldGroup
           groupName={groupConfig.groupName}
           basePath={groupConfig.basePath}
@@ -242,6 +243,10 @@ export const CasedataFormFieldRenderer: FC<Props> = ({ detail, idx, form, errand
       {!detail.field.includes('account.') && detail.label !== '' ? (
         <FormLabel className="mt-lg">{detail.label}</FormLabel>
       ) : null}
+
+      {detail.description && (
+        <FormHelperText className="m-0 mb-sm p-0 text-small text-dark-secondary">{detail.description}</FormHelperText>
+      )}
 
       {(detail.formField.type === 'text' ||
         detail.formField.type === 'date' ||

--- a/frontend/src/casedata/services/casedata-extra-parameters-service.ts
+++ b/frontend/src/casedata/services/casedata-extra-parameters-service.ts
@@ -17,6 +17,7 @@ import { mexSellLandToTheMunicipality_UppgiftFieldTemplate } from '@casedata/com
 import { mexSquarePlace_UppgiftFieldTemplate } from '@casedata/components/errand/extraparameter-templates/mex-templates/mex-square-place';
 import { mexTerminationOfLease_UppgiftFieldTemplate } from '@casedata/components/errand/extraparameter-templates/mex-templates/mex-termination-of-lease';
 import { changeApplication_UppgiftFieldTemplate } from '@casedata/components/errand/extraparameter-templates/paratransit-templates/paratransit-change-application';
+import { nationalEservice_UppgiftFieldTemplate } from '@casedata/components/errand/extraparameter-templates/paratransit-templates/paratransit-national-eservice';
 import { notification_UppgiftFieldTemplate } from '@casedata/components/errand/extraparameter-templates/paratransit-templates/paratransit-notification';
 import { notificationBusCard_UppgiftFieldTemplate } from '@casedata/components/errand/extraparameter-templates/paratransit-templates/paratransit-notification-bus-card';
 import { notificationChange_UppgiftFieldTemplate } from '@casedata/components/errand/extraparameter-templates/paratransit-templates/paratransit-notification-change';
@@ -29,6 +30,8 @@ import { parkingPermitAppeal_UppgiftFieldTemplate } from '@casedata/components/e
 import { lostParkingPermit_UppgiftFieldTemplate } from '@casedata/components/errand/extraparameter-templates/parkingpermit-templates/parkingpermit-lost-parking-permit';
 import { parkingPermit_UppgiftFieldTemplate } from '@casedata/components/errand/extraparameter-templates/parkingpermit-templates/parkingpermit-parkingpermit';
 import { parkingPermitRenewal_UppgiftFieldTemplate } from '@casedata/components/errand/extraparameter-templates/parkingpermit-templates/parkingpermit-renewal';
+import { CaseType } from '@casedata/interfaces/case-type';
+import { Channels } from '@casedata/interfaces/channels';
 import { IErrand } from '@casedata/interfaces/errand';
 import { ExtraParameter } from '@common/data-contracts/case-data/data-contracts';
 import { apiService } from '@common/services/api-service';
@@ -194,14 +197,19 @@ const template: ExtraParametersObject = {
   MEX_BUY_LAND_FROM_THE_MUNICIPALITY: mexBuyLandFromTheMunicipality_UppgiftFieldTemplate,
 };
 
-export const getExtraParametersLabels = (caseType: string): { [key: string]: string } => {
-  return (template as Record<string, any>)[caseType]?.reduce(
-    (acc: Record<string, string>, field: { field: string; label: string }) => {
-      acc[field.field] = field.label;
-      return acc;
-    },
-    {} as Record<string, string>
-  );
+// Nationella riksfärdtjänstansökningar (PARATRANSIT_NATIONAL) som kommit in via e-tjänsten
+// använder en fritextvariant av mallen i stället för den strukturerade reslistan.
+const isNationalEserviceErrand = (caseType: string, channel?: string): boolean =>
+  caseType === CaseType.PARATRANSIT_NATIONAL && channel === Channels.ESERVICE;
+
+export const getExtraParametersLabels = (caseType: string, channel?: string): { [key: string]: string } => {
+  const labelTemplate = isNationalEserviceErrand(caseType, channel)
+    ? nationalEservice_UppgiftFieldTemplate
+    : (template as Record<string, any>)[caseType];
+  return labelTemplate?.reduce((acc: Record<string, string>, field: { field: string; label: string }) => {
+    acc[field.field] = field.label;
+    return acc;
+  }, {} as Record<string, string>);
 };
 
 export const extraParametersToUppgiftMapper: (errand: IErrand) => UppgiftField[] = (errand) => {
@@ -216,7 +224,9 @@ export const extraParametersToUppgiftMapper: (errand: IErrand) => UppgiftField[]
 
   const caseType = errand.caseType;
   const resolvedCaseType = caseTypeTemplateAlias[caseType] ?? caseType;
-  const caseTypeTemplate = (template[resolvedCaseType] as UppgiftField[]) || baseDetails;
+  const caseTypeTemplate = isNationalEserviceErrand(caseType, errand.channel)
+    ? nationalEservice_UppgiftFieldTemplate
+    : (template[resolvedCaseType] as UppgiftField[]) || baseDetails;
 
   obj[caseType] = caseTypeTemplate?.map((field) => ({ ...field })) || [];
 

--- a/frontend/src/common/services/export-service.ts
+++ b/frontend/src/common/services/export-service.ts
@@ -69,7 +69,7 @@ export const exportSingleErrand: (
         key: ep.field,
         displayName: ep.label,
         values: Array.isArray(ep.value) ? ep.value : [ep.value],
-        label: getExtraParametersLabels(errand.caseType)?.[ep.field] || '',
+        label: getExtraParametersLabels(errand.caseType, errand.channel)?.[ep.field] || '',
       })),
   };
 


### PR DESCRIPTION
## Vad
Riksfärdtjänstansökningar (`PARATRANSIT_NATIONAL`) som kommer in via e-tjänsten **openE** får nu ett enda fritextfält **"Resor"** i stället för den strukturerade reslistan (x antal resor med egna fält).

## Varför
openE saknar stöd för den specialhantering som byggts i denna applikation med flera resor och egna strukturerade fält. Där löses resorna i stället med ett enda fritextfält, och handläggarvyn behöver spegla det för dessa ärenden.

## Hur
- Ny mallvariant `nationalEservice_UppgiftFieldTemplate` (`paratransit-national-eservice.ts`) – kopia av den nationella mallen där den repeterbara `personal.journey`-gruppen byts mot ett `textarea`-fält. Fritexten lagras/läses på nyckeln `personal.journeyText` (konstanten `NATIONAL_ESERVICE_JOURNEY_FIELD`).
- `extraParametersToUppgiftMapper` och `getExtraParametersLabels` väljer variantmallen när `caseType === PARATRANSIT_NATIONAL` **och** `channel === ESERVICE` (hjälpare `isNationalEserviceErrand`).
- `export-service` skickar med `channel` så PDF-etiketterna stämmer för varianten.

## Avgränsning
- Påverkar **endast** Ansökan riksfärdtjänst inkommen via kanalen ESERVICE.
- Manuellt registrerade ärenden (WEB_UI), Anmälan riksfärdtjänst och övriga FT-typer är oförändrade – strukturerad reslista kvar.

## Beroende
Fältet fylls automatiskt först när openE skickar restexten som en `extraParameter` med nyckeln `personal.journeyText`.

## Övriga rättningar i denna PR
- **Hjälptext för detaljfält visas nu.** Renderaren (`casedata-formfield-renderer.tsx`) visade tidigare `description` endast för `repeatableGroup`/`info`/`alert`. Nu visas hjälptext även för vanliga fält (text, textarea, select m.fl.) via `FormHelperText` med `text-small text-dark-secondary` som följer ljust/mörkt färgschema. Detta gör att Resor-hjälptexten och redan inlagda hjälptexter (t.ex. riksfärdtjänst-noten på "Beskriv ändamålet med resan") blir synliga och läsbara i båda lägena.
- **Saknade sektionsikoner åter.** `casedata-details-tab.tsx` begärde lucide-namn (`clipboard-signature`, `file-signature`) som inte längre finns i `iconMap` efter migrering till nya namn. Uppdaterade till `clipboard-pen`/`file-pen` så ikonerna visas igen för Yttre omständigheter, Medicinskt utlåtande och Uppsägning.

## Verifiering
- `yarn type-check` → 0 fel
- `eslint` på berörda filer → rent

https://jira.sundsvall.se/browse/DRAKEN-4461
