### PR TITLE
feat: visa medicinskt utlåtande som egen sektion endast för katla-färdtjänst

### DIFF
--- a/frontend/src/casedata/components/errand/tabs/details/casedata-details-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/details/casedata-details-tab.tsx
@@ -1,3 +1,4 @@
+import { Channels } from '@casedata/interfaces/channels';
 import { IErrand } from '@casedata/interfaces/errand';
 import { getErrand } from '@casedata/services/casedata-errand-service';
 import {
@@ -70,8 +71,18 @@ export const CasedataDetailsTab: React.FC<CasedataDetailsProps> = (props) => {
   };
 
   useEffect(() => {
+    const mappedFields: UppgiftField[] = (errand ? extraParametersToUppgiftMapper(errand) : undefined) || baseDetails;
+
+    // Medicinskt utlåtande visas som egen sektion endast när ärendet kommit in via
+    // katla-färdtjänsten (Channels.ESERVICE_KATLA). För övriga kanaler flyttas de
+    // medicinska fälten in under Yttre omständigheter (externa fält först, sedan
+    // medicinska enligt mallens ordning) och ingen separat medicinsk sektion visas.
     const uppgifterFields: UppgiftField[] =
-      (errand ? extraParametersToUppgiftMapper(errand) : undefined) || baseDetails;
+      errand?.channel === Channels.ESERVICE_KATLA
+        ? mappedFields
+        : mappedFields.map((f) =>
+            f.section === 'Medicinskt utlåtande' ? { ...f, section: 'Yttre omständigheter' } : f
+          );
 
     setFields(uppgifterFields ?? []);
     setRealEstates(errand?.facilities ?? []);


### PR DESCRIPTION
## Vad
Sektionen **Medicinskt utlåtande** visas nu som egen sektion endast när ärendet kommit in via katla-färdtjänsten (kanal `ESERVICE_KATLA` = "E-tjänst Färdtjänstregistrering"). För övriga kanaler visas de medicinska fälten i stället under **Yttre omständigheter**.

## Varför
För ärenden som inte kommer via katla-färdtjänsten ska medicinsk utlåtande-information inte ha en egen sektion utan leva tillsammans med yttre omständigheter. Detta gjordes ursprungligen i katla, men ska hanteras här i Draken där dessa ärenden faktiskt handläggs (katla skickar endast in ärenden och visar sina egna).

## Ändringar
I Draken finns inga separata `medical-opinion`/`external-circumstances`-komponenter — sektionerna byggs i `casedata-details-tab.tsx` genom att filtrera fälten på deras `section`-etikett, och fälten kommer från mallen i template-ordning (externa fält först, sedan medicinska).

- `casedata-details-tab.tsx`: I `useEffect`, efter att fälten mappats, märks de medicinska fältens `section` om från `Medicinskt utlåtande` till `Yttre omständigheter` när `errand.channel !== Channels.ESERVICE_KATLA`. Ingen fält-logik (default-värden, `dependsOn`) påverkas — endast sektionsetiketten ändras.

## Resultat
- **Kanal = katla-färdtjänsten** → Yttre omständigheter (egna fält) + separat Medicinskt utlåtande-sektion, som tidigare.
- **Övriga kanaler** → ingen separat medicinsk sektion; alla medicinska värden ligger under Yttre omständigheter (externa fält först, sedan medicinska enligt mallens ordning). Den separata sektionen blir tom och renderas inte (`filtered.length` = 0).

## Testning
- `npx tsc --noEmit` – inga typfel i de ändrade filerna.