### PR TITLE
feat: sätt handläggare vid avslut/vidarebefordran av supportärende utan handläggare

### DIFF
--- a/frontend/src/supportmanagement/components/support-errand/sidebar/buttons/support-close-errand-button.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/buttons/support-close-errand-button.component.tsx
@@ -14,6 +14,7 @@ import {
   ResolutionLabelKS,
   ResolutionLabelLOP,
   ResolutionLabelROB,
+  setSupportErrandAdmin,
   setSupportErrandStatus,
   Status,
   SupportErrand,
@@ -47,6 +48,7 @@ const getDefaultResolution = (errand: SupportErrand | undefined): Resolution => 
 };
 
 export const SupportCloseErrandButtonComponent: React.FC<{ disabled: boolean }> = ({ disabled }) => {
+  const user = useUserStore((s) => s.user);
   const administrators = useUserStore((s) => s.administrators);
   const municipalityId = useConfigStore((s) => s.municipalityId);
   const supportErrand = useSupportStore((s) => s.supportErrand);
@@ -70,11 +72,26 @@ export const SupportCloseErrandButtonComponent: React.FC<{ disabled: boolean }> 
     });
   };
 
+  // When an errand is closed without a handler (e.g. directly from status NEW), the user who
+  // closes it becomes the handler so the errand has a responsible person. Returns the resulting
+  // assigned user (the existing handler if one is already set).
+  const ensureHandlerAssigned = async (errandId: string): Promise<string | undefined> => {
+    if (supportErrand?.assignedUserId) return supportErrand.assignedUserId;
+    const currentAdmin = administrators.find((a) => a.adAccount === user.username);
+    if (currentAdmin) {
+      await setSupportErrandAdmin(errandId, municipalityId, currentAdmin.adAccount, undefined, currentAdmin.adAccount);
+      return currentAdmin.adAccount;
+    }
+    return undefined;
+  };
+
   const handleCloseErrand = async (resolution: Resolution, msg: boolean) => {
     if (!supportErrand?.id) return;
     const errandId = supportErrand.id;
     setIsLoading(true);
+    let assignedUserId: string | undefined;
     try {
+      assignedUserId = await ensureHandlerAssigned(errandId);
       await closeSupportErrand(errandId, municipalityId, resolution);
     } catch (e) {
       console.error('Failed to close support errand', e);
@@ -85,7 +102,7 @@ export const SupportCloseErrandButtonComponent: React.FC<{ disabled: boolean }> 
 
     if (msg) {
       try {
-        const admin = administrators.find((a) => a.adAccount === supportErrand.assignedUserId);
+        const admin = administrators.find((a) => a.adAccount === assignedUserId);
         const adminName = getAdminName(admin!);
         await sendClosingMessage(adminName, supportErrand, municipalityId);
       } catch (e) {
@@ -186,6 +203,7 @@ export const SupportCloseErrandButtonComponent: React.FC<{ disabled: boolean }> 
               leftIcon={<Check />}
               onClick={async () => {
                 try {
+                  await ensureHandlerAssigned(supportErrand.id ?? '');
                   await setSupportErrandStatus(supportErrand.id ?? '', municipalityId, Status.SOLVED);
                   window.close();
                 } catch (e) {

--- a/frontend/src/supportmanagement/services/support-errand-service.ts
+++ b/frontend/src/supportmanagement/services/support-errand-service.ts
@@ -1045,6 +1045,14 @@ export const forwardSupportErrand: (
     throw 'No message found. Cannot forward errand without message.';
   }
 
+  // The errand is closed when it's forwarded. If it has no handler (e.g. forwarded directly
+  // from status NEW), assign the current user so the errand always has a responsible person.
+  const assignSelfIfUnassigned = async () => {
+    if (!errand.assignedUserId) {
+      await setSupportErrandAdmin(errand.id!, municipalityId, user.username, undefined, user.username);
+    }
+  };
+
   let attachmentId = [] as string[];
   for (const att of supportAttachment) {
     attachmentId.push(att.id);
@@ -1072,6 +1080,7 @@ export const forwardSupportErrand: (
       message.senderName = 'Kontakt  Sundsvall';
     }
     await sendMessage(message);
+    await assignSelfIfUnassigned();
     return closeSupportErrand(errand.id, municipalityId, Resolution.REGISTERED_EXTERNAL_SYSTEM);
   } else if (data.recipient == 'DEPARTMENT' && data.department) {
     errand.stakeholders?.forEach((s) => {
@@ -1083,7 +1092,8 @@ export const forwardSupportErrand: (
     delete data.newEmail;
     return apiService
       .post<ApiSupportErrand, Partial<ForwardFormProps>>(`supporterrands/${municipalityId}/${errand.id!}/forward`, data)
-      .then(() => {
+      .then(async () => {
+        await assignSelfIfUnassigned();
         return closeSupportErrand(errand.id!, municipalityId, Resolution.REGISTERED_EXTERNAL_SYSTEM);
       })
       .catch((e: AxiosError) => {


### PR DESCRIPTION
## Bakgrund
Idag går det att avsluta ett supportärende direkt i status `NEW` (samt vidarebefordra det) utan att en handläggare sätts. Ärendet får då ingen ansvarig person — ingen får notiser om ärendet återöppnas och det går inte att i efterhand se vem som avslutade det.

## Ändring
Den inloggade användaren sätts nu automatiskt som handläggare **om ärendet saknar handläggare** när det avslutas eller vidarebefordras. Har ärendet redan en handläggare görs inget (no-op). Återanvänder befintlig logik (`setSupportErrandAdmin`) från "Starta handläggning".

Berörda flöden (supportmanagement):
- **Avsluta ärende** – `SupportCloseErrandButtonComponent` (huvudflödet + "har redan lösningskod"-vägen)
- **Vidarebefordra ärende** – `forwardSupportErrand` (e-post- och avdelningsgrenen)

**Casedata:** ingen ändring — "Avsluta ärendet" kräver redan att man är handläggaren, och enda vägen ur NEW ("Starta handläggning") sätter alltid handläggaren.

## Applikationer som ska testas
Endast supportmanagement-appar berörs: **KC, LOP, IK, KA, ROB, BOU, SE, MSVA**. Testa primärt **KC** och **LOP**.

## Så här testas flödet
Förutsättning: ärende i status `NEW` **utan** tilldelad handläggare.

- **A. Avsluta direkt från NEW:** Avsluta ärendet → välj lösningskod → Avsluta. Förväntat: status `SOLVED` + inloggad användare blir handläggare (Ansvarig). Verifiera `PATCH .../supporterrands/<mid>/<id>/admin` med `assignedUserId` = inloggad användare före avslut.
- **B. Avsluta med avslutsmeddelande:** kryssa i "Skicka meddelande till ärendeägare". Förväntat: meddelandet anger den nu tilldelade handläggaren (inte tomt namn).
- **C. Avsluta när lösningskod redan finns:** Avsluta → Avsluta (utan att ändra kod). Förväntat: handläggare sätts + avslutas.
- **D. Vidarebefordra (e-post):** Överlämna → E-post → bekräfta. Förväntat: vidarebefordras, avslutas (`REGISTERED_EXTERNAL_SYSTEM`) + handläggare sätts.
- **E. Vidarebefordra (avdelning):** som D men mottagare Avdelning.
- **F. Regression (befintlig handläggare):** avsluta/vidarebefordra ärende som redan har handläggare. Förväntat: handläggaren ändras **inte**, ingen extra `/admin`-PATCH.

## Notering
Befintliga Cypress-tester (KC/LOP) använder ärenden med handläggare → nya flödet blir no-op där, testerna påverkas inte.

https://jira.sundsvall.se/browse/DRAKEN-4407
