### PR TITLE
refactor: använd DatePicker istället för Input type="date"

### DIFF
--- a/frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx
@@ -53,6 +53,7 @@ import {
   Button,
   Combobox,
   cx,
+  DatePicker,
   Dialog,
   Disclosure,
   FormControl,
@@ -800,11 +801,12 @@ export const CasedataDecisionTab: FC<{
               <>
                 <FormControl className="w-full">
                   <FormLabel>Beslut giltigt från</FormLabel>
-                  <Input
+                  <DatePicker
                     type="date"
                     {...register('validFrom')}
                     size="sm"
                     disabled={isErrandLocked(errand) || isSent() || outcome !== DecisionOutcomes.Approval}
+                    invalid={!!errors.validFrom}
                     placeholder="Välj datum"
                     data-cy="validFrom-input"
                   />
@@ -815,11 +817,12 @@ export const CasedataDecisionTab: FC<{
 
                 <FormControl className="w-full">
                   <FormLabel>Beslut giltigt till</FormLabel>
-                  <Input
+                  <DatePicker
                     type="date"
                     {...register('validTo')}
                     size="sm"
                     disabled={isErrandLocked(errand) || isSent() || outcome !== DecisionOutcomes.Approval}
+                    invalid={!!errors.validTo}
                     placeholder="Välj datum"
                     data-cy="validTo-input"
                   />

--- a/frontend/src/casedata/components/suspend-errand.tsx
+++ b/frontend/src/casedata/components/suspend-errand.tsx
@@ -2,7 +2,7 @@ import { ErrandStatus } from '@casedata/interfaces/errand-status';
 import { getErrand, isErrandLocked, setErrandStatus } from '@casedata/services/casedata-errand-service';
 import { getToastOptions } from '@common/utils/toast-message-settings';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { Button, FormControl, FormLabel, Input, Modal, Textarea, useSnackbar } from '@sk-web-gui/react';
+import { Button, DatePicker, FormControl, FormLabel, Modal, Textarea, useSnackbar } from '@sk-web-gui/react';
 import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
 import dayjs from 'dayjs';
 import { CirclePause } from 'lucide-react';
@@ -103,7 +103,7 @@ export const SuspendErrandComponent: React.FC<{ disabled: boolean }> = ({ disabl
             <Modal.Content>
               <FormControl id="email" className="w-full" required>
                 <FormLabel className="text-small">Sätt en påminnelse för när ärendet ska återupptas</FormLabel>
-                <Input
+                <DatePicker
                   data-cy="date-input"
                   type="date"
                   min={dayjs().format('YYYY-MM-DD')}

--- a/frontend/src/supportmanagement/components/support-errand/sidebar/buttons/support-suspend-errand-button.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/buttons/support-suspend-errand-button.component.tsx
@@ -1,6 +1,6 @@
 import { getToastOptions } from '@common/utils/toast-message-settings';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { Button, FormControl, FormLabel, Input, Modal, Textarea, useSnackbar } from '@sk-web-gui/react';
+import { Button, DatePicker, FormControl, FormLabel, Modal, Textarea, useSnackbar } from '@sk-web-gui/react';
 import { useConfigStore, useSupportStore } from '@stores/index';
 import { getSupportErrandById, setSuspension, Status } from '@supportmanagement/services/support-errand-service';
 import dayjs from 'dayjs';
@@ -86,7 +86,7 @@ export const SupportSuspendErrandButtonComponent: React.FC<{ disabled: boolean }
             <Modal.Content>
               <FormControl id="email" className="w-full" required>
                 <FormLabel className="text-small">Sätt en påminnelse för när ärendet ska återupptas</FormLabel>
-                <Input
+                <DatePicker
                   data-cy="date-input"
                   type="date"
                   min={dayjs().format('YYYY-MM-DD')}


### PR DESCRIPTION
## Vad

Byter ut kvarvarande `Input type="date"` mot den delade `DatePicker`-komponenten (`@sk-web-gui/forms`), för konsekvens med resten av appen där datumfält redan använder `DatePicker` (kontrakt, tjänster, fakturering och filtrering).

## Uppdaterade filer

| Fil | Fält |
|-----|------|
| `frontend/src/casedata/components/suspend-errand.tsx` | Påminnelsedatum vid parkering av ärende |
| `frontend/src/supportmanagement/.../support-suspend-errand-button.component.tsx` | Motsvarande påminnelsedatum för supportärenden |
| `frontend/src/casedata/components/errand/tabs/decision/casedata-decision-tab.tsx` | Beslut giltigt från/till (PT) – även kopplat `invalid` mot formulärfel |

`Input` behålls i `casedata-decision-tab.tsx` eftersom den fortfarande används för dolda fält (`type="hidden"`).

## Varför detta är säkert

`DatePicker` wrappar samma underliggande `Input` (`DatePickerProps extends Omit<InputProps, 'type' | 'as'>` och `forwardRef` ner till `<input>`). Verifierat mot källkoden i `web-shared-components`:

- **`min`** fungerar oförändrat – `InputProps` extendar `React.ComponentPropsWithRef<'input'>` så native attribut flödar igenom.
- **`react-hook-form` `{...register()}`** fungerar oförändrat (`name`/`onChange`/`onBlur`/`ref`).
- **`size="sm"` och `invalid`** stöds.
- Renderar fortfarande native `<input type="date">`, så `data-cy`-attributen och Cypress-selektorerna är oförändrade.
- Bonus: `DatePicker` defaultar `max="9999-12-31"`, vilket hindrar att native årsfältet spiller över till fler än fyra siffror.

## Hur man validerar

**Automatiskt**
- `yarn --cwd frontend type-check` – inga fel i de berörda filerna.
- `yarn --cwd frontend lint` – rent.

**Manuellt**
1. **Parkera ärende (casedata):** Öppna ett ärende → "Parkera ärende" → bekräfta att datumväljaren visas, att datum inte kan väljas bakåt i tiden (`min` = idag) och att parkering med datum + kommentar fungerar.
2. **Parkera supportärende:** Samma flöde via supportärendets sidebar-knapp.
3. **Beslut (PT-ärende):** Öppna besluts-fliken på ett PT-ärende med utfall "Bifall" → kontrollera "Beslut giltigt från/till"-fälten: går att välja datum, blir disabled vid låst/skickat ärende eller annat utfall, och markeras som ogiltiga (`invalid`) vid valideringsfel.

https://jira.sundsvall.se/browse/DRAKEN-4506
