### PR TITLE
Fix unread conversation message indicators

### DIFF
--- a/backend/src/controllers/casedata/casedata-conversation.controller.ts
+++ b/backend/src/controllers/casedata/casedata-conversation.controller.ts
@@ -63,11 +63,11 @@ export class CaseDataConversationController {
         let firstName = undefined;
         let lastName = undefined;
         let direction = undefined;
-        let viewed = undefined;
+        let viewed = false;
 
         const isReadByCurrentUser = Array.isArray(msg.readBy) && msg.readBy.some((reader: any) => reader.identifier.value === req.user.username);
         if (isReadByCurrentUser) {
-          viewed = 'true';
+          viewed = true;
         }
 
         if (msg?.createdBy?.type === 'adAccount') {
@@ -75,6 +75,7 @@ export class CaseDataConversationController {
             firstName = req.user.firstName;
             lastName = req.user.lastName;
             direction = 'OUTBOUND';
+            viewed = true;
           } else {
             const adAccountUrl = `${this.EMPLOYEE_SERVICE}/${municipalityId}/portalpersondata/PERSONAL/${msg?.createdBy?.value}`;
             const res = await this.apiService.get<PortalPersonData>({ url: adAccountUrl }, req.user);

--- a/backend/src/controllers/supportmanagement/support-conversation.controller.ts
+++ b/backend/src/controllers/supportmanagement/support-conversation.controller.ts
@@ -61,17 +61,18 @@ export class SupportConversationController {
         if (msg.type === 'SYSTEM_CREATED') return;
         let sender = undefined;
         let direction = undefined;
-        let viewed = undefined;
+        let viewed = false;
 
         const isReadByCurrentUser = Array.isArray(msg.readBy) && msg.readBy.some((reader: any) => reader.identifier.value === req.user.username);
         if (isReadByCurrentUser) {
-          viewed = 'true';
+          viewed = true;
         }
 
         if (msg?.createdBy?.type === 'adAccount') {
           if (msg?.createdBy?.value === req.user.username) {
             sender = req.user.firstName + ' ' + req.user.lastName;
             direction = 'OUTBOUND';
+            viewed = true;
           } else {
             const adAccountUrl = `${this.EMPLOYEE_SERVICE}/${municipalityId}/portalpersondata/PERSONAL/${msg?.createdBy?.value}`;
             const res = await this.apiService.get<PortalPersonData>({ url: adAccountUrl }, req.user);

--- a/frontend/e2e/case-data/mex/errandPage-message-tab-mex.spec.ts
+++ b/frontend/e2e/case-data/mex/errandPage-message-tab-mex.spec.ts
@@ -1,10 +1,10 @@
-import { expect,test } from '../../fixtures/base.fixture';
+import { expect, test } from '../../fixtures/base.fixture';
 import { mockAddress } from '../fixtures/mockAddress';
 import { mockAdmins } from '../fixtures/mockAdmins';
 import { mockAsset } from '../fixtures/mockAsset';
 import { mockAttachments } from '../fixtures/mockAttachments';
 import { mockContractAttachment, mockLeaseAgreement } from '../fixtures/mockContract';
-import { mockConversationMessages,mockConversations } from '../fixtures/mockConversations';
+import { mockConversationMessages, mockConversations } from '../fixtures/mockConversations';
 import { mockEstateInfo11, mockEstateInfo12 } from '../fixtures/mockEstateInfo';
 import { mockHistory } from '../fixtures/mockHistory';
 import { mockJsonSchema } from '../fixtures/mockJsonSchema';
@@ -16,6 +16,7 @@ import { mockPersonId } from '../fixtures/mockPersonId';
 import { mockRelations } from '../fixtures/mockRelations';
 
 const b64 = (s: string) => Buffer.from(s, 'utf-8').toString('base64');
+const errandMessagesRoute = /\/errand\/\d+\/messages$/;
 const mockMessageTemplates = {
   data: [
     { identifier: 'mex.email.default', name: 'E-postmall', content: b64('<p>E-postmall innehåll</p>') },
@@ -85,7 +86,7 @@ test.describe('Message tab', () => {
     await mockRoute('**/stakeholders/personNumber', mockMexErrand_base.data.stakeholders, { method: 'POST' });
     await mockRoute('**/contracts/2024-01026', mockLeaseAgreement, { method: 'GET' }); // @getContract
     await mockRoute('**/contracts/2281/2024-01026/attachments/1', mockContractAttachment, { method: 'GET' }); // @getContractAttachment
-    await page.route(/\/errand\/\d+\/messages$/, async (route) => {
+    await page.route(errandMessagesRoute, async (route) => {
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockMessages) });
     });
 
@@ -153,6 +154,14 @@ test.describe('Message tab', () => {
     mockRoute,
     dismissCookieConsent,
   }) => {
+    await page.unroute(errandMessagesRoute);
+    await page.route(errandMessagesRoute, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: [], message: 'success' }),
+      });
+    });
     await page.unroute('**/namespace/errands/**/communication/conversations');
     await page.unroute('**/errands/**/communication/conversations/*/messages');
     await mockRoute('**/namespace/errands/**/communication/conversations', mockUnreadConversation, { method: 'GET' });

--- a/frontend/e2e/case-data/mex/errandPage-message-tab-mex.spec.ts
+++ b/frontend/e2e/case-data/mex/errandPage-message-tab-mex.spec.ts
@@ -1,19 +1,19 @@
-import { test, expect } from '../../fixtures/base.fixture';
-import { mockMessageRenderRequest, mockMessages } from '../fixtures/mockMessages';
-import { mockPersonId } from '../fixtures/mockPersonId';
-import { mockAdmins } from '../fixtures/mockAdmins';
-import { mockMe } from '../fixtures/mockMe';
-import { mockPermits } from '../fixtures/mockPermits';
-import { mockMexErrand_base } from '../fixtures/mockMexErrand';
-import { mockAttachments } from '../fixtures/mockAttachments';
-import { mockHistory } from '../fixtures/mockHistory';
+import { expect,test } from '../../fixtures/base.fixture';
 import { mockAddress } from '../fixtures/mockAddress';
+import { mockAdmins } from '../fixtures/mockAdmins';
 import { mockAsset } from '../fixtures/mockAsset';
-import { mockConversations, mockConversationMessages } from '../fixtures/mockConversations';
-import { mockRelations } from '../fixtures/mockRelations';
-import { mockJsonSchema } from '../fixtures/mockJsonSchema';
+import { mockAttachments } from '../fixtures/mockAttachments';
 import { mockContractAttachment, mockLeaseAgreement } from '../fixtures/mockContract';
+import { mockConversationMessages,mockConversations } from '../fixtures/mockConversations';
 import { mockEstateInfo11, mockEstateInfo12 } from '../fixtures/mockEstateInfo';
+import { mockHistory } from '../fixtures/mockHistory';
+import { mockJsonSchema } from '../fixtures/mockJsonSchema';
+import { mockMe } from '../fixtures/mockMe';
+import { mockMessageRenderRequest, mockMessages } from '../fixtures/mockMessages';
+import { mockMexErrand_base } from '../fixtures/mockMexErrand';
+import { mockPermits } from '../fixtures/mockPermits';
+import { mockPersonId } from '../fixtures/mockPersonId';
+import { mockRelations } from '../fixtures/mockRelations';
 
 const b64 = (s: string) => Buffer.from(s, 'utf-8').toString('base64');
 const mockMessageTemplates = {
@@ -25,6 +25,40 @@ const mockMessageTemplates = {
     { identifier: 'mex.sms.reminder', name: 'SMS-påminnelse', content: b64('SMS-påminnelse') },
     { identifier: 'mex.sms.signature', name: 'SMS-signatur', content: b64('/ {{user}}') },
     { identifier: 'internal.signature', name: 'Intern signatur', content: b64('/ {{user}}') },
+  ],
+  message: 'success',
+};
+
+const mockUnreadConversation = {
+  data: {
+    data: [
+      {
+        id: 'abababab-ed21-4b30-9e0c-1252c878153f',
+        topic: 'Överlämning',
+        type: 'INTERNAL',
+        relationIds: ['bd835475-cbc2-4b92-979d-8bc18bd75385'],
+      },
+    ],
+    message: 'success',
+  },
+  message: 'success',
+};
+
+const mockUnreadConversationMessages = {
+  data: [
+    {
+      conversationId: 'abababab-ed21-4b30-9e0c-1252c878153f',
+      messageId: 'unread-conversation-message',
+      sent: '2026-06-09T15:12:00.000Z',
+      message: '<p>Överlämning</p>',
+      attachments: [],
+      messageType: 'DRAKEN',
+      subject: 'Överlämning',
+      firstName: 'Kaltron',
+      lastName: 'Rexhaj',
+      direction: 'INBOUND',
+      viewed: false,
+    },
   ],
   message: 'success',
 };
@@ -112,6 +146,29 @@ test.describe('Message tab', () => {
           .click({ force: true });
       }
     }
+  });
+
+  test('counts unread conversation messages and marks them read locally', async ({
+    page,
+    mockRoute,
+    dismissCookieConsent,
+  }) => {
+    await page.unroute('**/namespace/errands/**/communication/conversations');
+    await page.unroute('**/errands/**/communication/conversations/*/messages');
+    await mockRoute('**/namespace/errands/**/communication/conversations', mockUnreadConversation, { method: 'GET' });
+    await mockRoute('**/errands/**/communication/conversations/*/messages', mockUnreadConversationMessages, {
+      method: 'GET',
+    });
+
+    await goToMessageTab(page, dismissCookieConsent);
+
+    await expect(page.getByRole('tab', { name: 'Meddelanden (1)' })).toBeVisible();
+    await expect(page.locator('[data-cy="node-unread-conversation-message"] span.bg-vattjom-surface-primary')).toBeVisible();
+
+    await page.locator('[data-cy="expand-message-button-unread-conversation-message"]').click();
+
+    await expect(page.getByRole('tab', { name: 'Meddelanden (0)' })).toBeVisible();
+    await expect(page.locator('[data-cy="node-unread-conversation-message"] span.bg-gray-200')).toBeVisible();
   });
 
   test('sends sms with template', async ({ page, mockRoute, dismissCookieConsent }) => {

--- a/frontend/e2e/kontaktcenter/errandPage-message-tab-kc.spec.ts
+++ b/frontend/e2e/kontaktcenter/errandPage-message-tab-kc.spec.ts
@@ -1,7 +1,11 @@
-import { test, expect } from '../fixtures/base.fixture';
 import { mockAdmins } from '../case-data/fixtures/mockAdmins';
 import { mockMe } from '../case-data/fixtures/mockMe';
+import { expect,test } from '../fixtures/base.fixture';
+//TODO:Update mockdata
+import { mockConversationMessages, mockConversations } from '../lop/fixtures/mockConversations';
+import { mockRelations } from '../lop/fixtures/mockRelations';
 import { mockMetaData } from './fixtures/mockMetadata';
+import { mockStakeholderStatus } from './fixtures/mockStakeholderStatus';
 import { mockSupportAdminsResponse } from './fixtures/mockSupportAdmins';
 import {
   mockSupportAttachments,
@@ -9,10 +13,45 @@ import {
   mockSupportErrandCommunication,
   mockSupportNotes,
 } from './fixtures/mockSupportErrands';
-//TODO:Update mockdata
-import { mockConversationMessages, mockConversations } from '../lop/fixtures/mockConversations';
-import { mockRelations } from '../lop/fixtures/mockRelations';
-import { mockStakeholderStatus } from './fixtures/mockStakeholderStatus';
+
+const mockUnreadSupportConversation = {
+  data: {
+    data: [
+      {
+        id: 'support-conversation',
+        topic: 'Överlämning',
+        type: 'INTERNAL',
+        relationIds: ['bd835475-cbc2-4b92-979d-8bc18bd75385'],
+      },
+    ],
+    message: 'success',
+  },
+  message: 'success',
+};
+
+const mockUnreadSupportConversationMessages = {
+  data: [
+    {
+      conversationId: 'support-conversation',
+      communicationID: 'support-conversation-message',
+      messageId: 'support-conversation-message',
+      errandNumber: mockSupportErrand.errandNumber,
+      sent: '2026-06-09T15:18:00.000Z',
+      messageBody: '<p>Överlämning</p>',
+      communicationAttachments: [],
+      communicationType: 'DRAKEN',
+      subject: 'Överlämning',
+      sender: 'Edwin Molina',
+      direction: 'INBOUND',
+      viewed: false,
+      emailHeaders: {},
+      target: 'Draken',
+      recipients: [],
+      ccRecipients: [],
+    },
+  ],
+  message: 'success',
+};
 
 test.describe('Message tab', () => {
   test.beforeEach(async ({ page, mockRoute }) => {
@@ -83,6 +122,31 @@ test.describe('Message tab', () => {
         }
       }
     }
+  });
+
+  test('counts unread conversation messages and marks them read locally', async ({ page, mockRoute }) => {
+    await page.unroute('**/supportmessage/2281/errands/*/communication');
+    await page.unroute('**/namespace/errands/**/communication/conversations');
+    await page.unroute('**/errands/**/communication/conversations/*/messages');
+    await mockRoute('**/supportmessage/2281/errands/*/communication', [], { method: 'GET' });
+    await mockRoute('**/namespace/errands/**/communication/conversations', mockUnreadSupportConversation, {
+      method: 'GET',
+    });
+    await mockRoute('**/errands/**/communication/conversations/*/messages', mockUnreadSupportConversationMessages, {
+      method: 'GET',
+    });
+
+    await page.reload();
+    await page.waitForResponse((resp) => resp.url().includes('supporterrands') && resp.status() === 200);
+    await page.getByRole('tab', { name: /Meddelanden/ }).click();
+
+    await expect(page.getByRole('tab', { name: 'Meddelanden (1)' })).toBeVisible();
+    await expect(page.locator('[data-cy="message-support-conversation-message"] span.bg-vattjom-surface-primary')).toBeVisible();
+
+    await page.locator('[data-cy="message-support-conversation-message"] button.sk-btn-ghost').click();
+
+    await expect(page.getByRole('tab', { name: 'Meddelanden (0)' })).toBeVisible();
+    await expect(page.locator('[data-cy="message-support-conversation-message"] span.bg-gray-200')).toBeVisible();
   });
 
   test('sends sms', async ({ page }) => {

--- a/frontend/src/casedata/components/errand/casedata-tabs-wrapper.tsx
+++ b/frontend/src/casedata/components/errand/casedata-tabs-wrapper.tsx
@@ -37,6 +37,7 @@ export const CasedataTabsWrapper: React.FC = () => {
     errand,
     setErrand,
     messages,
+    conversation,
     setMessages,
     setConversation,
     setConversationTree,
@@ -209,7 +210,7 @@ export const CasedataTabsWrapper: React.FC = () => {
         : [],
     },
     {
-      label: `Meddelanden (${countUnreadMessages(messages ?? [])})`,
+      label: `Meddelanden (${countUnreadMessages([...(messages ?? []), ...(conversation ?? [])])})`,
       content: errand?.id && (
         <CasedataMessagesTab
           setUnsaved={() => {}}

--- a/frontend/src/casedata/components/errand/tabs/messages/casedata-messages-tab.tsx
+++ b/frontend/src/casedata/components/errand/tabs/messages/casedata-messages-tab.tsx
@@ -1,6 +1,12 @@
 import { Channels } from '@casedata/interfaces/channels';
 import { isErrandLocked, validateAction } from '@casedata/services/casedata-errand-service';
-import { fetchMessagesWithTree, MessageNode, setMessageViewStatus } from '@casedata/services/casedata-message-service';
+import {
+  fetchMessagesWithTree,
+  isMessageViewed,
+  markConversationMessageViewed,
+  MessageNode,
+  setMessageViewStatus,
+} from '@casedata/services/casedata-message-service';
 import { CasedataMessageType, isCasedataWebMessageType } from '@casedata/services/casedata-message-types';
 import { Button, Divider, FormLabel, Select, useSnackbar } from '@sk-web-gui/react';
 import { useCasedataStore, useConfigStore, useUserStore } from '@stores/index';
@@ -23,6 +29,8 @@ export const CasedataMessagesTab: FC<{
   const setMessageTree = useCasedataStore((s) => s.setMessageTree);
   const conversation = useCasedataStore((s) => s.conversation);
   const conversationTree = useCasedataStore((s) => s.conversationTree);
+  const setConversation = useCasedataStore((s) => s.setConversation);
+  const setConversationTree = useCasedataStore((s) => s.setConversationTree);
   const user = useUserStore((s) => s.user);
   const [selectedMessage, setSelectedMessage] = useState<MessageNode>();
   const [showMessageComposer, setShowMessageComposer] = useState<boolean>(false);
@@ -43,7 +51,8 @@ export const CasedataMessagesTab: FC<{
 
   const setMessageViewed = (msg: MessageNode) => {
     if (msg.conversationId) {
-      console.warn('Not implemented');
+      setConversation(markConversationMessageViewed(conversation ?? [], msg));
+      setConversationTree(markConversationMessageViewed(conversationTree ?? [], msg));
       return;
     }
     if (!errand) return;
@@ -187,8 +196,10 @@ export const CasedataMessagesTab: FC<{
         {combinedMessages?.length ? (
           <MessageTreeComponent
             nodes={sortedMessages ?? []}
-            onSelect={(msg: MessageResponse) => {
-              setMessageViewed(msg);
+            onSelect={(msg: MessageNode) => {
+              if (!isMessageViewed(msg)) {
+                setMessageViewed(msg);
+              }
               setSelectedMessage(msg);
             }}
             setShowMessageComposer={setShowMessageComposer}

--- a/frontend/src/casedata/components/errand/tabs/messages/rendered-message.component.tsx
+++ b/frontend/src/casedata/components/errand/tabs/messages/rendered-message.component.tsx
@@ -3,7 +3,7 @@ import { Role } from '@casedata/interfaces/role';
 import { messageAttachment } from '@casedata/services/casedata-attachment-service';
 import { getConversationAttachment } from '@casedata/services/casedata-conversation-service';
 import { isErrandLocked, validateAction } from '@casedata/services/casedata-errand-service';
-import { MessageNode } from '@casedata/services/casedata-message-service';
+import { isMessageViewed, MessageNode } from '@casedata/services/casedata-message-service';
 import {
   CasedataMessageType,
   isCasedataReplyableMessageType,
@@ -75,6 +75,7 @@ export const RenderedMessage: FC<{
   const [expanded, setExpanded] = useState<boolean>(false);
   const channelPresentation = getChannelPresentation(message.messageType, errand?.channel === Channels.ESERVICE_KATLA);
   const ChannelIcon = channelPresentation?.Icon;
+  const viewed = isMessageViewed(message);
 
   useEffect(() => {
     const _a = errand ? validateAction(errand, user) : false;
@@ -178,7 +179,7 @@ export const RenderedMessage: FC<{
           <div className="flex gap-8">
             <span
               className={cx(
-                message.viewed ? 'bg-gray-200' : `bg-vattjom-surface-primary`,
+                viewed ? 'bg-gray-200' : `bg-vattjom-surface-primary`,
                 `self-center w-12 h-12 my-xs rounded-full flex items-center justify-center text-lg`
               )}
             ></span>
@@ -199,7 +200,7 @@ export const RenderedMessage: FC<{
 
         <div className="pl-xl flex justify-between items-start">
           <p
-            className={cx(`my-0 text-primary`, message.viewed ? 'font-normal' : 'font-bold')}
+            className={cx(`my-0 text-primary`, viewed ? 'font-normal' : 'font-bold')}
             data-cy="message-subject"
             dangerouslySetInnerHTML={{
               __html: sanitized(message.subject || ''),

--- a/frontend/src/casedata/services/casedata-message-service.ts
+++ b/frontend/src/casedata/services/casedata-message-service.ts
@@ -185,16 +185,33 @@ export const countAllMessages = (tree: MessageNode[]): number => {
   return c;
 };
 
+type MessageViewedValue = boolean | string | undefined;
+
+export const isMessageViewed = (message: { viewed?: MessageViewedValue }): boolean => {
+  return message.viewed === true || message.viewed === 'true';
+};
+
 export const countUnreadMessages = (tree: MessageNode[]): number => {
   if (!tree) {
     return 0;
   }
   let c = 0;
-  c += tree.filter((node) => !node.viewed).length;
+  c += tree.filter((node) => !isMessageViewed(node)).length;
   tree.forEach((root) => {
     c += countUnreadMessages(root.children ?? []);
   });
   return c;
+};
+
+export const markConversationMessageViewed = (tree: MessageNode[], selectedMessage: MessageNode): MessageNode[] => {
+  return tree.map((node) => ({
+    ...node,
+    viewed:
+      node.conversationId === selectedMessage.conversationId && node.messageId === selectedMessage.messageId
+        ? 'true'
+        : node.viewed,
+    children: node.children ? markConversationMessageViewed(node.children, selectedMessage) : node.children,
+  }));
 };
 
 export interface MessageNode extends MessageResponse {

--- a/frontend/src/casedata/services/casedata-message-service.ts
+++ b/frontend/src/casedata/services/casedata-message-service.ts
@@ -8,6 +8,11 @@ import { Render, TemplateSelector } from '@common/interfaces/template';
 import { ApiResponse, apiService } from '@common/services/api-service';
 import { isMEX } from '@common/services/application-service';
 import { base64Decode } from '@common/services/helper-service';
+import {
+  countUnreadMessages,
+  isMessageViewed,
+  markConversationMessageViewed as markConversationMessageViewedCommon,
+} from '@common/services/message-view-status-service';
 import { toBase64 } from '@common/utils/toBase64';
 import { UploadFile } from '@sk-web-gui/react';
 import dayjs from 'dayjs';
@@ -185,33 +190,10 @@ export const countAllMessages = (tree: MessageNode[]): number => {
   return c;
 };
 
-type MessageViewedValue = boolean | string | undefined;
-
-export const isMessageViewed = (message: { viewed?: MessageViewedValue }): boolean => {
-  return message.viewed === true || message.viewed === 'true';
-};
-
-export const countUnreadMessages = (tree: MessageNode[]): number => {
-  if (!tree) {
-    return 0;
-  }
-  let c = 0;
-  c += tree.filter((node) => !isMessageViewed(node)).length;
-  tree.forEach((root) => {
-    c += countUnreadMessages(root.children ?? []);
-  });
-  return c;
-};
+export { countUnreadMessages, isMessageViewed };
 
 export const markConversationMessageViewed = (tree: MessageNode[], selectedMessage: MessageNode): MessageNode[] => {
-  return tree.map((node) => ({
-    ...node,
-    viewed:
-      node.conversationId === selectedMessage.conversationId && node.messageId === selectedMessage.messageId
-        ? 'true'
-        : node.viewed,
-    children: node.children ? markConversationMessageViewed(node.children, selectedMessage) : node.children,
-  }));
+  return markConversationMessageViewedCommon(tree, selectedMessage, 'true');
 };
 
 export interface MessageNode extends MessageResponse {

--- a/frontend/src/common/services/message-view-status-service.ts
+++ b/frontend/src/common/services/message-view-status-service.ts
@@ -1,0 +1,45 @@
+export type MessageViewedValue = boolean | string | undefined;
+
+export type MessageViewNode<TNode> = {
+  viewed?: MessageViewedValue;
+  conversationId?: string;
+  messageId?: string;
+  children?: TNode[];
+};
+
+export type ConversationMessageKey = {
+  conversationId?: string;
+  messageId?: string;
+};
+
+export const isMessageViewed = (message: { viewed?: MessageViewedValue }): boolean => {
+  return message.viewed === true || message.viewed === 'true';
+};
+
+export const countUnreadMessages = <TNode extends MessageViewNode<TNode>>(tree?: TNode[]): number => {
+  if (!tree) {
+    return 0;
+  }
+
+  return tree.reduce((count, node) => {
+    const nodeCount = isMessageViewed(node) ? 0 : 1;
+    return count + nodeCount + countUnreadMessages(node.children);
+  }, 0);
+};
+
+export const markConversationMessageViewed = <TNode extends MessageViewNode<TNode>>(
+  tree: TNode[],
+  selectedMessage: ConversationMessageKey,
+  viewedValue: NonNullable<TNode['viewed']>
+): TNode[] => {
+  return tree.map((node) => ({
+    ...node,
+    viewed:
+      node.conversationId === selectedMessage.conversationId && node.messageId === selectedMessage.messageId
+        ? viewedValue
+        : node.viewed,
+    children: node.children
+      ? markConversationMessageViewed(node.children, selectedMessage, viewedValue)
+      : node.children,
+  }));
+};

--- a/frontend/src/supportmanagement/components/support-errand/support-tabs-wrapper.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/support-tabs-wrapper.tsx
@@ -15,6 +15,7 @@ import {
   countUnreadMessages,
   fetchSupportMessages,
   groupByConversationIdSortedTree,
+  markConversationMessageViewed,
   MessageNode,
 } from '@supportmanagement/services/support-message-service';
 import { Dispatch, FC, ReactNode, SetStateAction, useEffect, useMemo, useState } from 'react';
@@ -120,13 +121,17 @@ export const SupportTabsWrapper: FC<{
       },
       {
         key: 'messages',
-        label: `Meddelanden (${countUnreadMessages(messages)})`,
+        label: `Meddelanden (${countUnreadMessages([...(messages ?? []), ...(supportConversations ?? [])])})`,
         content: supportErrand && (
           <SupportMessagesTab
             messages={messages}
             messageTree={messageTree}
             supportConversations={supportConversations}
             conversationMessageTree={conversationMessageTree}
+            markConversationMessageViewed={(message) => {
+              setSupportConversations(markConversationMessageViewed(supportConversations, message));
+              setConversationMessageTree(markConversationMessageViewed(conversationMessageTree, message));
+            }}
             setUnsaved={setUnsavedChanges}
             update={update}
             municipalityId={municipalityId}

--- a/frontend/src/supportmanagement/components/support-errand/tabs/messages/rendered-support-message.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/tabs/messages/rendered-support-message.component.tsx
@@ -11,6 +11,7 @@ import { getSupportConversationAttachment } from '@supportmanagement/services/su
 import { isSupportErrandLocked, validateAction } from '@supportmanagement/services/support-errand-service';
 import {
   getMessageAttachment,
+  isMessageViewed,
   Message,
   MessageNode,
   setMessageViewStatus,
@@ -63,6 +64,7 @@ export const RenderedSupportMessage: FC<{
   const [expanded, setExpanded] = useState(false);
   const channelPresentation = communicationChannelPresentation[message.communicationType];
   const ChannelIcon = channelPresentation?.Icon;
+  const viewed = isMessageViewed(message);
 
   const allowed = useMemo(() => validateAction(supportErrand, user), [user, supportErrand]);
 
@@ -112,7 +114,7 @@ export const RenderedSupportMessage: FC<{
   }
 
   useEffect(() => {
-    if (!message.viewed && supportErrand.assignedUserId === user.username) {
+    if (!viewed && supportErrand.assignedUserId === user.username) {
       expanded &&
         isInViewport(document.querySelector(`.message-${message.communicationID}`)!) &&
         setMessageViewStatus(supportErrand.id!, municipalityId, message.communicationID, true).then(() => {
@@ -181,7 +183,7 @@ export const RenderedSupportMessage: FC<{
           <div className="flex gap-8">
             <span
               className={cx(
-                message.viewed ? 'bg-gray-200' : `bg-vattjom-surface-primary`,
+                viewed ? 'bg-gray-200' : `bg-vattjom-surface-primary`,
                 `self-center w-12 h-12 my-xs rounded-full flex items-center justify-center text-lg`
               )}
             ></span>
@@ -200,7 +202,7 @@ export const RenderedSupportMessage: FC<{
         </div>
         <div className="pl-xl flex justify-between items-start">
           <p
-            className={cx(`my-0 text-primary`, message.viewed ? 'font-normal' : 'font-bold')}
+            className={cx(`my-0 text-primary`, viewed ? 'font-normal' : 'font-bold')}
             dangerouslySetInnerHTML={{
               __html: sanitized(message.subject || ''),
             }}

--- a/frontend/src/supportmanagement/components/support-errand/tabs/messages/support-messages-tab.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/tabs/messages/support-messages-tab.tsx
@@ -3,7 +3,12 @@ import { Button, Divider, FormControl, FormLabel, Icon, Select } from '@sk-web-g
 import { useConfigStore, useSupportStore, useUserStore } from '@stores/index';
 import { SupportCommunicationType } from '@supportmanagement/services/support-communication-types';
 import { isSupportErrandLocked, Status, validateAction } from '@supportmanagement/services/support-errand-service';
-import { Message, setMessageViewStatus } from '@supportmanagement/services/support-message-service';
+import {
+  isMessageViewed,
+  Message,
+  MessageNode,
+  setMessageViewStatus,
+} from '@supportmanagement/services/support-message-service';
 import { Mail } from 'lucide-react';
 import { FC, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -16,6 +21,7 @@ export const SupportMessagesTab: FC<{
   messageTree: Message[];
   supportConversations: Message[];
   conversationMessageTree: Message[];
+  markConversationMessageViewed: (message: MessageNode) => void;
   setUnsaved: (unsaved: boolean) => void;
   update: () => void;
   municipalityId: string;
@@ -43,9 +49,10 @@ export const SupportMessagesTab: FC<{
 
   const onSelect = (message: Message) => {
     if (message.conversationId && message.conversationId !== '') {
-      console.warn('Not implemented');
-      props.update();
-    } else if (!message.viewed && supportErrand?.assignedUserId === user.username) {
+      if (!isMessageViewed(message)) {
+        props.markConversationMessageViewed(message);
+      }
+    } else if (!isMessageViewed(message) && supportErrand?.assignedUserId === user.username) {
       setMessageViewStatus(supportErrand!.id!, municipalityId, message.communicationID, true).then(() => {
         props.update();
       });

--- a/frontend/src/supportmanagement/services/support-message-service.ts
+++ b/frontend/src/supportmanagement/services/support-message-service.ts
@@ -1,4 +1,9 @@
 import { ApiResponse, apiService } from '@common/services/api-service';
+import {
+  countUnreadMessages,
+  isMessageViewed,
+  markConversationMessageViewed as markConversationMessageViewedCommon,
+} from '@common/services/message-view-status-service';
 import sanitized from '@common/services/sanitizer-service';
 import { toBase64 } from '@common/utils/toBase64';
 import dayjs from 'dayjs';
@@ -363,31 +368,8 @@ export const countAllMessages = (tree: MessageNode[]): number => {
   return c;
 };
 
-type MessageViewedValue = boolean | string | undefined;
-
-export const isMessageViewed = (message: { viewed?: MessageViewedValue }): boolean => {
-  return message.viewed === true || message.viewed === 'true';
-};
-
-export const countUnreadMessages = (tree: MessageNode[]): number => {
-  if (!tree) {
-    return 0;
-  }
-  let c = 0;
-  c += tree.filter((node) => !isMessageViewed(node)).length;
-  tree.forEach((root) => {
-    c += countUnreadMessages(root.children ?? []);
-  });
-  return c;
-};
+export { countUnreadMessages, isMessageViewed };
 
 export const markConversationMessageViewed = (tree: MessageNode[], selectedMessage: MessageNode): MessageNode[] => {
-  return tree.map((node) => ({
-    ...node,
-    viewed:
-      node.conversationId === selectedMessage.conversationId && node.messageId === selectedMessage.messageId
-        ? true
-        : node.viewed,
-    children: node.children ? markConversationMessageViewed(node.children, selectedMessage) : node.children,
-  }));
+  return markConversationMessageViewedCommon(tree, selectedMessage, true);
 };

--- a/frontend/src/supportmanagement/services/support-message-service.ts
+++ b/frontend/src/supportmanagement/services/support-message-service.ts
@@ -41,7 +41,7 @@ export interface Message {
   subject: string;
   sender: string;
   target: string;
-  viewed: boolean;
+  viewed: boolean | string;
   emailHeaders: Record<string, string[]>;
   conversationId?: string;
   messageId?: string;
@@ -363,14 +363,31 @@ export const countAllMessages = (tree: MessageNode[]): number => {
   return c;
 };
 
+type MessageViewedValue = boolean | string | undefined;
+
+export const isMessageViewed = (message: { viewed?: MessageViewedValue }): boolean => {
+  return message.viewed === true || message.viewed === 'true';
+};
+
 export const countUnreadMessages = (tree: MessageNode[]): number => {
   if (!tree) {
     return 0;
   }
   let c = 0;
-  c += tree.filter((node) => !node.viewed).length;
+  c += tree.filter((node) => !isMessageViewed(node)).length;
   tree.forEach((root) => {
     c += countUnreadMessages(root.children ?? []);
   });
   return c;
+};
+
+export const markConversationMessageViewed = (tree: MessageNode[], selectedMessage: MessageNode): MessageNode[] => {
+  return tree.map((node) => ({
+    ...node,
+    viewed:
+      node.conversationId === selectedMessage.conversationId && node.messageId === selectedMessage.messageId
+        ? true
+        : node.viewed,
+    children: node.children ? markConversationMessageViewed(node.children, selectedMessage) : node.children,
+  }));
 };


### PR DESCRIPTION
## Sammanfattning
- Räknar olästa conversation-meddelanden ihop med vanliga meddelanden i både MEX och Kontakt Sundsvall.
- Normaliserar `viewed` så bara `true`/`"true"` räknas som läst, medan `false`, `"false"` och saknat värde räknas som oläst.
- Släcker notispricken och uppdaterar flikräknaren lokalt när ett conversation-meddelande öppnas.
- Returnerar explicit boolean `viewed` från conversation-proxyerna och markerar egna conversation-meddelanden som lästa.
- Lägger Playwright-täckning för olästa conversation-meddelanden i MEX- och KC-meddelandeflödena.
- Samlar gemensam lässtatuslogik i en gemensam message view-status service för att minska duplicering mellan MEX och KC.

## Bakgrund / rotorsak
Överlämningsmeddelanden mellan Kontakt Sundsvall och MEX ligger som conversation-meddelanden. UI:t räknade tidigare huvudsakligen vanliga meddelanden och behandlade otydliga `viewed`-värden som lästa i vissa vyer. Därför kunde fliken visa `Meddelanden (0)` och pricken vara släckt trots att det fanns ett oläst överlämningsmeddelande.

## Påverkan
- Nya inkomna överlämningsmeddelanden visas som olästa.
- `Meddelanden (1)` visas när ett oläst conversation-meddelande finns.
- Notispricken är tänd tills meddelandet öppnas.
- När meddelandet öppnas går räknaren ned till `(0)` i aktuell vy.

## Validering
- `frontend npm run type-check`
- `backend npm run type-check`
- Riktad frontend/backend eslint på ändrade filer
- `frontend npm run format:check`
- `npm run test:e2e:kc -- e2e/kontaktcenter/errandPage-message-tab-kc.spec.ts`
- GitHub Actions: `E2E mex on ubuntu-latest` passerar
- GitHub Actions: SonarCloud Code Analysis passerar

## Notering
Lokal MEX Playwright-körning redirectar till `/mex/login?...NOT_AUTHORIZED` i min lokala miljö. CI-körningen för MEX är grön på PR:n.
