### PR TITLE
Filter active contracts by default

### DIFF
--- a/frontend/cypress/e2e/case-data/mex/contract-overview-mex.cy.ts
+++ b/frontend/cypress/e2e/case-data/mex/contract-overview-mex.cy.ts
@@ -1,17 +1,18 @@
 /// <reference types="cypress" />
 
 import { onlyOn } from '@cypress/skip-test';
+
 import { mockNotifications } from '../../../../cypress/e2e/kontaktcenter/fixtures/mockSupportNotifications';
 import { mockAdmins } from '../fixtures/mockAdmins';
 import { mockContractAttachment } from '../fixtures/mockContract';
 import {
-  mockContractsList,
-  mockContractsListEmpty,
-  mockContractsListFiltered,
   mockContractDetailLeaseAgreement,
   mockContractDetailPurchaseAgreement,
   mockContractInvoices,
   mockContractInvoicesEmpty,
+  mockContractsList,
+  mockContractsListEmpty,
+  mockContractsListFiltered,
 } from '../fixtures/mockContractsList';
 import { mockErrands_base } from '../fixtures/mockErrands';
 import { mockMe } from '../fixtures/mockMe';
@@ -98,6 +99,14 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
       cy.get('[data-cy="contract-lease-type-filter"]').should('exist');
       cy.get('[data-cy="contract-dates-filter"]').should('exist');
       cy.get('[data-cy="contract-status-filter"]').should('exist');
+      cy.get('[data-cy="contract-status-filter"]').click();
+      cy.get('[data-cy^="contract-status-filter-"]').then(($statuses) => {
+        expect([...$statuses].map((status) => status.getAttribute('data-cy'))).to.deep.equal([
+          'contract-status-filter-ACTIVE',
+          'contract-status-filter-DRAFT',
+          'contract-status-filter-TERMINATED',
+        ]);
+      });
     });
 
     it('can use the search field', () => {

--- a/frontend/cypress/e2e/case-data/mex/contract-overview-mex.cy.ts
+++ b/frontend/cypress/e2e/case-data/mex/contract-overview-mex.cy.ts
@@ -41,6 +41,13 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
       cy.get('h1').contains('Alla avtal').should('exist');
     });
 
+    it('fetches only active contracts by default', () => {
+      cy.get('button').contains('Avtalsöversikt').should('exist').click();
+      cy.wait('@getContracts').its('request.url').should('include', 'status=ACTIVE');
+      cy.get('[data-cy="contract-status-filter"]').click();
+      cy.get('[data-cy="contract-status-filter-ACTIVE"]').should('be.checked');
+    });
+
     it('displays the contracts table with correct headers', () => {
       navigateToContractOverview();
       cy.get('[data-cy="contracts-table"]').should('exist');
@@ -122,7 +129,7 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
       navigateToContractOverview();
       cy.get('[data-cy="contract-status-filter"]').click();
       cy.intercept('GET', '**/contracts?*', mockContractsListFiltered).as('getFilteredContracts');
-      cy.get('[data-cy="contract-status-filter-ACTIVE"]').click({ force: true });
+      cy.get('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
       cy.wait('@getFilteredContracts');
     });
 
@@ -202,14 +209,30 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
       cy.wait('@getSortedContracts');
     });
 
+    it('can sort by property designation and district', () => {
+      navigateToContractOverview();
+
+      cy.intercept('GET', '**/contracts?*sortBy=propertyDesignations.name*', mockContractsList).as(
+        'getContractsSortedByPropertyDesignation'
+      );
+      cy.get('[data-cy="contracts-table"] th').contains('Fastighetsbeteckning').click();
+      cy.wait('@getContractsSortedByPropertyDesignation');
+
+      cy.intercept('GET', '**/contracts?*sortBy=propertyDesignations.district*', mockContractsList).as(
+        'getContractsSortedByDistrict'
+      );
+      cy.get('[data-cy="contracts-table"] th').contains('Distrikt').click();
+      cy.wait('@getContractsSortedByDistrict');
+    });
+
     describe('Filter chips and clear filters', () => {
       it('shows a chip when filtering by status', () => {
         navigateToContractOverview();
         cy.get('[data-cy="contract-status-filter"]').click();
         cy.intercept('GET', '**/contracts?*', mockContractsListFiltered).as('getFilteredContracts');
-        cy.get('[data-cy="contract-status-filter-ACTIVE"]').click({ force: true });
+        cy.get('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
         cy.wait('@getFilteredContracts');
-        cy.get('[data-cy="tag-contract-status-ACTIVE"]').should('exist').and('contain.text', 'Aktiv');
+        cy.get('[data-cy="tag-contract-status-DRAFT"]').should('exist').and('contain.text', 'Utkast');
       });
 
       it('shows a chip when filtering by contract type', () => {
@@ -227,7 +250,9 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
         cy.intercept('GET', '**/contracts?*', mockContractsListFiltered).as('getFilteredContracts');
         cy.get('[data-cy="contract-lease-type-filter-LAND_LEASE_RESIDENTIAL"]').click({ force: true });
         cy.wait('@getFilteredContracts');
-        cy.get('[data-cy="tag-lease-type-LAND_LEASE_RESIDENTIAL"]').should('exist').and('contain.text', 'Bostadsarrende');
+        cy.get('[data-cy="tag-lease-type-LAND_LEASE_RESIDENTIAL"]')
+          .should('exist')
+          .and('contain.text', 'Bostadsarrende');
       });
 
       it('shows a chip when filtering by date period', () => {
@@ -245,14 +270,14 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
         navigateToContractOverview();
         cy.get('[data-cy="contract-status-filter"]').click();
         cy.intercept('GET', '**/contracts?*', mockContractsListFiltered).as('getFilteredContracts');
-        cy.get('[data-cy="contract-status-filter-ACTIVE"]').click({ force: true });
+        cy.get('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
         cy.wait('@getFilteredContracts');
-        cy.get('[data-cy="tag-contract-status-ACTIVE"]').should('exist');
+        cy.get('[data-cy="tag-contract-status-DRAFT"]').should('exist');
 
         cy.intercept('GET', '**/contracts?*', mockContractsList).as('getUnfilteredContracts');
-        cy.get('[data-cy="tag-contract-status-ACTIVE"]').click();
+        cy.get('[data-cy="tag-contract-status-DRAFT"]').click();
         cy.wait('@getUnfilteredContracts');
-        cy.get('[data-cy="tag-contract-status-ACTIVE"]').should('not.exist');
+        cy.get('[data-cy="tag-contract-status-DRAFT"]').should('not.exist');
       });
 
       it('removes a contract type chip when clicking it', () => {
@@ -291,7 +316,7 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
 
         cy.get('[data-cy="contract-status-filter"]').click();
         cy.intercept('GET', '**/contracts?*', mockContractsListFiltered).as('getFilteredContracts');
-        cy.get('[data-cy="contract-status-filter-ACTIVE"]').click({ force: true });
+        cy.get('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
         cy.wait('@getFilteredContracts');
 
         cy.get('[data-cy="tag-contract-clearAll"]').should('exist').and('contain.text', 'Rensa alla');
@@ -303,7 +328,7 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
         // Apply status filter
         cy.get('[data-cy="contract-status-filter"]').click();
         cy.intercept('GET', '**/contracts?*', mockContractsListFiltered).as('getFilteredContracts');
-        cy.get('[data-cy="contract-status-filter-ACTIVE"]').click({ force: true });
+        cy.get('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
         cy.wait('@getFilteredContracts');
 
         // Apply contract type filter
@@ -313,7 +338,7 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
         cy.wait('@getFilteredContracts2');
 
         // Both chips should exist
-        cy.get('[data-cy="tag-contract-status-ACTIVE"]').should('exist');
+        cy.get('[data-cy="tag-contract-status-DRAFT"]').should('exist');
         cy.get('[data-cy="tag-contract-type-LEASE_AGREEMENT"]').should('exist');
 
         // Click "Rensa alla"
@@ -322,7 +347,7 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
         cy.wait('@getUnfilteredContracts');
 
         // All chips should be gone
-        cy.get('[data-cy="tag-contract-status-ACTIVE"]').should('not.exist');
+        cy.get('[data-cy="tag-contract-status-DRAFT"]').should('not.exist');
         cy.get('[data-cy="tag-contract-type-LEASE_AGREEMENT"]').should('not.exist');
         cy.get('[data-cy="tag-contract-clearAll"]').should('not.exist');
       });
@@ -333,7 +358,7 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
         // Apply status filter
         cy.get('[data-cy="contract-status-filter"]').click();
         cy.intercept('GET', '**/contracts?*', mockContractsListFiltered).as('getFilteredContracts');
-        cy.get('[data-cy="contract-status-filter-ACTIVE"]').click({ force: true });
+        cy.get('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
         cy.wait('@getFilteredContracts');
 
         // Apply contract type filter
@@ -349,13 +374,13 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
         cy.wait('@getFilteredContracts3');
 
         // All three chips should be visible
-        cy.get('[data-cy="tag-contract-status-ACTIVE"]').should('exist');
+        cy.get('[data-cy="tag-contract-status-DRAFT"]').should('exist');
         cy.get('[data-cy="tag-contract-type-LEASE_AGREEMENT"]').should('exist');
         cy.get('[data-cy="tag-lease-type-LAND_LEASE_RESIDENTIAL"]').should('exist');
         cy.get('[data-cy="tag-contract-clearAll"]').should('exist');
       });
 
-      it('does not show chips when no filters are active', () => {
+      it('does not show chips when only the default active status filter is applied', () => {
         navigateToContractOverview();
         cy.get('[data-cy="tag-contract-clearAll"]').should('not.exist');
         cy.get('.sk-chip').should('not.exist');

--- a/frontend/cypress/e2e/case-data/mex/contract-overview-mex.cy.ts
+++ b/frontend/cypress/e2e/case-data/mex/contract-overview-mex.cy.ts
@@ -122,7 +122,7 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
       navigateToContractOverview();
       cy.get('[data-cy="contract-type-filter"]').click();
       cy.intercept('GET', '**/contracts?*', mockContractsListFiltered).as('getFilteredContracts');
-      cy.get('[data-cy="contract-type-filter-LEASE_AGREEMENT"]').click({ force: true });
+      cy.get('[data-cy="contract-type-filter-LEASE_AGREEMENT"]').click();
       cy.wait('@getFilteredContracts');
     });
 
@@ -130,7 +130,7 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
       navigateToContractOverview();
       cy.get('[data-cy="contract-lease-type-filter"]').click();
       cy.intercept('GET', '**/contracts?*', mockContractsListFiltered).as('getFilteredContracts');
-      cy.get('[data-cy="contract-lease-type-filter-LAND_LEASE_RESIDENTIAL"]').click({ force: true });
+      cy.get('[data-cy="contract-lease-type-filter-LAND_LEASE_RESIDENTIAL"]').click();
       cy.wait('@getFilteredContracts');
     });
 
@@ -138,7 +138,7 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
       navigateToContractOverview();
       cy.get('[data-cy="contract-status-filter"]').click();
       cy.intercept('GET', '**/contracts?*', mockContractsListFiltered).as('getFilteredContracts');
-      cy.get('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
+      cy.get('[data-cy="contract-status-filter-DRAFT"]').click();
       cy.wait('@getFilteredContracts');
     });
 
@@ -239,7 +239,7 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
         navigateToContractOverview();
         cy.get('[data-cy="contract-status-filter"]').click();
         cy.intercept('GET', '**/contracts?*', mockContractsListFiltered).as('getFilteredContracts');
-        cy.get('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
+        cy.get('[data-cy="contract-status-filter-DRAFT"]').click();
         cy.wait('@getFilteredContracts');
         cy.get('[data-cy="tag-contract-status-DRAFT"]').should('exist').and('contain.text', 'Utkast');
       });
@@ -248,7 +248,7 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
         navigateToContractOverview();
         cy.get('[data-cy="contract-type-filter"]').click();
         cy.intercept('GET', '**/contracts?*', mockContractsListFiltered).as('getFilteredContracts');
-        cy.get('[data-cy="contract-type-filter-LEASE_AGREEMENT"]').click({ force: true });
+        cy.get('[data-cy="contract-type-filter-LEASE_AGREEMENT"]').click();
         cy.wait('@getFilteredContracts');
         cy.get('[data-cy="tag-contract-type-LEASE_AGREEMENT"]').should('exist').and('contain.text', 'Arrende');
       });
@@ -257,7 +257,7 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
         navigateToContractOverview();
         cy.get('[data-cy="contract-lease-type-filter"]').click();
         cy.intercept('GET', '**/contracts?*', mockContractsListFiltered).as('getFilteredContracts');
-        cy.get('[data-cy="contract-lease-type-filter-LAND_LEASE_RESIDENTIAL"]').click({ force: true });
+        cy.get('[data-cy="contract-lease-type-filter-LAND_LEASE_RESIDENTIAL"]').click();
         cy.wait('@getFilteredContracts');
         cy.get('[data-cy="tag-lease-type-LAND_LEASE_RESIDENTIAL"]')
           .should('exist')
@@ -279,7 +279,7 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
         navigateToContractOverview();
         cy.get('[data-cy="contract-status-filter"]').click();
         cy.intercept('GET', '**/contracts?*', mockContractsListFiltered).as('getFilteredContracts');
-        cy.get('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
+        cy.get('[data-cy="contract-status-filter-DRAFT"]').click();
         cy.wait('@getFilteredContracts');
         cy.get('[data-cy="tag-contract-status-DRAFT"]').should('exist');
 
@@ -293,7 +293,7 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
         navigateToContractOverview();
         cy.get('[data-cy="contract-type-filter"]').click();
         cy.intercept('GET', '**/contracts?*', mockContractsListFiltered).as('getFilteredContracts');
-        cy.get('[data-cy="contract-type-filter-LEASE_AGREEMENT"]').click({ force: true });
+        cy.get('[data-cy="contract-type-filter-LEASE_AGREEMENT"]').click();
         cy.wait('@getFilteredContracts');
         cy.get('[data-cy="tag-contract-type-LEASE_AGREEMENT"]').should('exist');
 
@@ -325,7 +325,7 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
 
         cy.get('[data-cy="contract-status-filter"]').click();
         cy.intercept('GET', '**/contracts?*', mockContractsListFiltered).as('getFilteredContracts');
-        cy.get('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
+        cy.get('[data-cy="contract-status-filter-DRAFT"]').click();
         cy.wait('@getFilteredContracts');
 
         cy.get('[data-cy="tag-contract-clearAll"]').should('exist').and('contain.text', 'Rensa alla');
@@ -337,13 +337,13 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
         // Apply status filter
         cy.get('[data-cy="contract-status-filter"]').click();
         cy.intercept('GET', '**/contracts?*', mockContractsListFiltered).as('getFilteredContracts');
-        cy.get('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
+        cy.get('[data-cy="contract-status-filter-DRAFT"]').click();
         cy.wait('@getFilteredContracts');
 
         // Apply contract type filter
         cy.get('[data-cy="contract-type-filter"]').click();
         cy.intercept('GET', '**/contracts?*', mockContractsListFiltered).as('getFilteredContracts2');
-        cy.get('[data-cy="contract-type-filter-LEASE_AGREEMENT"]').click({ force: true });
+        cy.get('[data-cy="contract-type-filter-LEASE_AGREEMENT"]').click();
         cy.wait('@getFilteredContracts2');
 
         // Both chips should exist
@@ -367,19 +367,19 @@ onlyOn(Cypress.env('application_name') === 'MEX', () => {
         // Apply status filter
         cy.get('[data-cy="contract-status-filter"]').click();
         cy.intercept('GET', '**/contracts?*', mockContractsListFiltered).as('getFilteredContracts');
-        cy.get('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
+        cy.get('[data-cy="contract-status-filter-DRAFT"]').click();
         cy.wait('@getFilteredContracts');
 
         // Apply contract type filter
         cy.get('[data-cy="contract-type-filter"]').click();
         cy.intercept('GET', '**/contracts?*', mockContractsListFiltered).as('getFilteredContracts2');
-        cy.get('[data-cy="contract-type-filter-LEASE_AGREEMENT"]').click({ force: true });
+        cy.get('[data-cy="contract-type-filter-LEASE_AGREEMENT"]').click();
         cy.wait('@getFilteredContracts2');
 
         // Apply lease type filter
         cy.get('[data-cy="contract-lease-type-filter"]').click();
         cy.intercept('GET', '**/contracts?*', mockContractsListFiltered).as('getFilteredContracts3');
-        cy.get('[data-cy="contract-lease-type-filter-LAND_LEASE_RESIDENTIAL"]').click({ force: true });
+        cy.get('[data-cy="contract-lease-type-filter-LAND_LEASE_RESIDENTIAL"]').click();
         cy.wait('@getFilteredContracts3');
 
         // All three chips should be visible

--- a/frontend/e2e/case-data/mex/contract-overview-mex.spec.ts
+++ b/frontend/e2e/case-data/mex/contract-overview-mex.spec.ts
@@ -93,6 +93,15 @@ test.describe('Contract Overview page', () => {
     await expect(page.locator('[data-cy="contract-lease-type-filter"]')).toBeVisible();
     await expect(page.locator('[data-cy="contract-dates-filter"]')).toBeVisible();
     await expect(page.locator('[data-cy="contract-status-filter"]')).toBeVisible();
+    await page.locator('[data-cy="contract-status-filter"]').click();
+    const statusFilterOptions = await page
+      .locator('[data-cy^="contract-status-filter-"]')
+      .evaluateAll((statuses) => statuses.map((status) => status.getAttribute('data-cy')));
+    expect(statusFilterOptions).toEqual([
+      'contract-status-filter-ACTIVE',
+      'contract-status-filter-DRAFT',
+      'contract-status-filter-TERMINATED',
+    ]);
   });
 
   test('can use the search field', async ({ page, mockRoute }) => {

--- a/frontend/e2e/case-data/mex/contract-overview-mex.spec.ts
+++ b/frontend/e2e/case-data/mex/contract-overview-mex.spec.ts
@@ -124,7 +124,7 @@ test.describe('Contract Overview page', () => {
     await navigateToContractOverview(page);
     await page.locator('[data-cy="contract-type-filter"]').click();
     await mockRoute('**/contracts?*', mockContractsListFiltered, { method: 'GET' }); // @getFilteredContracts
-    await page.locator('[data-cy="contract-type-filter-LEASE_AGREEMENT"]').click({ force: true });
+    await page.locator('[data-cy="contract-type-filter-LEASE_AGREEMENT"]').click();
     await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
   });
 
@@ -132,7 +132,7 @@ test.describe('Contract Overview page', () => {
     await navigateToContractOverview(page);
     await page.locator('[data-cy="contract-lease-type-filter"]').click();
     await mockRoute('**/contracts?*', mockContractsListFiltered, { method: 'GET' }); // @getFilteredContracts
-    await page.locator('[data-cy="contract-lease-type-filter-LAND_LEASE_RESIDENTIAL"]').click({ force: true });
+    await page.locator('[data-cy="contract-lease-type-filter-LAND_LEASE_RESIDENTIAL"]').click();
     await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
   });
 
@@ -140,7 +140,7 @@ test.describe('Contract Overview page', () => {
     await navigateToContractOverview(page);
     await page.locator('[data-cy="contract-status-filter"]').click();
     await mockRoute('**/contracts?*', mockContractsListFiltered, { method: 'GET' }); // @getFilteredContracts
-    await page.locator('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
+    await page.locator('[data-cy="contract-status-filter-DRAFT"]').click();
     await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
   });
 
@@ -229,7 +229,8 @@ test.describe('Contract Overview page', () => {
         resp.status() === 200
     );
     await page.locator('[data-cy="contracts-table"] th').filter({ hasText: 'Fastighetsbeteckning' }).click();
-    await propertyDesignationRequest;
+    const propertyDesignationResponse = await propertyDesignationRequest;
+    expect(propertyDesignationResponse.url()).toContain('sortBy=propertyDesignations.name');
 
     const districtRequest = page.waitForResponse(
       (resp) =>
@@ -238,7 +239,8 @@ test.describe('Contract Overview page', () => {
         resp.status() === 200
     );
     await page.locator('[data-cy="contracts-table"] th').filter({ hasText: 'Distrikt' }).click();
-    await districtRequest;
+    const districtResponse = await districtRequest;
+    expect(districtResponse.url()).toContain('sortBy=propertyDesignations.district');
   });
 
   test.describe('Filter chips and clear filters', () => {
@@ -246,7 +248,7 @@ test.describe('Contract Overview page', () => {
       await navigateToContractOverview(page);
       await page.locator('[data-cy="contract-status-filter"]').click();
       await mockRoute('**/contracts?*', mockContractsListFiltered, { method: 'GET' }); // @getFilteredContracts
-      await page.locator('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
+      await page.locator('[data-cy="contract-status-filter-DRAFT"]').click();
       await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
       await expect(page.locator('[data-cy="tag-contract-status-DRAFT"]')).toBeVisible();
       await expect(page.locator('[data-cy="tag-contract-status-DRAFT"]')).toContainText('Utkast');
@@ -256,7 +258,7 @@ test.describe('Contract Overview page', () => {
       await navigateToContractOverview(page);
       await page.locator('[data-cy="contract-type-filter"]').click();
       await mockRoute('**/contracts?*', mockContractsListFiltered, { method: 'GET' }); // @getFilteredContracts
-      await page.locator('[data-cy="contract-type-filter-LEASE_AGREEMENT"]').click({ force: true });
+      await page.locator('[data-cy="contract-type-filter-LEASE_AGREEMENT"]').click();
       await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
       await expect(page.locator('[data-cy="tag-contract-type-LEASE_AGREEMENT"]')).toBeVisible();
       await expect(page.locator('[data-cy="tag-contract-type-LEASE_AGREEMENT"]')).toContainText('Arrende');
@@ -266,7 +268,7 @@ test.describe('Contract Overview page', () => {
       await navigateToContractOverview(page);
       await page.locator('[data-cy="contract-lease-type-filter"]').click();
       await mockRoute('**/contracts?*', mockContractsListFiltered, { method: 'GET' }); // @getFilteredContracts
-      await page.locator('[data-cy="contract-lease-type-filter-LAND_LEASE_RESIDENTIAL"]').click({ force: true });
+      await page.locator('[data-cy="contract-lease-type-filter-LAND_LEASE_RESIDENTIAL"]').click();
       await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
       await expect(page.locator('[data-cy="tag-lease-type-LAND_LEASE_RESIDENTIAL"]')).toBeVisible();
       await expect(page.locator('[data-cy="tag-lease-type-LAND_LEASE_RESIDENTIAL"]')).toContainText('Bostadsarrende');
@@ -287,7 +289,7 @@ test.describe('Contract Overview page', () => {
       await navigateToContractOverview(page);
       await page.locator('[data-cy="contract-status-filter"]').click();
       await mockRoute('**/contracts?*', mockContractsListFiltered, { method: 'GET' }); // @getFilteredContracts
-      await page.locator('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
+      await page.locator('[data-cy="contract-status-filter-DRAFT"]').click();
       await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
       await expect(page.locator('[data-cy="tag-contract-status-DRAFT"]')).toBeVisible();
 
@@ -301,7 +303,7 @@ test.describe('Contract Overview page', () => {
       await navigateToContractOverview(page);
       await page.locator('[data-cy="contract-type-filter"]').click();
       await mockRoute('**/contracts?*', mockContractsListFiltered, { method: 'GET' }); // @getFilteredContracts
-      await page.locator('[data-cy="contract-type-filter-LEASE_AGREEMENT"]').click({ force: true });
+      await page.locator('[data-cy="contract-type-filter-LEASE_AGREEMENT"]').click();
       await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
       await expect(page.locator('[data-cy="tag-contract-type-LEASE_AGREEMENT"]')).toBeVisible();
 
@@ -333,7 +335,7 @@ test.describe('Contract Overview page', () => {
 
       await page.locator('[data-cy="contract-status-filter"]').click();
       await mockRoute('**/contracts?*', mockContractsListFiltered, { method: 'GET' }); // @getFilteredContracts
-      await page.locator('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
+      await page.locator('[data-cy="contract-status-filter-DRAFT"]').click();
       await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
 
       await expect(page.locator('[data-cy="tag-contract-clearAll"]')).toBeVisible();
@@ -346,12 +348,12 @@ test.describe('Contract Overview page', () => {
       // Apply status filter
       await page.locator('[data-cy="contract-status-filter"]').click();
       await mockRoute('**/contracts?*', mockContractsListFiltered, { method: 'GET' }); // @getFilteredContracts
-      await page.locator('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
+      await page.locator('[data-cy="contract-status-filter-DRAFT"]').click();
       await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
 
       // Apply contract type filter
       await page.locator('[data-cy="contract-type-filter"]').click();
-      await page.locator('[data-cy="contract-type-filter-LEASE_AGREEMENT"]').click({ force: true });
+      await page.locator('[data-cy="contract-type-filter-LEASE_AGREEMENT"]').click();
       await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
 
       // Both chips should exist
@@ -375,17 +377,17 @@ test.describe('Contract Overview page', () => {
       // Apply status filter
       await page.locator('[data-cy="contract-status-filter"]').click();
       await mockRoute('**/contracts?*', mockContractsListFiltered, { method: 'GET' }); // @getFilteredContracts
-      await page.locator('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
+      await page.locator('[data-cy="contract-status-filter-DRAFT"]').click();
       await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
 
       // Apply contract type filter
       await page.locator('[data-cy="contract-type-filter"]').click();
-      await page.locator('[data-cy="contract-type-filter-LEASE_AGREEMENT"]').click({ force: true });
+      await page.locator('[data-cy="contract-type-filter-LEASE_AGREEMENT"]').click();
       await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
 
       // Apply lease type filter
       await page.locator('[data-cy="contract-lease-type-filter"]').click();
-      await page.locator('[data-cy="contract-lease-type-filter-LAND_LEASE_RESIDENTIAL"]').click({ force: true });
+      await page.locator('[data-cy="contract-lease-type-filter-LAND_LEASE_RESIDENTIAL"]').click();
       await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
 
       // All three chips should be visible

--- a/frontend/e2e/case-data/mex/contract-overview-mex.spec.ts
+++ b/frontend/e2e/case-data/mex/contract-overview-mex.spec.ts
@@ -1,15 +1,15 @@
-import { test, expect } from '../../fixtures/base.fixture';
+import { expect, test } from '../../fixtures/base.fixture';
 import { mockNotifications } from '../../kontaktcenter/fixtures/mockSupportNotifications';
 import { mockAdmins } from '../fixtures/mockAdmins';
 import { mockContractAttachment } from '../fixtures/mockContract';
 import {
-  mockContractsList,
-  mockContractsListEmpty,
-  mockContractsListFiltered,
   mockContractDetailLeaseAgreement,
   mockContractDetailPurchaseAgreement,
   mockContractInvoices,
   mockContractInvoicesEmpty,
+  mockContractsList,
+  mockContractsListEmpty,
+  mockContractsListFiltered,
 } from '../fixtures/mockContractsList';
 import { mockErrands_base } from '../fixtures/mockErrands';
 import { mockMe } from '../fixtures/mockMe';
@@ -36,6 +36,14 @@ test.describe('Contract Overview page', () => {
     await page.getByRole('button', { name: 'Avtalsöversikt' }).click();
     await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
     await expect(page.locator('h1').filter({ hasText: 'Alla avtal' })).toBeVisible();
+  });
+
+  test('fetches only active contracts by default', async ({ page }) => {
+    await page.getByRole('button', { name: 'Avtalsöversikt' }).click();
+    const response = await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
+    expect(response.url()).toContain('status=ACTIVE');
+    await page.locator('[data-cy="contract-status-filter"]').click();
+    await expect(page.locator('[data-cy="contract-status-filter-ACTIVE"]')).toBeChecked();
   });
 
   test('displays the contracts table with correct headers', async ({ page }) => {
@@ -91,9 +99,16 @@ test.describe('Contract Overview page', () => {
     await navigateToContractOverview(page);
     await page.locator('[data-cy="contract-query-filter"]').fill('BALDER');
     await mockRoute('**/contracts?*', mockContractsListFiltered, { method: 'GET' }); // @getFilteredContracts
-    await page.locator('[data-cy="contract-query-filter"]').locator('..').locator('button').filter({ hasText: 'Sök' }).click();
+    await page
+      .locator('[data-cy="contract-query-filter"]')
+      .locator('..')
+      .locator('button')
+      .filter({ hasText: 'Sök' })
+      .click();
     await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
-    await expect(page.locator('[data-cy="contracts-table"] tbody tr')).toHaveCount(mockContractsListFiltered.content?.length);
+    await expect(page.locator('[data-cy="contracts-table"] tbody tr')).toHaveCount(
+      mockContractsListFiltered.content?.length
+    );
   });
 
   test('can filter by contract type', async ({ page, mockRoute }) => {
@@ -116,7 +131,7 @@ test.describe('Contract Overview page', () => {
     await navigateToContractOverview(page);
     await page.locator('[data-cy="contract-status-filter"]').click();
     await mockRoute('**/contracts?*', mockContractsListFiltered, { method: 'GET' }); // @getFilteredContracts
-    await page.locator('[data-cy="contract-status-filter-ACTIVE"]').click({ force: true });
+    await page.locator('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
     await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
   });
 
@@ -194,15 +209,38 @@ test.describe('Contract Overview page', () => {
     await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
   });
 
+  test('can sort by property designation and district', async ({ page, mockRoute }) => {
+    await navigateToContractOverview(page);
+    await mockRoute('**/contracts?*', mockContractsList, { method: 'GET' });
+
+    const propertyDesignationRequest = page.waitForResponse(
+      (resp) =>
+        resp.url().includes('/contracts?') &&
+        resp.url().includes('sortBy=propertyDesignations.name') &&
+        resp.status() === 200
+    );
+    await page.locator('[data-cy="contracts-table"] th').filter({ hasText: 'Fastighetsbeteckning' }).click();
+    await propertyDesignationRequest;
+
+    const districtRequest = page.waitForResponse(
+      (resp) =>
+        resp.url().includes('/contracts?') &&
+        resp.url().includes('sortBy=propertyDesignations.district') &&
+        resp.status() === 200
+    );
+    await page.locator('[data-cy="contracts-table"] th').filter({ hasText: 'Distrikt' }).click();
+    await districtRequest;
+  });
+
   test.describe('Filter chips and clear filters', () => {
     test('shows a chip when filtering by status', async ({ page, mockRoute }) => {
       await navigateToContractOverview(page);
       await page.locator('[data-cy="contract-status-filter"]').click();
       await mockRoute('**/contracts?*', mockContractsListFiltered, { method: 'GET' }); // @getFilteredContracts
-      await page.locator('[data-cy="contract-status-filter-ACTIVE"]').click({ force: true });
+      await page.locator('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
       await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
-      await expect(page.locator('[data-cy="tag-contract-status-ACTIVE"]')).toBeVisible();
-      await expect(page.locator('[data-cy="tag-contract-status-ACTIVE"]')).toContainText('Aktiv');
+      await expect(page.locator('[data-cy="tag-contract-status-DRAFT"]')).toBeVisible();
+      await expect(page.locator('[data-cy="tag-contract-status-DRAFT"]')).toContainText('Utkast');
     });
 
     test('shows a chip when filtering by contract type', async ({ page, mockRoute }) => {
@@ -240,14 +278,14 @@ test.describe('Contract Overview page', () => {
       await navigateToContractOverview(page);
       await page.locator('[data-cy="contract-status-filter"]').click();
       await mockRoute('**/contracts?*', mockContractsListFiltered, { method: 'GET' }); // @getFilteredContracts
-      await page.locator('[data-cy="contract-status-filter-ACTIVE"]').click({ force: true });
+      await page.locator('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
       await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
-      await expect(page.locator('[data-cy="tag-contract-status-ACTIVE"]')).toBeVisible();
+      await expect(page.locator('[data-cy="tag-contract-status-DRAFT"]')).toBeVisible();
 
       await mockRoute('**/contracts?*', mockContractsList, { method: 'GET' }); // @getUnfilteredContracts
-      await page.locator('[data-cy="tag-contract-status-ACTIVE"]').click();
+      await page.locator('[data-cy="tag-contract-status-DRAFT"]').click();
       await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
-      await expect(page.locator('[data-cy="tag-contract-status-ACTIVE"]')).toHaveCount(0);
+      await expect(page.locator('[data-cy="tag-contract-status-DRAFT"]')).toHaveCount(0);
     });
 
     test('removes a contract type chip when clicking it', async ({ page, mockRoute }) => {
@@ -286,7 +324,7 @@ test.describe('Contract Overview page', () => {
 
       await page.locator('[data-cy="contract-status-filter"]').click();
       await mockRoute('**/contracts?*', mockContractsListFiltered, { method: 'GET' }); // @getFilteredContracts
-      await page.locator('[data-cy="contract-status-filter-ACTIVE"]').click({ force: true });
+      await page.locator('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
       await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
 
       await expect(page.locator('[data-cy="tag-contract-clearAll"]')).toBeVisible();
@@ -299,7 +337,7 @@ test.describe('Contract Overview page', () => {
       // Apply status filter
       await page.locator('[data-cy="contract-status-filter"]').click();
       await mockRoute('**/contracts?*', mockContractsListFiltered, { method: 'GET' }); // @getFilteredContracts
-      await page.locator('[data-cy="contract-status-filter-ACTIVE"]').click({ force: true });
+      await page.locator('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
       await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
 
       // Apply contract type filter
@@ -308,7 +346,7 @@ test.describe('Contract Overview page', () => {
       await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
 
       // Both chips should exist
-      await expect(page.locator('[data-cy="tag-contract-status-ACTIVE"]')).toBeVisible();
+      await expect(page.locator('[data-cy="tag-contract-status-DRAFT"]')).toBeVisible();
       await expect(page.locator('[data-cy="tag-contract-type-LEASE_AGREEMENT"]')).toBeVisible();
 
       // Click "Rensa alla"
@@ -317,7 +355,7 @@ test.describe('Contract Overview page', () => {
       await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
 
       // All chips should be gone
-      await expect(page.locator('[data-cy="tag-contract-status-ACTIVE"]')).toHaveCount(0);
+      await expect(page.locator('[data-cy="tag-contract-status-DRAFT"]')).toHaveCount(0);
       await expect(page.locator('[data-cy="tag-contract-type-LEASE_AGREEMENT"]')).toHaveCount(0);
       await expect(page.locator('[data-cy="tag-contract-clearAll"]')).toHaveCount(0);
     });
@@ -328,7 +366,7 @@ test.describe('Contract Overview page', () => {
       // Apply status filter
       await page.locator('[data-cy="contract-status-filter"]').click();
       await mockRoute('**/contracts?*', mockContractsListFiltered, { method: 'GET' }); // @getFilteredContracts
-      await page.locator('[data-cy="contract-status-filter-ACTIVE"]').click({ force: true });
+      await page.locator('[data-cy="contract-status-filter-DRAFT"]').click({ force: true });
       await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
 
       // Apply contract type filter
@@ -342,13 +380,13 @@ test.describe('Contract Overview page', () => {
       await page.waitForResponse((resp) => resp.url().includes('/contracts?') && resp.status() === 200);
 
       // All three chips should be visible
-      await expect(page.locator('[data-cy="tag-contract-status-ACTIVE"]')).toBeVisible();
+      await expect(page.locator('[data-cy="tag-contract-status-DRAFT"]')).toBeVisible();
       await expect(page.locator('[data-cy="tag-contract-type-LEASE_AGREEMENT"]')).toBeVisible();
       await expect(page.locator('[data-cy="tag-lease-type-LAND_LEASE_RESIDENTIAL"]')).toBeVisible();
       await expect(page.locator('[data-cy="tag-contract-clearAll"]')).toBeVisible();
     });
 
-    test('does not show chips when no filters are active', async ({ page }) => {
+    test('does not show chips when only the default active status filter is applied', async ({ page }) => {
       await navigateToContractOverview(page);
       await expect(page.locator('[data-cy="tag-contract-clearAll"]')).toHaveCount(0);
       await expect(page.locator('.sk-chip')).toHaveCount(0);
@@ -575,7 +613,6 @@ test.describe('Contract Overview page', () => {
         await page.locator('[data-cy="contract-row-0"]').click();
         await page.locator('[data-cy="fakturor-disclosure"]').click();
 
-
         await expect(page.locator('[data-cy="next-billing-date"]')).toContainText('2026-06-01');
       });
 
@@ -587,7 +624,6 @@ test.describe('Contract Overview page', () => {
 
         await page.locator('[data-cy="contract-row-0"]').click();
         await page.locator('[data-cy="fakturor-disclosure"]').click();
-
 
         await expect(page.locator('[data-cy="next-billing-date"]')).toContainText('-');
       });
@@ -611,7 +647,6 @@ test.describe('Contract Overview page', () => {
         await page.locator('[data-cy="contract-row-0"]').click();
         await page.locator('[data-cy="fakturor-disclosure"]').click();
 
-
         // Invoices table should be visible
         await expect(page.locator('[data-cy="contract-invoices-table"]')).toBeVisible();
       });
@@ -623,7 +658,6 @@ test.describe('Contract Overview page', () => {
 
         await page.locator('[data-cy="contract-row-0"]').click();
         await page.locator('[data-cy="fakturor-disclosure"]').click();
-
 
         // Check first invoice row
         await expect(page.locator('[data-cy="invoice-row-0"]')).toBeVisible();
@@ -640,7 +674,6 @@ test.describe('Contract Overview page', () => {
 
         await page.locator('[data-cy="contract-row-0"]').click();
         await page.locator('[data-cy="fakturor-disclosure"]').click();
-
 
         // Check status labels
         await expect(page.locator('[data-cy="invoice-status-0"]')).toContainText('Ny');
@@ -672,7 +705,6 @@ test.describe('Contract Overview page', () => {
 
         await page.locator('[data-cy="contract-row-0"]').click();
         await page.locator('[data-cy="fakturor-disclosure"]').click();
-
 
         // Empty state message should be visible
         await expect(page.locator('[data-cy="invoices-empty"]')).toBeVisible();
@@ -926,11 +958,11 @@ test.describe('Contract Overview page', () => {
         // Should open the new errand in a new tab
         await expect
           .poll(() =>
-            page.evaluate(
-              () => (window as unknown as { __openCalls: { url: string; target: string }[] }).__openCalls
-            )
+            page.evaluate(() => (window as unknown as { __openCalls: { url: string; target: string }[] }).__openCalls)
           )
-          .toContainEqual(expect.objectContaining({ url: expect.stringMatching(/\/arende\/MEX-2024-000999$/), target: '_blank' }));
+          .toContainEqual(
+            expect.objectContaining({ url: expect.stringMatching(/\/arende\/MEX-2024-000999$/), target: '_blank' })
+          );
       });
 
       test('shows success toast and opens new errand after creation', async ({ page, mockRoute }) => {
@@ -977,9 +1009,7 @@ test.describe('Contract Overview page', () => {
         // Should open the new errand
         await expect
           .poll(() =>
-            page.evaluate(
-              () => (window as unknown as { __openCalls: { url: string; target: string }[] }).__openCalls
-            )
+            page.evaluate(() => (window as unknown as { __openCalls: { url: string; target: string }[] }).__openCalls)
           )
           .toContainEqual(expect.objectContaining({ url: expect.stringMatching(/\/arende\/MEX-2024-000999$/) }));
       });

--- a/frontend/src/casedata/components/contract-overview/contract-overview.component.tsx
+++ b/frontend/src/casedata/components/contract-overview/contract-overview.component.tsx
@@ -14,6 +14,29 @@ import { ContractsFilterTags } from './contracts-filter-tags.component';
 import { ContractFilter, ContractFilterValues, ContractsFilteringComponent } from './contracts-filtering.component';
 import { ContractsTable, ContractTableForm } from './contracts-table.component';
 
+const contractFilterToObject = (filter: ContractFilter): { [key: string]: string } => {
+  const fObj: { [key: string]: string } = {};
+  if (filter.query?.trim()) {
+    fObj['query'] = filter.query.trim();
+  }
+  if (filter.status && filter.status.length > 0) {
+    fObj['status'] = filter.status.join(',');
+  }
+  if (filter.contractType && filter.contractType.length > 0) {
+    fObj['contractType'] = filter.contractType.join(',');
+  }
+  if (filter.leaseType && filter.leaseType.length > 0) {
+    fObj['leaseType'] = filter.leaseType.join(',');
+  }
+  if (filter.startdate?.trim()) {
+    fObj['startDate'] = filter.startdate.trim();
+  }
+  if (filter.enddate?.trim()) {
+    fObj['endDate'] = filter.enddate.trim();
+  }
+  return fObj;
+};
+
 export const ContractOverview: FC = () => {
   const filterForm = useForm<ContractFilter>({ defaultValues: ContractFilterValues });
   const { watch: watchFilter } = filterForm;
@@ -37,7 +60,9 @@ export const ContractOverview: FC = () => {
   const [selectedInvoice, setSelectedInvoice] = useState<CBillingRecord | null>(null);
   const [contractsResponse, setContractsResponse] = useState<PageContract | null>(null);
 
-  const [filterObject, setFilterObject] = useState<{ [key: string]: string }>({});
+  const [filterObject, setFilterObject] = useState<{ [key: string]: string }>(() =>
+    contractFilterToObject(ContractFilterValues)
+  );
 
   const handleRowClick = (contract: Contract) => {
     setSelectedContract(contract);
@@ -61,26 +86,16 @@ export const ContractOverview: FC = () => {
 
   useDebounceEffect(
     () => {
-      const fObj: { [key: string]: string } = {};
-      if (queryFilter?.trim()) {
-        fObj['query'] = queryFilter.trim();
-      }
-      if (statusFilter && statusFilter.length > 0) {
-        fObj['status'] = statusFilter.join(',');
-      }
-      if (contractTypeFilter && contractTypeFilter.length > 0) {
-        fObj['contractType'] = contractTypeFilter.join(',');
-      }
-      if (leaseTypeFilter && leaseTypeFilter.length > 0) {
-        fObj['leaseType'] = leaseTypeFilter.join(',');
-      }
-      if (startdate?.trim()) {
-        fObj['startDate'] = startdate.trim();
-      }
-      if (enddate?.trim()) {
-        fObj['endDate'] = enddate.trim();
-      }
-      setFilterObject(fObj);
+      setFilterObject(
+        contractFilterToObject({
+          query: queryFilter,
+          status: statusFilter,
+          contractType: contractTypeFilter,
+          leaseType: leaseTypeFilter,
+          startdate,
+          enddate,
+        })
+      );
     },
     200,
     [queryFilter, statusFilter, contractTypeFilter, leaseTypeFilter, startdate, enddate]

--- a/frontend/src/casedata/components/contract-overview/contracts-filter-tags.component.tsx
+++ b/frontend/src/casedata/components/contract-overview/contracts-filter-tags.component.tsx
@@ -21,14 +21,18 @@ const getLeaseTypeLabel = (value: string): string => {
 export const ContractsFilterTags: FC = () => {
   const { watch, setValue, reset } = useFormContext<ContractFilter>();
 
-  const statuses = watch('status');
+  const statuses = watch('status') ?? [];
   const contractTypeValues = watch('contractType');
   const leaseTypeValues = watch('leaseType');
   const startdate = watch('startdate');
   const enddate = watch('enddate');
+  const defaultStatuses = ContractFilterValues.status;
+  const hasDefaultStatuses =
+    statuses.length === defaultStatuses.length && defaultStatuses.every((status) => statuses.includes(status));
+  const hasStatusFilterChanged = !hasDefaultStatuses;
 
   const hasTags =
-    statuses.length > 0 || contractTypeValues.length > 0 || leaseTypeValues.length > 0 || startdate || enddate;
+    hasStatusFilterChanged || contractTypeValues.length > 0 || leaseTypeValues.length > 0 || startdate || enddate;
 
   const handleRemoveStatus = (value: string) => {
     setValue(
@@ -66,15 +70,16 @@ export const ContractsFilterTags: FC = () => {
 
   return (
     <div className="flex gap-8 flex-wrap justify-start">
-      {statuses.map((status, index) => (
-        <Chip
-          data-cy={`tag-contract-status-${status}`}
-          key={`contractStatus-${index}`}
-          onClick={() => handleRemoveStatus(status)}
-        >
-          {getStatusLabel(status)}
-        </Chip>
-      ))}
+      {hasStatusFilterChanged &&
+        statuses.map((status, index) => (
+          <Chip
+            data-cy={`tag-contract-status-${status}`}
+            key={`contractStatus-${index}`}
+            onClick={() => handleRemoveStatus(status)}
+          >
+            {getStatusLabel(status)}
+          </Chip>
+        ))}
 
       {contractTypeValues.map((type, index) => (
         <Chip

--- a/frontend/src/casedata/components/contract-overview/contracts-filtering.component.tsx
+++ b/frontend/src/casedata/components/contract-overview/contracts-filtering.component.tsx
@@ -25,8 +25,8 @@ export const ContractFilterValues: ContractFilter = {
 };
 
 export const statusOptions = [
-  { label: 'Utkast', value: Status.DRAFT },
   { label: 'Aktiv', value: Status.ACTIVE },
+  { label: 'Utkast', value: Status.DRAFT },
   { label: 'Avslutad', value: Status.TERMINATED },
 ];
 

--- a/frontend/src/casedata/components/contract-overview/contracts-filtering.component.tsx
+++ b/frontend/src/casedata/components/contract-overview/contracts-filtering.component.tsx
@@ -17,7 +17,7 @@ export interface ContractFilter {
 
 export const ContractFilterValues: ContractFilter = {
   query: '',
-  status: [],
+  status: [Status.ACTIVE],
   contractType: [],
   leaseType: [],
   startdate: '',

--- a/frontend/src/casedata/components/contract-overview/contracts-table.component.tsx
+++ b/frontend/src/casedata/components/contract-overview/contracts-table.component.tsx
@@ -83,8 +83,8 @@ const formatPeriod = (start?: string, end?: string): ReactNode => {
 
 export const contractTableLabels = [
   { label: 'Status', sortable: true, column: 'status' },
-  { label: 'Fastighetsbeteckning', sortable: false, column: 'propertyDesignations' },
-  { label: 'Distrikt', sortable: false, column: 'district' },
+  { label: 'Fastighetsbeteckning', sortable: true, column: 'propertyDesignations.name' },
+  { label: 'Distrikt', sortable: true, column: 'propertyDesignations.district' },
   { label: 'Avtalstyp', sortable: true, column: 'type' },
   { label: 'Undertyp', sortable: true, column: 'leaseType' },
   { label: 'Avtals-id', sortable: true, column: 'id' },


### PR DESCRIPTION
## Summary
- Default contract overview status filter to active contracts.
- Keep the default active filter out of filter chips/clear-all UI until the user changes filters.
- Enable sorting for Fastighetsbeteckning and Distrikt.
- Update Cypress and Playwright coverage for the new defaults and sort fields.


Jira: https://jira.sundsvall.se/browse/DRAKEN-4426
