### PR TITLE
refactor: decouple supportmanagement from casedata imports

### DIFF
--- a/frontend/src/app/[locale]/oversikt/oversikt-page-client.tsx
+++ b/frontend/src/app/[locale]/oversikt/oversikt-page-client.tsx
@@ -32,7 +32,7 @@ export function OversiktPageClient() {
               return <AttestationTab />;
             }
             if (municipalityId) {
-              return <OngoingSupportErrands ongoing={{ errands: [], labels: [] }} />;
+              return <OngoingSupportErrands />;
             }
             return null;
           })()}

--- a/frontend/src/supportmanagement/components/ongoing-support-errands/ongoing-support-errands.component.tsx
+++ b/frontend/src/supportmanagement/components/ongoing-support-errands/ongoing-support-errands.component.tsx
@@ -1,4 +1,3 @@
-import { ErrandsData } from '@casedata/interfaces/errand';
 import { attestationEnabled } from '@common/services/feature-flag-service';
 import { useDebounceEffect } from '@common/utils/useDebounceEffect';
 import { useBillingStore, useConfigStore, useMetadataStore, useSupportStore, useUserStore } from '@stores/index';
@@ -31,7 +30,7 @@ export interface TableForm {
   pageSize: number;
 }
 
-export const OngoingSupportErrands: FC<{ ongoing: ErrandsData }> = (props) => {
+export const OngoingSupportErrands: FC = () => {
   const filterForm = useForm<SupportManagementFilter>({ defaultValues: SupportManagementValues });
   const {
     watch: watchFilter,

--- a/frontend/src/supportmanagement/components/support-errand/sidebar/sidebar-generic-notes.component.tsx
+++ b/frontend/src/supportmanagement/components/support-errand/sidebar/sidebar-generic-notes.component.tsx
@@ -1,5 +1,3 @@
-import { NoteType } from '@casedata/interfaces/errandNote';
-import { noteIsComment, noteIsTjansteanteckning } from '@casedata/services/casedata-errand-notes-service';
 import { sanitizedInline } from '@common/services/sanitizer-service';
 import { getInitialsFromADUsername } from '@common/services/user-service';
 import { getToastOptions } from '@common/utils/toast-message-settings';
@@ -18,8 +16,10 @@ import {
   useSnackbar,
 } from '@sk-web-gui/react';
 import { useConfigStore, useSupportStore, useUserStore } from '@stores/index';
+import { NoteType } from '@supportmanagement/interfaces/genericNote';
 import { ErrandNotesTabFormModel, GenericNote } from '@supportmanagement/interfaces/genericNote';
 import { ExternalIdType, getSupportErrandById } from '@supportmanagement/services/support-errand-service';
+import { noteIsComment, noteIsTjansteanteckning } from '@supportmanagement/services/support-note-service';
 import {
   deleteSupportNote,
   getSupportNotes,

--- a/frontend/src/supportmanagement/components/support-message-form/support-message-form.component.tsx
+++ b/frontend/src/supportmanagement/components/support-message-form/support-message-form.component.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useMessageTemplates } from '@casedata/hooks/useMessageTemplates';
-import { ACCEPTED_UPLOAD_FILETYPES } from '@casedata/services/casedata-attachment-service';
 import CommonNestedEmailArrayV2 from '@common/components/commonNestedEmailArrayV2';
 import CommonNestedPhoneArrayV2 from '@common/components/commonNestedPhoneArrayV2';
 import TextEditor from '@common/components/dynamic-text-editor';
@@ -38,7 +36,9 @@ import {
   useSnackbar,
 } from '@sk-web-gui/react';
 import { useConfigStore, useSupportStore, useUserStore } from '@stores/index';
+import { useMessageTemplates } from '@supportmanagement/hooks/useMessageTemplates';
 import {
+  ACCEPTED_UPLOAD_FILETYPES,
   getSupportAttachment,
   SingleSupportAttachment,
   SupportAttachment,

--- a/frontend/src/supportmanagement/hooks/useMessageTemplates.ts
+++ b/frontend/src/supportmanagement/hooks/useMessageTemplates.ts
@@ -1,0 +1,130 @@
+import { User } from '@common/interfaces/user';
+import { EMAIL_INFORMATION_TEXT, MessageTemplates } from '@common/services/message-template-body-service';
+import { getTemplateRole, getTemplateType } from '@common/utils/template-metadata';
+import {
+  fetchTemplatesWithMetadata,
+  replaceTemplateParameters,
+} from '@supportmanagement/services/message-template-service';
+import { useEffect, useState } from 'react';
+
+interface UseMessageTemplatesResult {
+  templates: MessageTemplates | null;
+  loading: boolean;
+  error: string | null;
+  reload: () => void;
+}
+
+export function useMessageTemplates(user: User, shouldLoad: boolean): UseMessageTemplatesResult {
+  const [templates, setTemplates] = useState<MessageTemplates | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!shouldLoad || templates) return;
+
+    const loadTemplates = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const app = process.env.NEXT_PUBLIC_APPLICATION?.toLowerCase() || 'mex';
+        const userName = `${user.firstName} ${user.lastName}`;
+
+        const [appResult, defaultResult, internalResult] = await Promise.all([
+          fetchTemplatesWithMetadata({ prefix: `${app}.` }),
+          fetchTemplatesWithMetadata({ prefix: 'default.' }),
+          fetchTemplatesWithMetadata({ prefix: 'internal.' }),
+        ]);
+
+        const getContent = (id: string, params: Record<string, string> = {}) => {
+          const template = appResult.byId[id] || defaultResult.byId[id] || internalResult.byId[id];
+          if (!template) return '';
+          return replaceTemplateParameters(template.content, params);
+        };
+
+        // Helper: get app-specific content, falling back to default.* prefix
+        const getContentWithFallback = (type: string, params: Record<string, string> = {}) => {
+          const appContent = getContent(`${app}.${type}`, params);
+          if (appContent) return appContent;
+          return getContent(`default.${type}`, params);
+        };
+
+        const internalSignature = getContent('internal.signature', { user: userName });
+
+        const smsSignature = getContentWithFallback('sms.signature', { user: userName });
+        const smsContent = getContentWithFallback('sms.default', { user: userName });
+        const smsTemplate = smsContent + smsSignature;
+
+        const emailSignature = getContentWithFallback('email.signature', {
+          user: userName,
+          email_information: EMAIL_INFORMATION_TEXT,
+        });
+
+        const emailTemplates = appResult.templates.filter((t) => {
+          return (
+            getTemplateType(t) === 'email' &&
+            !['signature', 'publicdocuments', 'closing'].includes(getTemplateRole(t) || '')
+          );
+        });
+
+        // If no app-specific email templates, use default ones
+        const fallbackEmailTemplates =
+          emailTemplates.length === 0
+            ? defaultResult.templates.filter((t) => {
+                return (
+                  getTemplateType(t) === 'email' &&
+                  !['signature', 'publicdocuments', 'closing'].includes(getTemplateRole(t) || '')
+                );
+              })
+            : [];
+
+        const smsTemplates = appResult.templates.filter((t) => {
+          return getTemplateType(t) === 'sms' && !['signature', 'closing'].includes(getTemplateRole(t) || '');
+        });
+
+        // If no app-specific sms templates, use default ones
+        const fallbackSmsTemplates =
+          smsTemplates.length === 0
+            ? defaultResult.templates.filter((t) => {
+                return getTemplateType(t) === 'sms' && !['signature', 'closing'].includes(getTemplateRole(t) || '');
+              })
+            : [];
+
+        const byId: Record<string, string> = {};
+        for (const t of defaultResult.templates) {
+          byId[t.identifier] = t.content;
+        }
+        for (const t of appResult.templates) {
+          byId[t.identifier] = t.content;
+        }
+        for (const t of internalResult.templates) {
+          byId[t.identifier] = t.content;
+        }
+
+        setTemplates({
+          internalSignature,
+          smsTemplate,
+          smsSignature,
+          emailSignature,
+          emailTemplates: [...emailTemplates, ...fallbackEmailTemplates],
+          smsTemplates: [...smsTemplates, ...fallbackSmsTemplates],
+          byId,
+          app,
+        });
+      } catch (err) {
+        console.error('Failed to load templates', err);
+        setError('Failed to load templates');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadTemplates();
+  }, [shouldLoad, templates, user.firstName, user.lastName]);
+
+  const reload = () => {
+    setTemplates(null);
+  };
+
+  return { templates, loading, error, reload };
+}

--- a/frontend/src/supportmanagement/interfaces/genericNote.ts
+++ b/frontend/src/supportmanagement/interfaces/genericNote.ts
@@ -12,3 +12,5 @@ export interface ErrandNotesTabFormModel {
   partyId?: string;
   text: string;
 }
+
+export type NoteType = 'PUBLIC' | 'INTERNAL' | 'UNKNOWN';

--- a/frontend/src/supportmanagement/services/support-billing-service.ts
+++ b/frontend/src/supportmanagement/services/support-billing-service.ts
@@ -1,10 +1,10 @@
-import { All } from '@casedata/interfaces/priority';
 import { PortalPersonData } from '@common/data-contracts/employee/data-contracts';
 import { User } from '@common/interfaces/user';
 import { ApiResponse, apiService } from '@common/services/api-service';
 import { twoDecimals } from '@common/services/helper-service';
 import { useSnackbar } from '@sk-web-gui/react';
 import { useBillingStore, useConfigStore } from '@stores/index';
+import { All } from '@supportmanagement/interfaces/priority';
 import { useCallback, useEffect } from 'react';
 import {
   CBillingRecord,

--- a/frontend/src/supportmanagement/services/support-note-service.ts
+++ b/frontend/src/supportmanagement/services/support-note-service.ts
@@ -1,4 +1,5 @@
 import { apiService } from '@common/services/api-service';
+import { NoteType } from '@supportmanagement/interfaces/genericNote';
 
 export interface SupportNoteDto {
   context: string;
@@ -111,4 +112,12 @@ export const deleteSupportNote: (errandId: string, municipalityId: string, noteI
       console.error('Something went wrong when deleting note');
       throw e;
     });
+};
+
+export const noteIsComment = (noteType: NoteType): boolean => {
+  return noteType === 'INTERNAL';
+};
+
+export const noteIsTjansteanteckning = (noteType: NoteType): boolean => {
+  return noteType === 'PUBLIC';
 };


### PR DESCRIPTION
## Vad

Frikopplar `supportmanagement` från `casedata` i frontend. Modulen importerade tidigare 6 symboler från `@casedata/*` — nu har den **noll** sådana imports. Varje symbol har fått ett supportmanagement-eget hem; `casedata` är **orört**.

## Varför

Första, säkra steget mot att kunna separera casedata (som ska frysas) från supportmanagement (produkten som utvecklas vidare). När supportmanagement inte längre når in i `@casedata/*` blir casedata ett rent "löv" som kan extraheras/frysas utan att släpas med i produktens vidareutveckling.

Backend-frikopplingen (forward-flödet via en genererad casedata-API-klient bakom feature-flag) görs i en separat PR i samband med själva repo-splitten — den ändrar ett live-flöde och kräver integrationstest, så den hör inte hemma i den här rena refaktorn.

## Ändringar

| Symbol | Förut (`@casedata`) | Nu |
|---|---|---|
| `All` | `interfaces/priority` | `@supportmanagement/interfaces/priority` (fanns redan, identisk) |
| `ACCEPTED_UPLOAD_FILETYPES` | `casedata-attachment-service` | `@supportmanagement/services/support-attachment-service` (identisk lista) |
| `useMessageTemplates` | `casedata/hooks` | ny `@supportmanagement/hooks/useMessageTemplates` (kropp helt casedata-fri) |
| `NoteType` | `interfaces/errandNote` | `@supportmanagement/interfaces/genericNote` |
| `noteIsComment` / `noteIsTjansteanteckning` | `casedata-errand-notes-service` | `@supportmanagement/services/support-note-service` |
| `ErrandsData` (prop) | `interfaces/errand` | borttagen — `ongoing`-propen var död (caller skickade en dummy som aldrig lästes) |

## Beteende

Beteendebevarande — varje flyttad symbol är identisk med sin casedata-motsvarighet (samma enum/typ/lista/hook-kropp), och den borttagna propen lästes aldrig.

## Verifiering

- `tsc --noEmit` rent
- `eslint --max-warnings=0` rent på alla ändrade filer
- Inga e2e-/cypress-beroenden på den borttagna propen (träffarna avser API-mock-fixturen `mockOngoingSupportErrands`)
