### PR TITLE
Feature/draken 4576 saml hardening

### DIFF
--- a/backend/.env.bou.example.local
+++ b/backend/.env.bou.example.local
@@ -1,5 +1,8 @@
 # Environment
 NODE_ENV=development
+# ENVIRONMENT=LOCAL turns off the Secure cookie flag for local http (yarn dev + local prod builds).
+# For test environment use TEST, and leave it unset/empty for production.
+ENVIRONMENT=LOCAL
 # PORT
 PORT=3001
 # Base prefix to be added to all end-points

--- a/backend/.env.kc.example.local
+++ b/backend/.env.kc.example.local
@@ -1,5 +1,8 @@
 # Environment
 NODE_ENV=development
+# ENVIRONMENT=LOCAL turns off the Secure cookie flag for local http (yarn dev + local prod builds).
+# For test environment use TEST, and leave it unset/empty for production.
+ENVIRONMENT=LOCAL
 # PORT
 PORT=3001
 # Base prefix to be added to all end-points

--- a/backend/.env.lok.example.local
+++ b/backend/.env.lok.example.local
@@ -1,5 +1,8 @@
 # Environment
 NODE_ENV=development
+# ENVIRONMENT=LOCAL turns off the Secure cookie flag for local http (yarn dev + local prod builds).
+# For test environment use TEST, and leave it unset/empty for production.
+ENVIRONMENT=LOCAL
 # PORT
 PORT=3001
 # Base prefix to be added to all end-points

--- a/backend/.env.lop.example.local
+++ b/backend/.env.lop.example.local
@@ -1,5 +1,8 @@
 # Environment
 NODE_ENV=development
+# ENVIRONMENT=LOCAL turns off the Secure cookie flag for local http (yarn dev + local prod builds).
+# For test environment use TEST, and leave it unset/empty for production.
+ENVIRONMENT=LOCAL
 # PORT
 PORT=3001
 # Base prefix to be added to all end-points

--- a/backend/.env.mex.example.local
+++ b/backend/.env.mex.example.local
@@ -1,5 +1,8 @@
 # Environment
 NODE_ENV=development
+# ENVIRONMENT=LOCAL turns off the Secure cookie flag for local http (yarn dev + local prod builds).
+# For test environment use TEST, and leave it unset/empty for production.
+ENVIRONMENT=LOCAL
 # PORT
 PORT=3001
 # Base prefix to be added to all end-points

--- a/backend/.env.msva.example.local
+++ b/backend/.env.msva.example.local
@@ -1,5 +1,8 @@
 # Environment
 NODE_ENV=development
+# ENVIRONMENT=LOCAL turns off the Secure cookie flag for local http (yarn dev + local prod builds).
+# For test environment use TEST, and leave it unset/empty for production.
+ENVIRONMENT=LOCAL
 # PORT
 PORT=3001
 # Base prefix to be added to all end-points

--- a/backend/.env.pt.example.local
+++ b/backend/.env.pt.example.local
@@ -1,5 +1,8 @@
 # Environment
 NODE_ENV=development
+# ENVIRONMENT=LOCAL turns off the Secure cookie flag for local http (yarn dev + local prod builds).
+# For test environment use TEST, and leave it unset/empty for production.
+ENVIRONMENT=LOCAL
 # PORT
 PORT=3001
 # Base prefix to be added to all end-points

--- a/backend/.env.rob.example.local
+++ b/backend/.env.rob.example.local
@@ -1,5 +1,8 @@
 # Environment
 NODE_ENV=development
+# ENVIRONMENT=LOCAL turns off the Secure cookie flag for local http (yarn dev + local prod builds).
+# For test environment use TEST, and leave it unset/empty for production.
+ENVIRONMENT=LOCAL
 # PORT
 PORT=3001
 # Base prefix to be added to all end-points

--- a/backend/.env.se.example.local
+++ b/backend/.env.se.example.local
@@ -1,5 +1,8 @@
 # Environment
 NODE_ENV=development
+# ENVIRONMENT=LOCAL turns off the Secure cookie flag for local http (yarn dev + local prod builds).
+# For test environment use TEST, and leave it unset/empty for production.
+ENVIRONMENT=LOCAL
 # PORT
 PORT=3001
 # Base prefix to be added to all end-points

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -216,14 +216,8 @@ class App {
         store: this.sessionStore,
         cookie: {
           path: BASE_URL_PREFIX,
-          httpOnly: true, // XSS protection; independent of TLS
-          // The app is served over https in both TEST and production (only the IdP is http, and the
-          // session cookie is scoped to the app domain — it never travels to the IdP), so Secure is
-          // correct in every deployed env. Off only for local dev: a non-production build, or a
-          // local production build served over http://localhost (signalled by ENVIRONMENT=LOCAL).
+          httpOnly: true,
           secure: this.env === 'production' && process.env.ENVIRONMENT !== 'LOCAL',
-          // Frontend + backend are same-origin (foobar.domain.com + foobar.domain.com/api), so Lax
-          // works everywhere; the cross-site IdP callback doesn't need the cookie sent.
           sameSite: 'lax',
           maxAge: 12 * 60 * 60 * 1000,
         },

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -216,8 +216,14 @@ class App {
         store: this.sessionStore,
         cookie: {
           path: BASE_URL_PREFIX,
-          httpOnly: true,
-          secure: NODE_ENV === 'production',
+          httpOnly: true, // XSS protection; independent of TLS
+          // The app is served over https in both TEST and production (only the IdP is http, and the
+          // session cookie is scoped to the app domain — it never travels to the IdP), so Secure is
+          // correct in every deployed env. Off only for local dev: a non-production build, or a
+          // local production build served over http://localhost (signalled by ENVIRONMENT=LOCAL).
+          secure: this.env === 'production' && process.env.ENVIRONMENT !== 'LOCAL',
+          // Frontend + backend are same-origin (foobar.domain.com + foobar.domain.com/api), so Lax
+          // works everywhere; the cross-site IdP callback doesn't need the cookie sent.
           sameSite: 'lax',
         },
       }),
@@ -337,6 +343,7 @@ class App {
 
       passport.authenticate('saml', (err: Error | null, user: Express.User | false | null) => {
         if (err) {
+          logger.warn(`SAML login callback failed: ${err.name}: ${err.message}`);
           const queries = new URLSearchParams(failureRedirect.searchParams);
           if (err?.name) {
             queries.append('failMessage', err.name);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -70,16 +70,16 @@ const samlStrategy = new Strategy(
     // Identity Provider's public key
     idpCert: SAML_IDP_PUBLIC_CERT!,
     issuer: SAML_ISSUER!,
-    wantAssertionsSigned: false,
+    wantAssertionsSigned: true,
     signatureAlgorithm: 'sha256',
     digestAlgorithm: 'sha256',
     // maxAssertionAgeMs: 2592000000,
     // authnRequestBinding: 'HTTP-POST',
     //logoutUrl: 'http://194.71.24.30/sso',
     logoutCallbackUrl: SAML_LOGOUT_CALLBACK_URL!,
-    acceptedClockSkewMs: -1,
+    acceptedClockSkewMs: 5000,
     wantAuthnResponseSigned: false,
-    audience: false,
+    audience: SAML_ISSUER!,
   },
   async function (profile: Profile | null, done: VerifiedCallback) {
     if (!profile) {
@@ -133,7 +133,8 @@ const samlStrategy = new Strategy(
         permissions: getPermissions(appGroups),
       };
 
-      logger.info(`Found user: ${JSON.stringify(findUser)}`);
+      logger.info(`Authenticated user ${findUser.username} (role: ${findUser.role})`);
+      logger.debug(`Found user: ${JSON.stringify(findUser)}`);
 
       done(null, findUser);
     } catch (err) {
@@ -215,6 +216,9 @@ class App {
         store: this.sessionStore,
         cookie: {
           path: BASE_URL_PREFIX,
+          httpOnly: true,
+          secure: NODE_ENV === 'production',
+          sameSite: 'lax',
         },
       }),
     );
@@ -284,7 +288,8 @@ class App {
         }
 
         let successRedirect: URL, failureRedirect: URL;
-        const urls = req?.body?.RelayState.split(',');
+        const relayState = typeof req?.body?.RelayState === 'string' ? req.body.RelayState : '';
+        const urls = relayState.split(',');
 
         if (isValidUrl(urls[0]) && isValidOrigin(urls[0])) {
           successRedirect = new URL(urls[0]);
@@ -316,7 +321,8 @@ class App {
     this.app.post(`${BASE_URL_PREFIX}/saml/login/callback`, samlLimiter, bodyParser.urlencoded({ extended: false }), (req, res, next) => {
       let successRedirect: URL, failureRedirect: URL;
 
-      const urls = req?.body?.RelayState.split(',');
+      const relayState = typeof req?.body?.RelayState === 'string' ? req.body.RelayState : '';
+      const urls = relayState.split(',');
 
       if (isValidUrl(urls[0]) && isValidOrigin(urls[0])) {
         successRedirect = new URL(urls[0]);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -225,6 +225,7 @@ class App {
           // Frontend + backend are same-origin (foobar.domain.com + foobar.domain.com/api), so Lax
           // works everywhere; the cross-site IdP callback doesn't need the cookie sent.
           sameSite: 'lax',
+          maxAge: 12 * 60 * 60 * 1000,
         },
       }),
     );

--- a/backend/src/services/authorization.service.ts
+++ b/backend/src/services/authorization.service.ts
@@ -6,8 +6,8 @@ import { logger } from '@/utils/logger';
 import { roleADMapping } from './ad-role.service';
 
 export function authorizeGroups(groups: string) {
-  logger.info(`authorizing groups ${groups}`);
-  logger.info(`against ${AUTHORIZED_GROUPS}`);
+  logger.debug(`authorizing groups ${groups}`);
+  logger.debug(`against ${AUTHORIZED_GROUPS}`);
   const authorizedGroupsList = AUTHORIZED_GROUPS!.split(',');
   const groupsList = groups.split(',').map((g: string) => g.toLowerCase());
   return authorizedGroupsList.some(authorizedGroup => groupsList.includes(authorizedGroup.toLowerCase()));

--- a/backend/src/utils/session-store.ts
+++ b/backend/src/utils/session-store.ts
@@ -5,7 +5,7 @@ import createFileStore from 'session-file-store';
 import { logger } from './logger';
 import { getRedisClient } from './redis';
 
-const SESSION_TTL = 4 * 24 * 60 * 60;
+const SESSION_TTL = 12 * 60 * 60;
 
 export async function createSessionStore(): Promise<session.Store> {
   const redisClient = await getRedisClient();

--- a/backend/src/utils/validateEnv.ts
+++ b/backend/src/utils/validateEnv.ts
@@ -45,6 +45,24 @@ function warnMissingEnv(spec: EnvSpec): void {
 
 const s = (type: 'str' | 'port' | 'url' = 'str') => ({ type });
 
+const EXAMPLE_SECRET = 'foobar'; // shipped in .env.*.example.local
+const RECOMMENDED_SECRET_LENGTH = 32; // ~256-bit when base64/hex
+
+function validateSecretStrength(): void {
+  // Enforce only in deployed envs (TEST/prod run NODE_ENV=production); local dev may keep the template value.
+  if (process.env.NODE_ENV !== 'production') {
+    return;
+  }
+  const secret = (process.env.SECRET_KEY ?? '').trim();
+  if (secret === EXAMPLE_SECRET) {
+    console.error('\nInsecure SECRET_KEY: it is the shipped example value; set a strong unique secret.\n');
+    process.exit(1);
+  }
+  if (secret.length < RECOMMENDED_SECRET_LENGTH) {
+    console.warn(`⚠️  SECRET_KEY is shorter than the recommended ${RECOMMENDED_SECRET_LENGTH} characters.`);
+  }
+}
+
 const validateEnv = () => {
   const commonSpec: EnvSpec = {
     NODE_ENV: s(),
@@ -92,6 +110,8 @@ const validateEnv = () => {
       SUPPORTMANAGEMENT_SENDER_SMS: s(),
     });
   }
+
+  validateSecretStrength();
 };
 
 export default validateEnv;

--- a/frontend/src/app/[locale]/login/page.tsx
+++ b/frontend/src/app/[locale]/login/page.tsx
@@ -49,7 +49,7 @@ const Login: FC = () => {
     });
     url.search = queries.toString();
 
-    router.push(url.toString());
+    window.location.assign(url.toString());
   };
 
   useEffect(() => {

--- a/frontend/src/app/[locale]/logout/page.tsx
+++ b/frontend/src/app/[locale]/logout/page.tsx
@@ -1,11 +1,8 @@
 'use client';
 
 import { appURL } from '@common/utils/app-url';
-import { useRouter } from 'next/navigation';
 import { FC, useEffect } from 'react';
 const Logout: FC = () => {
-  const router = useRouter();
-
   useEffect(() => {
     localStorage.clear();
     sessionStorage.clear();
@@ -14,8 +11,7 @@ const Logout: FC = () => {
       successRedirect: `${appURL()}/login?loggedout`,
     });
 
-    router.push(`${process.env.NEXT_PUBLIC_API_URL}/saml/logout?${query.toString()}`);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    window.location.assign(`${process.env.NEXT_PUBLIC_API_URL}/saml/logout?${query.toString()}`);
   }, []);
 
   return <></>;


### PR DESCRIPTION
Jira: https://jira.sundsvall.se/browse/DRAKEN-4576

Härdning av SAML-autentiseringen i backend och åtgärdar flera säkerhetsbrister i inloggnings- och sessionshanteringen. Ingen funktionell förändring för användaren – inloggningen fungerar som tidigare (verifierad mot fake-IdP).

SAML-validering (backend/src/app.ts)
- Kräver signerade assertions (wantAssertionsSigned: true)
- Återinför tidskontroll av assertions (acceptedClockSkewMs -1 → 5000)
- Aktiverar audience-kontroll (audience false → SAML_ISSUER)

Session & cookie
- Härdad sessionscookie – httpOnly, sameSite: 'lax' samt secure i driftsatta miljöer (inaktivt vid lokal utveckling via ENVIRONMENT=LOCAL i env-filen).
- Kortare sessionslivslängd – 12 timmar (tidigare 4 dygn), både server-TTL och cookiens maxAge.
- Full sidladdning vid in-/utloggning (window.location.assign istället för router.push) – krävs för att sessionscookien med SameSite=Lax ska följa med genom IdP-omdirigeringen.

Uppstart & loggning
- Kontroll av SECRET_KEY vid uppstart – stoppar appen om exempelvärdet foobar används i produktion, varnar för nycklar kortare än 32 tecken.
- Mindre PII i loggar – användarnamn/roll på info-nivå, fullständig profil endast på debug; grupptilldelning flyttad till debug.
- Robustare RelayState-hantering i SAML-callbacks (kraschar inte vid saknad/felaktig RelayState).

Övrigt
ENVIRONMENT=LOCAL tillagd i env-mallarna (styr secure-cookie i lokal utveckling).
 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).
